### PR TITLE
skip running ci workflow when pr only change markdown files

### DIFF
--- a/.github/workflows/proton_ci.yml
+++ b/.github/workflows/proton_ci.yml
@@ -13,6 +13,7 @@ on: # yamllint disable-line rule:truthy
       - '**.md'
       - 'docker/docs/**'
       - 'docs/**'
+      - 'spec/**'
       - 'utils/check-style/aspell-ignore/**'
 
 jobs:

--- a/.github/workflows/proton_ci.yml
+++ b/.github/workflows/proton_ci.yml
@@ -10,9 +10,7 @@ on: # yamllint disable-line rule:truthy
     branches:
       - develop
     paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'SECURITY.md'
+      - '**.md'
       - 'docker/docs/**'
       - 'docs/**'
       - 'utils/check-style/aspell-ignore/**'


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
