### PR TITLE
Feature/issue 53 fix wrong spelling of comments

### DIFF
--- a/tests/stream/test_stream_smoke/0000_smoke_case.json
+++ b/tests/stream/test_stream_smoke/0000_smoke_case.json
@@ -1,6 +1,6 @@
 {
     "test_suite_name": "smoke",
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "test_suite_config": {
         "table_schemas":[

--- a/tests/stream/test_stream_smoke/0000_smoke_case1.json
+++ b/tests/stream/test_stream_smoke/0000_smoke_case1.json
@@ -1,6 +1,6 @@
 {
     "test_suite_name": "smoke1",
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "test_suite_config": {
         "table_schemas":[

--- a/tests/stream/test_stream_smoke/0001_view_case.json
+++ b/tests/stream/test_stream_smoke/0001_view_case.json
@@ -1,6 +1,6 @@
 {
     "test_suite_name": "view",
-    "commments":
+    "comments":
         "test_mvs covering the steam query smoke cases.",
     "test_suite_config": {
         "table_schemas":[

--- a/tests/stream/test_stream_smoke/0002_ingest_and_ddl_case.json
+++ b/tests/stream/test_stream_smoke/0002_ingest_and_ddl_case.json
@@ -3,7 +3,7 @@
     "test_suite_config":{
         "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"]}}
     },
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "tests": [
 

--- a/tests/stream/test_stream_smoke/0004_privilege.json
+++ b/tests/stream/test_stream_smoke/0004_privilege.json
@@ -4,7 +4,7 @@
     "test_suite_config":{
         "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"]}}
     },
-    "commments":
+    "comments":
         "Tests covering the privilige smoke cases.",
     "tests": [
 

--- a/tests/stream/test_stream_smoke/0005_streaming_only_case.json
+++ b/tests/stream/test_stream_smoke/0005_streaming_only_case.json
@@ -1,6 +1,6 @@
 {
     "test_suite_name": "streaming_only",
-    "commments":
+    "comments":
         "test_stream_onlys covering the steam query smoke cases for streaming only mode.",
     "test_suite_config": {
         "table_schemas":[

--- a/tests/stream/test_stream_smoke/0005_streaming_only_case1.json
+++ b/tests/stream/test_stream_smoke/0005_streaming_only_case1.json
@@ -1,6 +1,6 @@
 {
     "test_suite_name": "streaming_only1",
-    "commments":
+    "comments":
         "test_stream_only1 covering the steam query smoke cases for streaming only mode.",
     "test_suite_config": {
         "table_schemas":[

--- a/tests/stream/test_stream_smoke/0006_session_window.json
+++ b/tests/stream/test_stream_smoke/0006_session_window.json
@@ -1,7 +1,7 @@
 {
     "test_suite_name": "session",
     "tag":"smoke",
-    "commments":
+    "comments":
         "Tests covering session window test cases.",
     "test_suite_config": {
         "table_schemas":[

--- a/tests/stream/test_stream_smoke/0007_type_and_func_case.json
+++ b/tests/stream/test_stream_smoke/0007_type_and_func_case.json
@@ -3,7 +3,7 @@
     "test_suite_config":{
         "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["view", "cluster_table_bug"]}}
     },
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "tests": [
 

--- a/tests/stream/test_stream_smoke/0007_type_and_func_case1.json
+++ b/tests/stream/test_stream_smoke/0007_type_and_func_case1.json
@@ -3,7 +3,7 @@
     "test_suite_config":{
         "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["view", "cluster_table_bug"]}}
     },
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "tests": [
 

--- a/tests/stream/test_stream_smoke/0008_topmax_case.json
+++ b/tests/stream/test_stream_smoke/0008_topmax_case.json
@@ -6,7 +6,7 @@
         "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["cluster_table_bug"]}}
         
     },
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "tests": [
 

--- a/tests/stream/test_stream_smoke/0010_cte_case.json
+++ b/tests/stream/test_stream_smoke/0010_cte_case.json
@@ -4,7 +4,7 @@
   "test_suite_config":{
     "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["view", "cluster_table_bug"]}}
   },
-  "commments": "Tests covering the CTE smoke cases.",
+  "comments": "Tests covering the CTE smoke cases.",
   "tests": [
     {
       "id": 0,

--- a/tests/stream/test_stream_smoke/0011_json_case.json
+++ b/tests/stream/test_stream_smoke/0011_json_case.json
@@ -21,7 +21,7 @@
         },
         "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["view", "cluster_table_bug"]}}
     },
-    "commments":
+    "comments":
         "Tests covering the steam query smoke cases.",
     "tests": [
         {


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
`"commments"`->`"comments"`