### PR TITLE
Feature/change multishards sharding expr behavior for versioned_kv/changelog_kv

### DIFF
--- a/programs/server/config.yaml
+++ b/programs/server/config.yaml
@@ -975,7 +975,7 @@ settings:
     stream:
         default_shards: 1
         default_replicas: 1
-        default_sharding_expr: "rand()"
+        default_sharding_expr: ""   # Default is `rand()`, or `sip_hash64(<primary_keys...>)` if has primary keys
         distributed_ingest_mode: "async"    # Data ingestion mode for Stream
         logstore: ""
         logstore_replication_factor: 1

--- a/programs/server/config.yaml
+++ b/programs/server/config.yaml
@@ -975,7 +975,7 @@ settings:
     stream:
         default_shards: 1
         default_replicas: 1
-        default_sharding_expr: ""   # Default is `rand()`, or `sip_hash64(<primary_keys...>)` if has primary keys
+        default_sharding_expr: ""   # Empty string means `rand()` or `sip_hash64() if primary key set`
         distributed_ingest_mode: "async"    # Data ingestion mode for Stream
         logstore: ""
         logstore_replication_factor: 1

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3357,7 +3357,7 @@ void InterpreterSelectQuery::buildWatermarkQueryPlan(QueryPlan & query_plan) con
 
 void InterpreterSelectQuery::buildStreamingProcessingQueryPlanBeforeJoin(QueryPlan & query_plan)
 {
-    if (!isStreaming() || has_user_defined_emit_strategy || !hasStreamingWindowFunc())
+    if (!isStreaming() || query_info.has_non_aggregate_over || has_user_defined_emit_strategy || !hasStreamingWindowFunc())
         return;
 
     if (query_info.hasPartitionByKeys())

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3631,7 +3631,7 @@ void InterpreterSelectQuery::checkAndPrepareStreamingFunctions()
             /// Precached ahead partition keys before analyzing AST to avoid keys missing,
             /// in special case when `select i, max(i) over (partition by id) from test group by i`,
             /// it will be optimized to `select i, i from test group by i`
-            if (query_info.has_aggregate_over)
+            if (query_info.has_aggregate_over || query_info.has_non_aggregate_over)
             {
                 query_info.partition_by_keys.reserve(definition.partition_by->children.size());
                 for (const auto & column_ast : definition.partition_by->children)

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -168,7 +168,7 @@ struct Settings;
     /** Settings for Stream */ \
     M(UInt64, shards, 1, "Shards number for Stream", 0) \
     M(UInt64, replicas, 1, "Replicas number for Stream", 0) \
-    M(String, sharding_expr, "rand()", "Sharding method of Stream. Default is 'rand()'.", 0) \
+    M(String, sharding_expr, "", "Sharding method of Stream. Default is 'rand()', or 'sip_hash64(<primary_keys...>)' if has primary keys.", 0) \
     M(String, event_time_column, "now64(3, 'UTC')", "Event time expression of Stream. Default is '_tp_time'.", 0) \
     M(String, host_shards, "", "Stream shards the current proton instance is hosting", 0) \
     M(String, subtype, "tabular", "Engine subtype", 0) \
@@ -192,7 +192,7 @@ struct Settings;
 #define CONFIGURABLE_STREAM_SETTINGS(M) \
     M(UInt64, default_shards, 1, "Default shards number for Stream", 0) \
     M(UInt64, default_replicas, 1, "Default replicas number for Stream", 0) \
-    M(String, default_sharding_expr, "rand()", "Default sharding method of Stream", 0) \
+    M(String, default_sharding_expr, "", "Default sharding method of Stream", 0) \
     M(String, distributed_ingest_mode, "async", "Data ingestion mode for Stream", 0) \
     M(String, logstore, "", "Backend streaming storage for write ahead log implementation", 1) \
     M(Int64, logstore_replication_factor, 1, "Replication number of logstore", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -168,7 +168,7 @@ struct Settings;
     /** Settings for Stream */ \
     M(UInt64, shards, 1, "Shards number for Stream", 0) \
     M(UInt64, replicas, 1, "Replicas number for Stream", 0) \
-    M(String, sharding_expr, "", "Sharding method of Stream. Default is 'rand()', or 'sip_hash64(<primary_keys...>)' if has primary keys.", 0) \
+    M(String, sharding_expr, "", "Sharding method of Stream. Empty string means `rand()` or `sip_hash64() if primary key set", 0) \
     M(String, event_time_column, "now64(3, 'UTC')", "Event time expression of Stream. Default is '_tp_time'.", 0) \
     M(String, host_shards, "", "Stream shards the current proton instance is hosting", 0) \
     M(String, subtype, "tabular", "Engine subtype", 0) \

--- a/tests/stream/test_stream_smoke/0012_multishards1.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards1.yaml
@@ -57,7 +57,6 @@ tests:
           - client: python
             query_id: '1300'
             depends_on_stream: test13_subst_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(val),
@@ -228,7 +227,6 @@ tests:
           - client: python
             query_id: '1301'
             depends_on_stream: test13_subst_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_1_sec_large(val),
@@ -337,7 +335,6 @@ tests:
           - client: python
             query_id: '1302'
             depends_on_stream: test13_subst_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(val),
@@ -506,7 +503,6 @@ tests:
           - client: python
             query_id: '1303'
             depends_on_stream: test13_subst_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_1_sec_large(val)
@@ -602,7 +598,6 @@ tests:
           - client: python
             query_id: '1304'
             depends_on_stream: test13_multishard_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -802,7 +797,6 @@ tests:
           - client: python
             query_id: '1305'
             depends_on_stream: test13_multishard_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -938,7 +932,6 @@ tests:
           - client: python
             query_id: '1306'
             depends_on_stream: test13_multishard_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -1137,7 +1130,6 @@ tests:
           - client: python
             query_id: '1307'
             depends_on_stream: test13_multishard_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -1284,7 +1276,6 @@ tests:
           - client: python
             query_id: '1308'
             depends_on_stream: test13_subst_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -1530,7 +1521,6 @@ tests:
           - client: python
             query_id: '1309'
             depends_on_stream: test13_subst_1
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,

--- a/tests/stream/test_stream_smoke/0012_multishards2.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards2.yaml
@@ -58,7 +58,6 @@ tests:
           - client: python
             query_id: '1310'
             depends_on_stream: test13_subst_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -303,7 +302,6 @@ tests:
           - client: python
             query_id: '1311'
             depends_on_stream: test13_subst_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -486,7 +484,6 @@ tests:
           - client: python
             query_id: '1312'
             depends_on_stream: test13_multishard_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -692,7 +689,6 @@ tests:
           - client: python
             query_id: '1313'
             depends_on_stream: test13_multishard_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -837,7 +833,6 @@ tests:
           - client: python
             query_id: '1314'
             depends_on_stream: test13_multishard_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -1042,7 +1037,6 @@ tests:
           - client: python
             query_id: '1315'
             depends_on_stream: test13_multishard_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -1203,7 +1197,6 @@ tests:
           - client: python
             query_id: '1316'
             depends_on_stream: test13_subst_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_2_add_five(val),
@@ -1309,7 +1302,6 @@ tests:
           - client: python
             query_id: '1317'
             depends_on_stream: test13_subst_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select plus(val, 5),
@@ -1509,7 +1501,6 @@ tests:
           - client: python
             query_id: '1319'
             depends_on_stream: test13_multishard_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),

--- a/tests/stream/test_stream_smoke/0012_multishards2.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards2.yaml
@@ -1384,7 +1384,6 @@ tests:
       - substream
       - streaming_tailing
       - stateful_function
-      - bug
     name: substreaming tailing with stateful func
     description: substreaming tailing with stateful func
     steps:
@@ -1416,7 +1415,6 @@ tests:
           - client: python
             query_id: '1318'
             depends_on_stream: test13_subst_2
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(val, 1),

--- a/tests/stream/test_stream_smoke/0012_multishards3.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards3.yaml
@@ -115,7 +115,6 @@ tests:
           - client: python
             query_id: '1320'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_3_sec_large(i),
@@ -221,7 +220,6 @@ tests:
           - client: python
             query_id: '1321'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -377,7 +375,6 @@ tests:
           - client: python
             query_id: '1322'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_3_sec_large(i)
@@ -473,7 +470,6 @@ tests:
           - client: python
             query_id: '1323'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -673,7 +669,6 @@ tests:
           - client: python
             query_id: '1324'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -809,7 +804,6 @@ tests:
           - client: python
             query_id: '1325'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -1004,7 +998,6 @@ tests:
           - client: python
             query_id: '1326'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_3_sec_large(i),
@@ -1147,7 +1140,6 @@ tests:
           - client: python
             query_id: '1327'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -1382,7 +1374,6 @@ tests:
           - client: python
             query_id: '1328'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -1555,7 +1546,6 @@ tests:
           - client: python
             query_id: '1329'
             depends_on_stream: test13_multishard_3
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),

--- a/tests/stream/test_stream_smoke/0012_multishards4.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards4.yaml
@@ -105,7 +105,6 @@ tests:
           - client: python
             query_id: '1330'
             depends_on_stream: test13_multishard_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_4_sec_large(i),
@@ -269,7 +268,6 @@ tests:
           - client: python
             query_id: '1331'
             depends_on_stream: test13_multishard_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -464,7 +462,6 @@ tests:
           - client: python
             query_id: '1332'
             depends_on_stream: test13_multishard_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -598,7 +595,6 @@ tests:
           - client: python
             query_id: '1333'
             depends_on_stream: test13_multishard_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(speed),
@@ -789,7 +785,6 @@ tests:
           - client: python
             query_id: '1334'
             depends_on_stream: test13_multishard_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_4_sec_large(to_float(speed)),
@@ -942,7 +937,6 @@ tests:
           - client: python
             query_id: '1335'
             depends_on_stream: test13_subq_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select cnt,
@@ -1128,7 +1122,6 @@ tests:
           - client: python
             query_id: '1336'
             depends_on_stream: test13_subq_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select sec_l,
@@ -1256,7 +1249,6 @@ tests:
           - client: python
             query_id: '1337'
             depends_on_stream: test13_subq_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select mx,
@@ -1438,7 +1430,6 @@ tests:
           - client: python
             query_id: '1338'
             depends_on_stream: test13_subq_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select sec_l
@@ -1563,7 +1554,6 @@ tests:
           - client: python
             query_id: '1339'
             depends_on_stream: test13_multishard_4
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,

--- a/tests/stream/test_stream_smoke/0012_multishards5.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards5.yaml
@@ -128,7 +128,6 @@ tests:
           - client: python
             query_id: '1340'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select k,
@@ -294,7 +293,6 @@ tests:
           - client: python
             query_id: '1341'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -518,7 +516,6 @@ tests:
           - client: python
             query_id: '1342'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_5_sec_large(to_float(i)) as sec_l,
@@ -690,7 +687,6 @@ tests:
           - client: python
             query_id: '1343'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -913,7 +909,6 @@ tests:
           - client: python
             query_id: '1344'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select k2,
@@ -1066,7 +1061,6 @@ tests:
           - client: python
             query_id: '1345'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i) as mx,
