### PR TITLE
fix: docker entrypoint uses wrong IP address to run proton-client.

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -130,7 +130,7 @@ if [ -n "$(ls /docker-entrypoint-initdb.d/)" ] || [ -n "$PROTON_DB" ]; then
         sleep 1
     done
 
-    protonclient=( proton-client --multiquery --host "128.0.0.1" -u "$PROTON_USER" --password "$PROTON_PASSWORD" )
+    protonclient=( proton-client --multiquery --host "127.0.0.1" -u "$PROTON_USER" --password "$PROTON_PASSWORD" )
 
     echo
 


### PR DESCRIPTION
fixes #38

PR checklist:
- Did you run ClangFormat ?
  N/A
- Did you separate headers to a different section in existing community code base ?
  N/A
- Did you surround `proton: starts/ends` for new code in existing community code base ?
  N/A

Please write user-readable short description of the changes:

Fixed a wrong IP address (typo).