### PR TITLE
support telemetry

### DIFF
--- a/base/base/ClockUtils.h
+++ b/base/base/ClockUtils.h
@@ -29,11 +29,13 @@ using UTCClock = ClockUtils<std::chrono::system_clock, TimeScale>;
 template<typename TimeScale>
 using MonotonicClock = ClockUtils<std::chrono::steady_clock, TimeScale>;
 
+using UTCMinutes = UTCClock<std::chrono::minutes>;
 using UTCSeconds = UTCClock<std::chrono::seconds>;
 using UTCMilliseconds = UTCClock<std::chrono::milliseconds>;
 using UTCMicroseconds = UTCClock<std::chrono::microseconds>;
 using UTCNanoseconds = UTCClock<std::chrono::nanoseconds>;
 
+using MonotonicMinutes = MonotonicClock<std::chrono::minutes>;
 using MonotonicSeconds = MonotonicClock<std::chrono::seconds>;
 using MonotonicMilliseconds = MonotonicClock<std::chrono::milliseconds>;
 using MonotonicMicroseconds = MonotonicClock<std::chrono::microseconds>;

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -10,7 +10,8 @@ set (SAN_FLAGS "${SAN_FLAGS} -g -fno-omit-frame-pointer -DSANITIZER")
 
 if (SANITIZE)
     if (SANITIZE STREQUAL "address")
-        set (ASAN_FLAGS "-fsanitize=address -fsanitize-address-use-after-scope")
+        # https://github.com/llvm/llvm-project/issues/59007
+        set (ASAN_FLAGS "-fsanitize=address -fsanitize-address-use-after-scope -lresolv")
         if (COMPILER_CLANG)
             if (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 15 AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 16)
                 # LLVM-15 has a bug in Address Sanitizer, preventing the usage

--- a/programs/server/CMakeLists.txt
+++ b/programs/server/CMakeLists.txt
@@ -2,6 +2,7 @@ include(${proton_SOURCE_DIR}/cmake/embed_binary.cmake)
 
 set(CLICKHOUSE_SERVER_SOURCES
     MetricsTransmitter.cpp
+    TelemetryCollector.cpp
     Server.cpp
 )
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <Poco/Version.h>
 #include <Poco/Net/HTTPServer.h>
+#include <Poco/Net/HTTPSClientSession.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Util/HelpFormatter.h>
 #include <Poco/Environment.h>
@@ -86,6 +87,7 @@
 #include "config_version.h"
 
 /// proton: starts
+#include "TelemetryCollector.h"
 #include <Checkpoint/CheckpointCoordinator.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <Functions/UserDefined/ExternalUserDefinedFunctionsLoader.h>
@@ -294,6 +296,7 @@ void initGlobalSingletons(DB::ContextMutablePtr & context)
     DB::DiskUtilChecker::instance(context);
     DB::ExternalGrokPatterns::instance(context);
     DB::ExternalUserDefinedFunctionsLoader::instance(context);
+    DB::TelemetryCollector::instance(context);
 }
 
 void deinitGlobalSingletons(DB::ContextMutablePtr & context)
@@ -1407,6 +1410,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         /// which causes use after free segfault when ExternalGrokPatterns/PlacementService tries to deactivate its task from the
         /// ScheduleThreadPool which doesn't exist any more
         ExternalGrokPatterns::instance(global_context).shutdown();
+        TelemetryCollector::instance(global_context).shutdown();
         /// proton : ends
 
         global_context->shutdown();