@@ -1283,7 +1277,6 @@ tests:
           - client: python
             query_id: '1346'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_5_sec_large(i) as sec_l,
@@ -1441,7 +1434,6 @@ tests:
           - client: python
             query_id: '1347'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -1665,7 +1657,6 @@ tests:
           - client: python
             query_id: '1348'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select id,
@@ -1828,7 +1819,6 @@ tests:
           - client: python
             query_id: '1349'
             depends_on_stream: test13_multishard_5
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(speed),

--- a/tests/stream/test_stream_smoke/0012_multishards6.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards6.yaml
@@ -128,7 +128,6 @@ tests:
           - client: python
             query_id: '1350'
             depends_on_stream: test13_multishard_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_6_sec_large(to_float(speed)) as sec_l,
@@ -318,7 +317,6 @@ tests:
           - client: python
             query_id: '1351'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_6_add_five(val),
@@ -472,7 +470,6 @@ tests:
           - client: python
             query_id: '1352'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_13_6_add_five(test_13_6_add_five(val)),
@@ -594,7 +591,6 @@ tests:
           - client: python
             query_id: '1353'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select format('val: {}', to_string(val)),
@@ -705,7 +701,6 @@ tests:
           - client: python
             query_id: '1354'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select pow(plus(val, f1), 2),
