### PR TITLE
Feature issue 135 disable weekly release

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -3,9 +3,6 @@ name: release_build
 
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-  schedule:
-    # build at 15:30UTC,8:30PST, 23:30CST, on every Tuesday and Friday
-    - cron:  '30 15 * * 4' #was 30 15 * * 2,5
 
 jobs:
   Build:


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
disable weekly release