--- a/programs/server/TelemetryCollector.cpp
+++ b/programs/server/TelemetryCollector.cpp
@@ -1,0 +1,123 @@
+#include "TelemetryCollector.h"
+#include "config_version.h"
+
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/HTTPSClientSession.h>
+#include <base/ClockUtils.h>
+#include <base/getMemoryAmount.h>
+#include <Common/DateLUT.h>
+#include <Common/getNumberOfPhysicalCPUCores.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+
+namespace DB
+{
+
+TelemetryCollector::TelemetryCollector(ContextPtr context_)
+    : log(&Poco::Logger::get("TelemetryCollector")),
+    pool(context_->getSchedulePool()),
+    started_on_in_minutes(UTCMinutes::now())
+{
+    const auto & config = context_->getConfigRef();
+
+    if (!config.getBool("telemetry_enabled", true))
+    {
+        LOG_WARNING(log, "Please note that telemetry is disabled.");
+        is_shutdown.test_and_set();
+        return;
+    }
+
+    WriteBufferFromOwnString wb;
+    writeDateTimeTextISO(UTCMilliseconds::now(), 3, wb, DateLUT::instance("UTC"));
+    started_on = wb.str();
+
+    LOG_WARNING(log, "Please note that telemetry is enabled. "
+            "This is used to collect the version and runtime environment information to Timeplus, Inc. "
+            "You can disable it by setting telemetry_enabled to false in config.yaml");
+
+    collector_task = pool.createTask("TelemetryCollector", [this]() { this->collect(); });
+    collector_task->activate();
+    collector_task->schedule();
+}
+
+TelemetryCollector::~TelemetryCollector()
+{
+    shutdown();
+}
+
+void TelemetryCollector::shutdown()
+{
+    if (!is_shutdown.test_and_set())
+    {
+        LOG_INFO(log, "Stopped");
+        collector_task->deactivate();
+    }
+}
+
+void TelemetryCollector::collect()
+{
+    SCOPE_EXIT({
+        collector_task->scheduleAfter(INTERVAL_MS);
+    });
+
+    constexpr auto jitsu_url = "https://data.timeplus.com/api/s/s2s/track";
+    constexpr auto jitsu_token = "U7qmIGzuZvvkp16iPaYLeBR4IHfKBY6P:Cc6EUDRmEHG9TCO7DX8x23xWrdFg8pBU";
+
+    try
+    {
+        Poco::URI uri(jitsu_url);
+        Poco::Net::HTTPSClientSession session(uri.getHost(), uri.getPort());
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, uri.getPathAndQuery());
+
+        auto memory_in_gb = getMemoryAmount() / 1024 / 1024 / 1024;
+        auto cpu = getNumberOfPhysicalCPUCores();
+
+        Int64 duration_in_minute = UTCMinutes::now() - started_on_in_minutes;
+
+        std::string data = fmt::format("{{"
+            "\"type\": \"track\","
+            "\"event\": \"protonPing\","
+            "\"properties\": {{"
+            "    \"cpu\": \"{}\","
+            "    \"memory_in_GB\": \"{}\","
+            "    \"edition\": \"{}\","
+            "    \"version\": \"{}\","
+            "    \"new_session\": \"{}\","
+            "    \"started_on\": \"{}\","
+            "    \"duration_in_minute\": \"{}\""
+            "}}"
+        "}}", cpu, memory_in_gb, EDITION, VERSION_STRING, new_session, started_on, duration_in_minute);
+
+        new_session = false;
+
+        request.setContentLength(data.length());
+        request.setContentType("application/json");
+        request.add("X-Write-Key", jitsu_token);
+
+        auto & requestStream = session.sendRequest(request);
+        requestStream << data;
+
+        Poco::Net::HTTPResponse response;
+
+        auto & responseStream = session.receiveResponse(response);
+
+        if (response.getStatus() != Poco::Net::HTTPResponse::HTTP_OK)
+        {
+            std::stringstream ss;
+            ss << responseStream.rdbuf();
+            LOG_WARNING(log, "Failed to send telemetry: {}.", ss.str());
+            return;
+        }
+
+        LOG_INFO(log, "Telemetry sent successfully.");
+    }
+    catch (Poco::Exception & ex)
+    {
+        LOG_WARNING(log, "Failed to send telemetry: {}.", ex.displayText());
+    }
+}
+
+}