@@ -826,7 +821,6 @@ tests:
           - client: python
             query_id: '1355'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select pow(2, val),
@@ -954,7 +948,6 @@ tests:
           - client: python
             query_id: '1356'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(val),
@@ -1059,7 +1052,6 @@ tests:
           - client: python
             query_id: '1357'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(val),
@@ -1192,7 +1184,6 @@ tests:
           - client: python
             query_id: '1358'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(val),
@@ -1320,7 +1311,6 @@ tests:
           - client: python
             query_id: '1359'
             depends_on_stream: test13_subq_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(val),

--- a/tests/stream/test_stream_smoke/0012_multishards7.yaml
+++ b/tests/stream/test_stream_smoke/0012_multishards7.yaml
@@ -80,7 +80,6 @@ tests:
           - client: python
             query_id: '1360'
             depends_on_stream: test13_subq_7
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(val),
@@ -196,7 +195,6 @@ tests:
           - client: python
             query_id: '1361'
             depends_on_stream: test13_multishard_7
-            query_end_timer: 12
             query_type: stream
             query: |
               select i,
@@ -292,7 +290,6 @@ tests:
           - client: python
             query_id: '1362'
             depends_on_stream: test13_multishard_7
-            query_end_timer: 12
             query_type: stream
             query: |
               select if(i > k1, i, k1),
@@ -387,7 +384,6 @@ tests:
           - client: python
             query_id: '1363'
             depends_on_stream: test13_multishard_7
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i),

--- a/tests/stream/test_stream_smoke/0013_changelog_stream10.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream10.yaml
@@ -1355,7 +1355,6 @@ tests:
       - group_by
       - primary_key
       - stateful_function
-      - bug
     name: subquery from subquery from view aggr with stateful function, update
     description: subquery from subquery from view aggr with stateful function, update
     steps:
@@ -1398,7 +1397,6 @@ tests:
           - client: python
             query_id: '1482'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -1484,6 +1482,16 @@ tests:
             wait: 1
             query: |
               drop stream if exists test14_multishard_10;
+
+    expected_results:
+      - query_id: '1482'
+        expected_results:
+          - [1, 1, 1, 1, 'a']
+          - [2, 2, 2, 1, 'a']
+          - [0, 0, nan, 0, 'a']
+          - [4, 4, 4, 1, 'a']
+          - [0, 0, nan, 0, 'a']
+          - [8, 8, 8, 1, 'a']
 
   - id: 83
     tags:

--- a/tests/stream/test_stream_smoke/0013_changelog_stream10.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream10.yaml
@@ -105,7 +105,6 @@ tests:
           - client: python
             query_id: '1472'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_10_sec_large(i)
@@ -237,7 +236,6 @@ tests:
           - client: python
             query_id: '1473'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_10_sec_large(i)
@@ -322,7 +320,6 @@ tests:
           - client: python
             query_id: '1474'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),
@@ -430,7 +427,6 @@ tests:
           - client: python
             query_id: '1475'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),
@@ -539,7 +535,6 @@ tests:
           - client: python
             query_id: '1476'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),
@@ -663,7 +658,6 @@ tests:
           - client: python
             query_id: '1477'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),
@@ -808,7 +802,6 @@ tests:
           - client: python
             query_id: '1478'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),
@@ -953,7 +946,6 @@ tests:
           - client: python
             query_id: '1479'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select power(10, log2(i)),
@@ -1104,7 +1096,6 @@ tests:
           - client: python
             query_id: '1480'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select power(10, log2(i)),
@@ -1252,7 +1243,6 @@ tests:
           - client: python
             query_id: '1481'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -1609,7 +1599,6 @@ tests:
           - client: python
             query_id: '1483'
             depends_on_stream: test14_multishard_10
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_10_sec_large(i),

--- a/tests/stream/test_stream_smoke/0013_changelog_stream11.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream11.yaml
@@ -130,7 +130,6 @@ tests:
           - client: python
             query_id: '1484'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_11_sec_large(i),
@@ -298,7 +297,6 @@ tests:
           - client: python
             query_id: '1485'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select max_i,
@@ -719,7 +717,6 @@ tests:
           - client: python
             query_id: '1487'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select sec_l,
@@ -945,7 +942,6 @@ tests:
           - client: python
             query_id: '1488'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select sec_l,
@@ -1109,7 +1105,6 @@ tests:
           - client: python
             query_id: '1489'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select max_i,
@@ -1513,7 +1508,6 @@ tests:
           - client: python
             query_id: '1491'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select sec_l
@@ -1731,7 +1725,6 @@ tests:
           - client: python
             query_id: '1492'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select sec_l
@@ -1842,7 +1835,6 @@ tests:
           - client: python
             query_id: '1493'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),
@@ -2055,7 +2047,6 @@ tests:
           - client: python
             query_id: '1495'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_11_add_five(i),

--- a/tests/stream/test_stream_smoke/0013_changelog_stream11.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream11.yaml
@@ -214,6 +214,18 @@ tests:
             query: |
               drop stream if exists test14_multishard_11;
 
+    expected_results:
+      - query_id: '1484'
+        expected_results:
+          - [1, 1, 1, 1, 1]
+          - [2, 1, 1.5, 2, 1]
+          - [2, 1, 1.5, 2, 1]
+          - [6, 6, 6, 1, 2]
+          - [2, 1, 1.5, 2, 1]
+          - [7, 6, 6.5, 2, 2]
+          - [8, 1, 3.6666666666666665, 3, 1]
+          - [7, 6, 6.5, 2, 2]
+
   - id: 85
     tags:
       - versioned_kv
@@ -395,7 +407,6 @@ tests:
       - group_by
       - no_primary_key
       - stateful_function
-      - bug
     name: subquery from view from subquery aggr with stateful function, update
     description: subquery from view from subquery aggr with stateful function, update
     steps:
@@ -416,6 +427,12 @@ tests:
             query_type: table
             wait: 1
             query: |
+              drop stream if exists test14_target_multishard_changelog_kv_11;
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: |
               drop stream if exists test14_multishard_11;
 
           - client: python
@@ -429,7 +446,14 @@ tests:
             query_type: table
             wait: 1
             query: |
-              create materialized view if not exists test14_view1_11 as
+              create stream if not exists test14_target_multishard_changelog_kv_11(i float, k1 int, k2 string) primary key k2
+              settings mode='changelog_kv', shards=3;
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: |
+              create materialized view if not exists test14_view1_11 into test14_target_multishard_changelog_kv_11 as
                 (select i,
                         k1,
                         k2
@@ -439,7 +463,7 @@ tests:
                            k2
                     from test14_multishard_11
                     where k1 <> 0 )
-                 where k2 <> 'd' );
+                 where k2 <> 'd' emit changelog);
 
           - client: python
             query_type: table
@@ -458,7 +482,6 @@ tests:
           - client: python
             query_id: '1486'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select max_i,
@@ -543,7 +566,29 @@ tests:
             query_type: table
             wait: 1
             query: |
+              drop stream if exists test14_target_multishard_changelog_kv_11;
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: |
               drop stream if exists test14_multishard_11;
