### PR TITLE
use environment to enable/disable telemetry

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -13,7 +13,7 @@ endif ()
 
 # proton: starts
 set (VERSION_NAME "proton")
-set (EDITION "OSS")
+set (EDITION "oss")
 # proton: ends
 
 set (VERSION_FULL "${VERSION_NAME} ${VERSION_STRING}")

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -247,6 +247,15 @@ if [ -n "$MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO" ]; then
     fi
 fi
 
+if [ -n "$TELEMETRY_ENABLED" ]; then
+    # Replace `telemetry_enabled: true` in config.yaml with customized one
+    sed -i"" "s/telemetry_enabled: true/telemetry_enabled: $TELEMETRY_ENABLED/g" "$PROTON_CONFIG"
+    if [[ $? -ne 0 ]]; then
+        echo >&2 'Failed to setup telemetry_enabled for stream storage.'
+        exit 1
+    fi
+fi
+
 if [ "$STREAM_STORAGE_TYPE" = "kafka" ]; then
     sed -i"" "/kafka:/{n;s/enabled: false/enabled: true/g}" "$PROTON_CONFIG"
     if [[ $? -ne 0 ]]; then

--- a/programs/server/TelemetryCollector.cpp
+++ b/programs/server/TelemetryCollector.cpp
@@ -79,10 +79,10 @@ void TelemetryCollector::collect()
 
         std::string data = fmt::format("{{"
             "\"type\": \"track\","
-            "\"event\": \"protonPing\","
+            "\"event\": \"proton_ping\","
             "\"properties\": {{"
             "    \"cpu\": \"{}\","
-            "    \"memory_in_GB\": \"{}\","
+            "    \"memory_in_gb\": \"{}\","
             "    \"edition\": \"{}\","
             "    \"version\": \"{}\","
             "    \"new_session\": \"{}\","


### PR DESCRIPTION
* use environment to enable/disable telemetry
* fix some naming convention

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