--- a/programs/server/TelemetryCollector.h
+++ b/programs/server/TelemetryCollector.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Core/BackgroundSchedulePool.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+
+class TelemetryCollector
+{
+private:
+    Poco::Logger * log;
+
+    BackgroundSchedulePool & pool;
+    BackgroundSchedulePoolTaskHolder collector_task;
+    std::atomic_flag is_shutdown;
+
+    std::string started_on;
+    bool new_session = true;
+    Int64 started_on_in_minutes;
+
+    static constexpr auto INTERVAL_MS = 60 * 60 * 1000; /// 1 hour
+
+public:
+    static TelemetryCollector & instance(ContextPtr context_)
+    {
+        static TelemetryCollector inst(context_);
+        return inst;
+    }
+
+    ~TelemetryCollector();
+    void shutdown();
+
+private:
+    void collect();
+    TelemetryCollector(ContextPtr context_);
+};
+}

--- a/programs/server/config.yaml
+++ b/programs/server/config.yaml
@@ -144,6 +144,9 @@ max_connections: 4096
 # For 'Connection: keep-alive' in HTTP 1.1
 keep_alive_timeout: 3
 
+# Enable telemetry. This is used to collect the version and runtime environment information to Timeplus, Inc.
+telemetry_enabled: true
+
 # gRPC protocol (see src/Server/grpc_protos/proton_grpc.proto for the API)
 # grpc_port: 9100
 grpc:

--- a/src/Server/RestRouterHandlers/PingHandler.cpp
+++ b/src/Server/RestRouterHandlers/PingHandler.cpp
@@ -20,7 +20,7 @@ namespace ErrorCodes
 namespace
 {
     std::map<String, String> colname_bldkey_mapping
-        = {{"VERSION_DESCRIBE", "version"}, {"BUILD_TIME", "time"}, {"VERSION_GITHASH", "commit_sha"}, {"EDITION", "EDITION"}};
+        = {{"VERSION_DESCRIBE", "version"}, {"BUILD_TIME", "time"}, {"VERSION_GITHASH", "commit_sha"}, {"EDITION", "edition"}};
 }
 
 std::pair<String, Int32> PingHandler::executeGet(const Poco::JSON::Object::Ptr & /*payload*/) const


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:


log:
```
2023.09.12 12:00:02.219658 [ 1552129 ] {} <Warning> Application: Please note that telemetry is enabled. This is used to collect the version and runtime environment information to Timeplus, Inc. You can disable it by setting telemetry_enabled to false in config.yaml
2023.09.12 12:00:03.010125 [ 1552129 ] {} <Information> Application: Telemetry sent successfully.
```

event:

```
{
	"event": "protonPing",
	"messageId": "ipK9FM2B5g25hXSjVWrv45RY",
	"properties": {
		"cpu": "20",
		"duration_in_minute": "0",
		"edition": "OSS",
		"memory_in_gb": "31",
		"new_session": "true",
		"started_on": "2023-09-12T09:26:14.214Z",
		"version": "1.3.9"
	},
	"receivedAt": "2023-09-12T09:26:14.897Z",
	"request_ip": "222.70.237.111",
	"timestamp": "2023-09-12T09:26:14.897Z",
	"type": "track"
}
```

```
{
	"event": "protonPing",
	"messageId": "Ns1skfAxsTkPpjCMxDOcvaUL",
	"properties": {
		"cpu": "20",
		"duration_in_minute": "1",
		"edition": "OSS",
		"memory_in_gb": "31",
		"new_session": "false",
		"started_on": "2023-09-12T09:26:14.214Z",
		"version": "1.3.9"
	},
	"receivedAt": "2023-09-12T09:29:07.544Z",
	"request_ip": "222.70.237.111",
	"timestamp": "2023-09-12T09:29:07.544Z",
	"type": "track"
}
```