+
+    expected_results:
+      - query_id: '1486'
+        expected_results:
+          - [1, 1, 1, 1, 1]
+          - [2, 2, 2, 1, 1]
+          - [0, 0, nan, 0, 1]
+          - [4, 4, 4, 1, 1]
+          - [4, 4, 4, 1, 1]
+          - [5, 5, 5, 1, 2]
+          - [4, 4, 4, 1, 1]
+          - [6, 5, 5.5, 2, 2]
+          - [4, 4, 4, 1, 1]
+          - [7, 5, 6, 2, 2]
+          - [8, 8, 8, 1, 1]
+          - [7, 5, 6, 2, 2]
 
   - id: 87
     tags:
@@ -984,6 +1029,18 @@ tests:
             query: |
               drop stream if exists test14_multishard_11;
 
+    expected_results:
+      - query_id: '1488'
+        expected_results:
+          - [1, 1, 1, 1, 1]
+          - [2, 1, 1.5, 2, 1]
+          - [2, 1, 1.5, 2, 1]
+          - [6, 6, 6, 1, 2]
+          - [2, 1, 1.5, 2, 1]
+          - [7, 6, 6.5, 2, 2]
+          - [8, 1, 3.6666666666666665, 3, 1]
+          - [7, 6, 6.5, 2, 2]
+
   - id: 89
     tags:
       - versioned_kv
@@ -1156,7 +1213,6 @@ tests:
       - tail/aggr
       - no_group_by
       - stateful_function
-      - bug
     name: subquery from view from subquery aggr with stateful function, update
     description: subquery from view from subquery aggr with stateful function, update
     steps:
@@ -1183,6 +1239,12 @@ tests:
             query_type: table
             wait: 1
             query: |
+              drop stream if exists test14_target_changelog_kv_multishard_11;
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: |
               create stream if not exists test14_multishard_11(i float, k1 int, k2 string) primary key k2
               settings mode='versioned_kv', shards=3;
 
@@ -1190,7 +1252,14 @@ tests:
             query_type: table
             wait: 1
             query: |
-              create materialized view if not exists test14_view1_11 as
+              create stream if not exists test14_target_changelog_kv_multishard_11(i float, k1 int, k2 string) primary key k2
+              settings mode='changelog_kv', shards=3;
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: |
+              create materialized view if not exists test14_view1_11 into test14_target_changelog_kv_multishard_11 as
                 (select i,
                         k1,
                         k2
@@ -1200,7 +1269,7 @@ tests:
                            k2
                     from test14_multishard_11
                     where k1 <> 0 )
-                 where k2 <> 'd' );
+                 where k2 <> 'd' emit changelog);
 
           - client: python
             query_type: table
@@ -1216,7 +1285,6 @@ tests:
           - client: python
             query_id: '1490'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select max_i,
@@ -1301,6 +1369,24 @@ tests:
             wait: 1
             query: |
               drop stream if exists test14_multishard_11;
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: |
+              drop stream if exists test14_target_changelog_kv_multishard_11;
+
+    expected_results:
+      - query_id: '1490'
+        expected_results:
+          - [1, 1, 1, 1]
+          - [2, 2, 2, 1]
+          - [0, 0, nan, 0]
+          - [4, 4, 4, 1]
+          - [5, 4, 4.5, 2]
+          - [6, 4, 5, 3]
+          - [7, 4, 5.333, 3]
+          - [8, 5, 6.666, 3]
 
   - id: 91
     tags:
@@ -1809,7 +1895,6 @@ tests:
       - partition_by_primary_key
       - streaming_tailing
       - stateful_function
-      - bug
     name: partition by primary key, streaming tailing, stateful function, update
     description: partition by primary key, streaming tailing, stateful function, update
     steps:
@@ -1830,7 +1915,6 @@ tests:
           - client: python
             query_id: '1494'
             depends_on_stream: test14_multishard_11
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 1),

--- a/tests/stream/test_stream_smoke/0013_changelog_stream11.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream11.yaml
@@ -481,7 +481,7 @@ tests:
 
           - client: python
             query_id: '1486'
-            depends_on_stream: test14_multishard_11
+            depends_on_stream: test14_view2_11
             query_type: stream
             query: |
               select max_i,
@@ -1284,7 +1284,7 @@ tests:
 
           - client: python
             query_id: '1490'
-            depends_on_stream: test14_multishard_11
+            depends_on_stream: test14_view2_11
             query_type: stream
             query: |
               select max_i,

--- a/tests/stream/test_stream_smoke/0013_changelog_stream12.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream12.yaml
@@ -65,7 +65,6 @@ tests:
           - client: python
             query_id: '1496'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_12_add_five(i),
@@ -186,7 +185,6 @@ tests:
           - client: python
             query_id: '1497'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select pow(10, i),
@@ -259,7 +257,6 @@ tests:
           - client: python
             query_id: '1498'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select pow(10, i),
@@ -383,7 +380,6 @@ tests:
           - client: python
             query_id: '1499'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -462,7 +458,6 @@ tests:
           - client: python
             query_id: '14100'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -649,7 +644,6 @@ tests:
           - client: python
             query_id: '14101'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_12_sec_large(i),
@@ -726,7 +720,6 @@ tests:
           - client: python
             query_id: '14102'
             depends_on_stream: test14_multishard_12
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),

