### PR TITLE
fix tsa warning. 

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -534,22 +534,17 @@ void LocalServer::processConfig()
 
         if (config().has("multiquery"))
             is_multiquery = true;
-
-        load_suggestions = true;
     }
     else
     {
-        if (delayed_interactive)
-        {
-            load_suggestions = true;
-        }
-
         need_render_progress = config().getBool("progress", false);
         echo_queries = config().hasOption("echo") || config().hasOption("verbose");
         ignore_error = config().getBool("ignore-error", false);
         is_multiquery = true;
     }
+
     print_stack_trace = config().getBool("stacktrace", false);
+    load_suggestions = (is_interactive || delayed_interactive) && !config().getBool("disable_suggestion", false);
 
     auto logging = (config().has("logger.console")
                     || config().has("logger.level")

--- a/src/Client/LineReader.cpp
+++ b/src/Client/LineReader.cpp
@@ -112,10 +112,10 @@ void LineReader::Suggest::addWords(Words && new_words)
         std::lock_guard lock(mutex);
         addNewWords(words, new_words, std::less<std::string>{});
         addNewWords(words_no_case, new_words_no_case, NoCaseCompare{});
-    }
 
-    assert(std::is_sorted(words.begin(), words.end()));
-    assert(std::is_sorted(words_no_case.begin(), words_no_case.end(), NoCaseCompare{}));
+        assert(std::is_sorted(words.begin(), words.end()));
+        assert(std::is_sorted(words_no_case.begin(), words_no_case.end(), NoCaseCompare{}));
+    }
 }
 
 LineReader::LineReader(const String & history_file_path_, bool multiline_, Patterns extenders_, Patterns delimiters_)


### PR DESCRIPTION
porting https://github.com/ClickHouse/ClickHouse/commit/0250b289160ea3d03f9098f6560179e4b87e1396 fix tsa warning.
```
proton/src/Client/LineReader.cpp:117:27: warning: reading variable 'words' requires holding mutex 'mutex' [-Wthread-safety-analysis]
    assert(std::is_sorted(words.begin(), words.end()));
```