### PR TITLE
fix: GET /streams on non-exist and empty databases.

### DIFF
--- a/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
@@ -201,7 +201,7 @@ std::pair<String, Int32> TableRestRouterHandler::executeGet(const Poco::JSON::Ob
     if (!DatabaseCatalog::instance().tryGetDatabase(requested_database))
         return {
             jsonErrorResponse(fmt::format("Databases {} does not exist.", requested_database), ErrorCodes::UNKNOWN_DATABASE),
-            HTTPResponse::HTTP_BAD_REQUEST};
+            HTTPResponse::HTTP_NOT_FOUND};
 
     TablePtrs streams;
     auto node_identity{query_context->getNodeIdentity()};

--- a/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
@@ -207,21 +207,13 @@ std::pair<String, Int32> TableRestRouterHandler::executeGet(const Poco::JSON::Ob
     auto node_identity{query_context->getNodeIdentity()};
     auto this_host{query_context->getHostFQDN()};
 
-    if (requested_database.empty())
-        queryStreams(query_context, [&](Block && block) {
-            streams.reserve(block.rows());
-            for (size_t row = 0; row < block.rows(); ++row)
-                streams.push_back(std::make_shared<Table>(node_identity, this_host, block, row));
-        });
-    else if (requested_name.empty())
+    if (requested_name.empty())
     {
         queryStreamsByDatabasse(query_context, requested_database, [&](Block && block) {
             streams.reserve(block.rows());
             for (size_t row = 0; row < block.rows(); ++row)
                 streams.push_back(std::make_shared<Table>(node_identity, this_host, block, row));
         });
-        if (streams.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "database '{}' does not have any streams", requested_database);
     }
     else
     {

--- a/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
@@ -200,7 +200,7 @@ std::pair<String, Int32> TableRestRouterHandler::executeGet(const Poco::JSON::Ob
 
     if (!DatabaseCatalog::instance().tryGetDatabase(requested_database))
         return {
-            jsonErrorResponse(fmt::format("Databases {} does not exist.", database), ErrorCodes::UNKNOWN_DATABASE),
+            jsonErrorResponse(fmt::format("Databases {} does not exist.", requested_database), ErrorCodes::UNKNOWN_DATABASE),
             HTTPResponse::HTTP_BAD_REQUEST};
 
     TablePtrs streams;

--- a/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
@@ -221,7 +221,7 @@ std::pair<String, Int32> TableRestRouterHandler::executeGet(const Poco::JSON::Ob
                 streams.push_back(std::make_shared<Table>(node_identity, this_host, block, row));
         });
         if (streams.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "database '{}' doesn't exit or does not have any streams", requested_database);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "database '{}' does not have any streams", requested_database);
     }
     else
     {

--- a/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
@@ -223,7 +223,9 @@ std::pair<String, Int32> TableRestRouterHandler::executeGet(const Poco::JSON::Ob
                 streams.push_back(std::make_shared<Table>(node_identity, this_host, block, row));
         });
         if (streams.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "No stream named '{}' in database '{}'", requested_name, requested_database);
+            return {
+                jsonErrorResponse(fmt::format("No stream named '{}' in database '{}'", requested_name, requested_database), ErrorCodes::UNKNOWN_STREAM),
+                HTTPResponse::HTTP_NOT_FOUND};
     }
 
     Poco::JSON::Object resp;

--- a/tests/stream/test_stream_smoke/0003_rest.json
+++ b/tests/stream/test_stream_smoke/0003_rest.json
@@ -266,6 +266,77 @@
                     "expected_results": "dev1\tca\t100\t100\t2020-01-01 11:11:11.000\ndev2\tca\t100\t100\t2020-01-01 11:11:11.000\ndev3\t\t100\t100\t2020-01-01 11:11:11.000\ndev777\t\t100\t100\t2020-01-01 11:11:11.000\n"
                 }
             ]
+        },
+        {
+            "id": 4,
+            "tags": [],
+            "name": "get_streams",
+            "description": "verify GET /proton/v1/ddl/streams behavior (incomplete)",
+            "steps": [
+                {
+                    "description": "Call GET /streams on a non-exist database",
+                    "statements": [
+                        {
+                            "client": "rest",
+                            "rest_type": "raw",
+                            "query_type": "table",
+                            "query_id": "410",
+                            "query_url": "/proton/v1/ddl/streams/nonexist",
+                            "http_method": "GET"
+                        }
+                    ]
+                },
+                {
+                    "description": "Call GET /streams on an empty database (i.e. no streams). This test assumes no other tests create any stream in the `neutron` database.",
+                    "statements": [
+                        {
+                            "client": "rest",
+                            "rest_type": "raw",
+                            "query_type": "table",
+                            "query_id": "411",
+                            "query_url": "/proton/v1/ddl/streams/neutron",
+                            "http_method": "GET"
+                        }
+                    ]
+                },
+                {
+                    "description": "Call GET /streams on a non-exist stream",
+                    "statements": [
+                        {
+                            "client": "rest",
+                            "rest_type": "raw",
+                            "query_type": "table",
+                            "query_id": "412",
+                            "query_url": "/proton/v1/ddl/streams/neutron/foo",
+                            "http_method": "GET"
+                        }
+                    ]
+                }
+            ],
+            "expected_results": [
+                {
+                    "query_id": "410",
+                    "expected_results": {
+                        "code": 81,
+                        "error_msg": "Databases nonexist does not exist."
+                    }
+                },
+                {
+                    "query_id": "411",
+                    "expected_results": {
+                        "data": [],
+                        "request_id": "any_value"
+                    }
+                },
+                {
+                    "query_id": "412",
+                    "expected_results": {
+                        "code": 60,
+                        "error_msg": "No stream named 'foo' in database 'neutron'",
+                        "request_id": "any_value"
+                    }
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Now, GET /streams:
* returns 404 if the target databse does not exist
* returns 404 if the target stream does not exist
* return 200 with empty array for `data` if the target database has no streams

closes #56 