--- a/tests/stream/test_stream_smoke/0013_changelog_stream12.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream12.yaml
@@ -442,7 +442,6 @@ tests:
       - group_by
       - primary_key
       - stateful_function
-      - bug
     name: update versioned_kv and query with partition by primary key, group by, primary key and stateful function
     description: update versioned_kv and query with partition by primary key, group by, primary key and stateful function
     steps:

--- a/tests/stream/test_stream_smoke/0013_changelog_stream4.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream4.yaml
@@ -71,7 +71,6 @@ tests:
           - client: python
             query_id: '1400'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select * from test14_view_4;
 
@@ -144,7 +143,6 @@ tests:
           - client: python
             query_id: '1401'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select i, k1, k2, _tp_delta from test14_view_4;
 
@@ -229,7 +227,6 @@ tests:
           - client: python
             query_id: '1402'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select * from test14_view2_4;
 
@@ -303,7 +300,6 @@ tests:
           - client: python
             query_id: '1403'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte1 as (with cte2 as(
@@ -397,7 +393,6 @@ tests:
           - client: python
             query_id: '1404'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select i, k1, k2, _tp_delta from test14_view2_4;
 
@@ -504,7 +499,6 @@ tests:
           - client: python
             query_id: '1405'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select test_14_4_add_five(i), k2, _tp_delta from test14_view_4;
 
@@ -606,7 +600,6 @@ tests:
           - client: python
             query_id: '1406'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select test_14_4_add_five(i), k2, _tp_delta from test14_view_4;
 
@@ -694,7 +687,6 @@ tests:
           - client: python
             query_id: '1407'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte1 as (
@@ -810,7 +802,6 @@ tests:
           - client: python
             query_id: '1408'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select test_14_4_add_five(i), k2, _tp_delta from test14_view2_4;
 
@@ -958,7 +949,6 @@ tests:
           - client: python
             query_id: '1409'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select test_14_4_sec_large(i), k2 from test14_view_4 group by k2;
 
@@ -1108,7 +1098,6 @@ tests:
           - client: python
             query_id: '1410'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select test_14_4_sec_large(i), k2 from test14_view_4 group by k2;
 
@@ -1271,7 +1260,6 @@ tests:
           - client: python
             query_id: '1411'
             depends_on_stream: test14_subquery_4
-            query_end_timer: 12
             query_type: stream
             query: select test_14_4_sec_large(i), k2 from test14_view2_4 group by k2;
 

--- a/tests/stream/test_stream_smoke/0013_changelog_stream5.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream5.yaml
@@ -117,7 +117,6 @@ tests:
           - client: python
             query_id: '1412'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte1 as (
@@ -268,7 +267,6 @@ tests:
           - client: python
             query_id: '1413'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select test_14_5_sec_large(i), k2 from test14_view2_5 group by k2;
 
@@ -363,7 +361,6 @@ tests:
           - client: python
             query_id: '1414'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select max(i), min(i), avg(i), k1 from test14_view_5 group by k1;
 
@@ -456,7 +453,6 @@ tests:
           - client: python
             query_id: '1415'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select max(i), min(i), avg(i), k1 from test14_view_5 group by k1;
 
@@ -568,7 +564,6 @@ tests:
           - client: python
             query_id: '1416'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select max(i), min(i), avg(i), k1 from test14_view2_5 group by k1;
 
@@ -659,7 +654,6 @@ tests:
           - client: python
             query_id: '1417'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte1 as (with cte2 as (
@@ -780,7 +774,6 @@ tests:
           - client: python
             query_id: '1418'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select test_14_5_add_five(i), k2, _tp_delta from test14_view2_5;
 
@@ -867,7 +860,6 @@ tests:
           - client: python
             query_id: '1419'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select lag(i, 2), k2 from test14_view_5;
 
@@ -956,7 +948,6 @@ tests:
           - client: python
             query_id: '1420'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select lag(i, 2), k2 from test14_view_5;
 
@@ -1054,7 +1045,6 @@ tests:
           - client: python
             query_id: '1421'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select lag(i, 2), k2 from test14_view2_5;
 
@@ -1134,7 +1124,6 @@ tests:
           - client: python
             query_id: '1422'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte1 as (
@@ -1234,7 +1223,6 @@ tests:
           - client: python
             query_id: '1423'
             depends_on_stream: test14_subquery_5
-            query_end_timer: 12
             query_type: stream
             query: select lag(i, 2), k2 from test14_view2_5;
 

--- a/tests/stream/test_stream_smoke/0013_changelog_stream6.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream6.yaml
@@ -72,7 +72,6 @@ tests:
           - client: python
             query_id: '1424'
             depends_on_stream: test14_subquery_6
-            query_end_timer: 12
             query_type: stream
             query: select max(i), min(i), avg(i) from test14_view_6 group by k2;
 
@@ -137,7 +136,6 @@ tests:
           - client: python
             query_id: '1425'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select val, id, lag(val, 2), _tp_delta from changelog(test14_substream_6, id) partition by id;
 
@@ -250,7 +248,6 @@ tests:
           - client: python
             query_id: '1426'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select val, id, test_14_6_add_five(val), _tp_delta from changelog(test14_substream_6, id) partition by id;
 
@@ -342,7 +339,6 @@ tests:
           - client: python
             query_id: '1427'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select val, id, upper(name), _tp_delta from changelog(test14_substream_6, id) partition by id;
 
@@ -435,7 +431,6 @@ tests:
           - client: python
             query_id: '1428'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(val), min(val), avg(val), id from changelog(test14_substream_6, id)
@@ -583,7 +578,6 @@ tests:
           - client: python
             query_id: '1429'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select test_14_6_sec_large(val), name from changelog(test14_substream_6, id) partition by id group by name;
 
@@ -748,7 +742,6 @@ tests:
           - client: python
             query_id: '1431'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select lag(val, 1), val, id, name from changelog(test14_substream_6, id) partition by id;
 
@@ -841,7 +834,6 @@ tests:
           - client: python
             query_id: '1432'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select (val), id from changelog(test14_substream_6, id) partition by id;
 
@@ -917,7 +909,6 @@ tests:
           - client: python
             query_id: '1433'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte as (select * from tumble(test14_substream_6, ts, 3s))
@@ -1081,7 +1072,6 @@ tests:
           - client: python
             query_id: '1435'
             depends_on_stream: test14_substream_6
-            query_end_timer: 12
             query_type: stream
             query: select max(val), min(val), avg(val), name from changelog(test14_substream_6, id) partition by name group by id emit periodic 1s;
 

--- a/tests/stream/test_stream_smoke/0013_changelog_stream7.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream7.yaml
@@ -118,7 +118,6 @@ tests:
           - client: python
             query_id: '1436'
             depends_on_stream: test14_substream_7
-            query_end_timer: 12
             query_type: stream
             query: select test_14_7_sec_large(val), max(val), min(val), avg(val), name from changelog(test14_substream_7, id) partition by name group by id;
 
@@ -193,56 +192,55 @@ tests:
           - client: python
             query_id: '1437'
             depends_on_stream: test14_substream_7
-            query_end_timer: 12
             query_type: stream
-            query: select max(val), min(val), avg(val), name from changelog(test14_substream_7, id) partition by name group by types;
+            query: select max(val), min(val), avg(val), name from changelog(test14_substream_7, id) partition by name group by types emit periodic 1s;
 
           - client: python
             query_type: table
             depends_on: '1437'
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (1, 'c', 2, 'a');
 
           - client: python
             query_type: table
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (3, 'b', 3, 'b');
 
           - client: python
             query_type: table
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (5, 'a', 1, 'c');
 
           - client: python
             query_type: table
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (8, 'c', 12, 'a');
 
           - client: python
             query_type: table
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (9, 'b', 3, 'b');
 
           - client: python
             query_type: table
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (11, 'a', 2, 'b');
 
           - client: python
             query_type: table
-            wait: 2
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (10, 'c', 1, 'c');
 
           - client: python
             query_type: table
             kill: '1437'
-            kill_wait: 2
-            wait: 2
+            kill_wait: 3
+            wait: 1
             query: insert into test14_substream_7(val, types, id, name) values (14, 'b', 2, 'b');
 
           - client: python
             query_type: table
-            wait: 3
+            wait: 1
             query: drop stream if exists test14_substream_7;
 
     expected_results:
@@ -345,7 +343,6 @@ tests:
           - client: python
             query_id: '1438'
             depends_on_stream: test14_substream_7
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_7_sec_large(val), max(val), min(val), avg(val), name from changelog(test14_substream_7, id)
@@ -423,7 +420,6 @@ tests:
           - client: python
             query_id: '1439'
             depends_on_stream: test14_substream_7
-            query_end_timer: 12
             query_type: stream
             query: select max(val), min(val), avg(val), count(*), sum(val), window_start from tumble(test14_stream, ts, 5s) group by window_start;
 
@@ -512,7 +508,6 @@ tests:
           - client: python
             query_id: '1440'
             depends_on_stream: test14_substream_7
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(val), min(val), avg(val), count(*), sum(val), window_start from hop(test14_stream, ts, 2s, 5s)
@@ -627,7 +622,6 @@ tests:
           - client: python
             query_id: '1441'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: select i, k1, k2, lag(i, 2), upper(k2), test_14_7_add_five(i) from test14_view_7;
 
@@ -751,7 +745,6 @@ tests:
           - client: python
             query_id: '1442'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: select i, k1, k2, lag(i, 2), upper(k2), test_14_7_add_five(i) from test14_view_7;
 
@@ -883,7 +876,6 @@ tests:
           - client: python
             query_id: '1443'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: select i, k1, k2, lag(i, 2), upper(k2), test_14_7_add_five(i) from test14_view2_7;
 
@@ -998,7 +990,6 @@ tests:
           - client: python
             query_id: '1444'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: |
               with cte1 as (with cte2 as (select i, k1, k2, _tp_delta from test14_subquery_7) select * from cte2)
@@ -1132,7 +1123,6 @@ tests:
           - client: python
             query_id: '1445'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: select i, k1, k2, lag(i, 2), upper(k2), test_14_7_add_five(i) from test14_view2_7;
 
@@ -1238,7 +1228,6 @@ tests:
           - client: python
             query_id: '1446'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: select max(i), min(i), avg(i), k2 from test14_view_7 group by k2 emit periodic 1s;
 
@@ -1329,7 +1318,6 @@ tests:
           - client: python
             query_id: '1447'
             depends_on_stream: test14_subquery_7
-            query_end_timer: 12
             query_type: stream
             query: select max(i), min(i), avg(i), k2 from test14_view_7 group by k2 emit periodic 1s;
 

--- a/tests/stream/test_stream_smoke/0013_changelog_stream8.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream8.yaml
@@ -793,7 +793,6 @@ tests:
           - client: python
             query_id: '1456'
             depends_on_stream: test14_multishard_8
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 2),
@@ -880,7 +879,6 @@ tests:
           - client: python
             query_id: '1457'
             depends_on_stream: test14_multishard_8
-            query_end_timer: 12
             query_type: stream
             query: |
               select lag(i, 2),
@@ -995,7 +993,6 @@ tests:
           - client: python
             query_id: '1458'
             depends_on_stream: test14_multishard_8
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_8_add_five(i),
@@ -1102,7 +1099,6 @@ tests:
           - client: python
             query_id: '1459'
             depends_on_stream: test14_multishard_8
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_8_add_five(i),

--- a/tests/stream/test_stream_smoke/0013_changelog_stream9.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream9.yaml
@@ -289,7 +289,6 @@ tests:
       - group_by
       - primary_key
       - stateful_function
-      - bug
     name: update rows to multi_shard versioned_kv and query with streaming aggreagation by primary key
     description: update rows to multi_shard versioned_kv and query with streaming aggreagation by primary key
     steps:
@@ -791,7 +790,6 @@ tests:
       - group_by
       - no_primary_key
       - stateful_function
-      - bug
     name: update rows to multi_shard versioned_kv and query with streaming aggreagation by primary key
     description: update rows to multi_shard versioned_kv and query with streaming aggreagation by primary key
     steps:
@@ -812,7 +810,6 @@ tests:
           - client: python
             query_id: '1467'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -885,6 +882,7 @@ tests:
           - [4, 4, 4, 1, 2]
           - [2, 2, 2, 1, 1]
           - [5, 4, 4.5, 2, 2]
+          - [0, 0, nan, 0, 1]
           - [6, 4, 5, 3, 2]
 
   - id: 68
@@ -1254,7 +1252,6 @@ tests:
       - global_aggregation
       - no_group_by
       - stateful_function
-      - bug
     name: update rows of multi_shard versioned_kv no group_by with stateful function
     description: update rows of multi_shard versioned_kv no group_by with stateful function
     steps:

--- a/tests/stream/test_stream_smoke/0013_changelog_stream9.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream9.yaml
@@ -43,7 +43,6 @@ tests:
           - client: python
             query_id: '1460'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select concat(upper(k2), to_string(i)),
@@ -130,7 +129,6 @@ tests:
           - client: python
             query_id: '1461'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select concat(upper(k2), to_string(i)),
@@ -228,7 +226,6 @@ tests:
           - client: python
             query_id: '1462'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -309,7 +306,6 @@ tests:
           - client: python
             query_id: '1463'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -477,7 +473,6 @@ tests:
           - client: python
             query_id: '1464'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_9_sec_large(i),
@@ -616,7 +611,6 @@ tests:
           - client: python
             query_id: '1465'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_9_sec_large(i),
@@ -705,7 +699,6 @@ tests:
           - client: python
             query_id: '1466'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -974,7 +967,6 @@ tests:
           - client: python
             query_id: '1468'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_9_sec_large(i),
@@ -1110,7 +1102,6 @@ tests:
           - client: python
             query_id: '1469'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select test_14_9_sec_large(i),
@@ -1198,7 +1189,6 @@ tests:
           - client: python
             query_id: '1470'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),
@@ -1272,7 +1262,6 @@ tests:
           - client: python
             query_id: '1471'
             depends_on_stream: test14_multishard_9
-            query_end_timer: 12
             query_type: stream
             query: |
               select max(i),

--- a/tests/stream/test_stream_smoke/0016_substream_case.json
+++ b/tests/stream/test_stream_smoke/0016_substream_case.json
@@ -229,7 +229,7 @@
     },
     {
       "id": 2,
-      "tags": ["non_aggregate_over"],
+      "tags": ["non_aggregate_over", "bug"],
       "name": "non_aggr_over",
       "description": "non-aggregation with over functions in same substream",
       "steps":[


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
Thie close #131, and fix #76 , fix #66 
The change log:
- change default sharding expression to ``, which will be determined as `rand()`, or `sip_hash64(<primary_keys>)`  if has primary keys
- fix minor error
- fix some smoke tests