### PR TITLE
Bugfix/fix substituted streaming function show name

### DIFF
--- a/src/Interpreters/Streaming/SubstituteStreamingFunction.cpp
+++ b/src/Interpreters/Streaming/SubstituteStreamingFunction.cpp
@@ -81,6 +81,8 @@ void StreamingFunctionData::visit(DB::ASTFunction & func, DB::ASTPtr)
         auto iter = func_map.find(func.name);
         if (iter != func_map.end())
         {
+            /// Always show original column name
+            func.code_name = func.getColumnNameWithoutAlias();
             func.name = iter->second;
             return;
         }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix #91 , The change log:
- keeping original name after substituted streaming function