### PR TITLE
Add more examples for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You should see data like the following:
 
 Now that you're running Proton and have created your first stream, query, and view, you can explore [reading and writing data from Apache Kafka](https://docs.timeplus.com/proton-kafka#tutorial) with External Streams, or view the [Proton documentation](https://docs.timeplus.com/proton) to explore additional capabilities.
 
-To see how such a deployment of Proton works as a demo, using `owl-shop` sample live data, check out our [tutorial with Docker Compose](https://docs.timeplus.com/proton-kafka#tutorial).
+To see more examples of using Proton, check out the [examples](https://github.com/timeplus-io/proton/tree/develop/examples) folder.
 
 ## Get more with Timeplus
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,10 @@
 version: '3.7'
 name: proton-demo
-networks:
-  demo_network:
-    driver: bridge
 volumes:
   redpanda: null
 services:
   proton:
      image: ghcr.io/timeplus-io/proton:latest
-     networks:
-      - demo_network
 
   redpanda:
     image: docker.redpanda.com/redpandadata/redpanda:v23.2.8
@@ -22,8 +17,6 @@ services:
       - --mode dev-container
     volumes:
       - redpanda:/var/lib/redpanda/data
-    networks:
-      - demo_network
 
   console:
     image: docker.redpanda.com/redpandadata/console:v2.3.1
@@ -36,15 +29,11 @@ services:
           brokers: ["redpanda:9092"]
     ports:
       - 8080:8080
-    networks:
-      - demo_network
     depends_on:
       - redpanda
 
   owl-shop:
     image: quay.io/cloudhut/owl-shop:latest
-    networks:
-      - demo_network
     #platform: 'linux/amd64'
     environment:
       - SHOP_KAFKA_BROKERS=redpanda:9092

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Examples
+
+This folder lists some examples to run Proton in various use cases. For more real-world examples, please check https://docs.timeplus.com/showcases
+
+- ecommerce: a combination of Proton, Redpanda, owl-shop and Redpanda Console. Owl Shop is an imaginary ecommerce shop that simulates microservices exchanging data via Apache Kafka. Sample data streams are: clickstreams(frontend events), customer info, customer orders. [Learn more](https://docs.timeplus.com/proton-kafka#tutorial)
+
+- carsharing: just two containers: Proton and [Chameleon](https://github.com/timeplus-io/chameleon). It is an imginary carsharing company. Sensors are equipped in each car to report car locations. The customers use the mobile app to find available cars nearby, book them, unlock them and hit the road. At the end of the trip, the customer parks the car, locks it, and ends the trip. The payment will proceed automatically with the registered credit card. [Learn more](https://docs.timeplus.com/usecases)

--- a/examples/carsharing/README.md
+++ b/examples/carsharing/README.md
@@ -1,0 +1,107 @@
+# Demo for Carsharing Use Case
+
+
+
+This docker compose file demonstrates some typical query patterns that you can achieve in Proton to solve various use cases. 
+
+For more details, please check https://docs.timeplus.com/usecases
+
+
+
+## Start the example
+
+Simply run `docker compose up` in this folder. Two docker containers in the stack:
+
+1. ghcr.io/timeplus-io/proton:latest, as the streaming database
+2. timeplus/cardemo:latest, as the data generator
+
+## Customer Scenario and Data Model
+
+You are the lead business analyst in a carsharing company. Sensors are equipped in each car to report car locations. The customers use the mobile app to find available cars nearby, book them, unlock them and hit the road. At the end of the trip, the customer parks the car, locks it, and ends the trip. The payment will proceed automatically with the registered credit card.
+
+Some of the typical use cases for time-sensitive insights are:
+
+- How many cars are being driven by users in certain locations? Do we need to move some cars from less busy locations to those hot zones?
+- Which cars are being driven too fast or running low on fuel? The service team may need to take action.
+- Which users keep booking cars then canceling them? Shall we send real-time notification to those users to avoid abuse.
+
+There are multiple data streams in the systems:
+
+
+
+
+```mermaid
+erDiagram
+    bookings }o--|| dim_user_info: reserve
+    bookings ||--o| trips:transaction
+    bookings ||--|| dim_car_info: use
+    car_live_data }o--|| dim_car_info: report
+    dim_user_info {
+      string uid
+      string first_name
+      string last_name
+    }
+    dim_car_info {
+      string cid
+      string license_plate_no
+      bool in_service
+    }
+    car_live_data {
+      string cid
+    }
+    bookings {
+      string bid
+      string uid
+      string cid
+    }
+    trips {
+      string tid
+      string bid
+      datetime start_time
+      datetime end_time
+      float stat_lon
+      float start_lat
+      float end_lon
+      float end_lat
+      float km
+      decimal amount
+    }
+```
+
+
+
+## Sample queries
+
+Please check https://docs.timeplus.com/usecases for more sample queries.
+
+```sql
+-- List live data
+SELECT * FROM car_live_data; 
+
+-- Filter data
+SELECT time,cid,gas_percent FROM car_live_data WHERE gas_percent < 25;  
+
+-- Downsampling
+SELECT window_start,cid, avg(gas_percent) AS avg_gas_percent,avg(speed_kmh) AS avg_speed FROM
+tumble(car_live_data,1m) GROUP BY window_start, cid; 
+
+-- Create materlized view
+CREATE MATERIALIZED VIEW car_live_data_1min as
+SELECT window_start AS time,cid, avg(gas_percent) AS avg_gas,avg(speed_kmh) AS avg_speed 
+FROM tumble(car_live_data,1m) GROUP BY window_start, cid; 
+SELECT * FROM car_live_data_1min;
+
+-- Top K
+SELECT window_start,top_k(cid,3) AS popular_cars FROM tumble(bookings,1h) GROUP BY window_start;
+
+-- JOIN
+SELECT avg(gap) FROM
+( SELECT
+    date_diff('second', bookings.booking_time, trips.start_time) AS gap
+  FROM bookings
+  INNER JOIN trips ON (bookings.bid = trips.bid) 
+     AND date_diff_within(2m, bookings.booking_time, trips.start_time)
+) WHERE _tp_time >= now()-1d;
+
+```
+

--- a/examples/carsharing/docker-compose.yml
+++ b/examples/carsharing/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.7'
+name: proton-demo-carsharing
+services:
+  proton:
+     image: ghcr.io/timeplus-io/proton:latest
+
+  carsharing_datagen:
+    image: timeplus/cardemo:latest
+    entrypoint: /bin/sh
+    command: -c "sleep 15 && echo \"$$CONSOLE_CONFIG_FILE\" > /timeplus/sink.yaml;  /timeplus/cardemo --config /timeplus/.cardemo.yaml -f /timeplus/sink.yaml"
+    environment:
+      CONSOLE_CONFIG_FILE: |
+        sinks:
+          - type: proton
+            properties:
+              interval: 200
+              host: proton
+    depends_on:
+      - proton

--- a/examples/ecommerce/README.md
+++ b/examples/ecommerce/README.md
@@ -1,0 +1,39 @@
+# Demo for ecommerce shop use cases
+
+This docker compose file demonstrates how to read/write data in Kafka/Redpanda with External Streams.
+
+For more details, please check https://docs.timeplus.com/proton-kafka#tutorial
+
+## Start the example
+
+Simply run `docker compose up` in this folder. Four docker containers in the stack:
+1. ghcr.io/timeplus-io/proton:latest, as the streaming database.
+2. quay.io/cloudhut/owl-shop:latest, as the data generator. [Owl Shop](https://github.com/cloudhut/owl-shop) is an imaginary ecommerce shop that simulates microservices exchanging data via Apache Kafka.
+3. docker.redpanda.com/redpandadata/redpanda, as the Kafka compatiable streaming message bus
+4. docker.redpanda.com/redpandadata/console, as the web UI to explore data in Kafka/Redpanda
+
+## Run SQL
+
+You can use `docker exec -it <name> proton-client` to run the SQL client in Proton container. Or use the Docker Desktop UI to choose the container, choose "Exec" tab and type `proton-client` to start the SQL client.
+
+Run the following commands:
+```sql
+-- Create externarl stream to read data from Kafka/Redpanda
+CREATE EXTERNAL STREAM frontend_events(raw string)
+SETTINGS type='kafka', 
+         brokers='redpanda:9092',
+         topic='owlshop-frontend-events';
+
+-- Scan incoming events
+select * from frontend_events;
+
+-- Get live count
+select count() from frontend_events;
+
+-- Filter events by JSON attributes
+select _tp_time, raw:ipAddress, raw:requestedUrl from frontend_events where raw:method='POST';
+
+-- Show a live ASCII bar chart
+select raw:method, count() as cnt, bar(cnt, 0, 40,5) as bar from frontend_events
+group by raw:method order by cnt desc limit 5 by emit_version();
+```

--- a/examples/ecommerce/docker-compose.yml
+++ b/examples/ecommerce/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.7'
+name: proton-demo-ecommerce
+volumes:
+  redpanda: null
+services:
+  proton:
+     image: ghcr.io/timeplus-io/proton:latest
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.2.8
+    command:
+      - redpanda start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --smp 1
+      - --memory 1G
+      - --mode dev-container
+    volumes:
+      - redpanda:/var/lib/redpanda/data
+
+  console:
+    image: docker.redpanda.com/redpandadata/console:v2.3.1
+    entrypoint: /bin/sh
+    command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
+    environment:
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["redpanda:9092"]
+    ports:
+      - 8080:8080
+    depends_on:
+      - redpanda
+
+  owl-shop:
+    image: quay.io/cloudhut/owl-shop:latest
+    #platform: 'linux/amd64'
+    environment:
+      - SHOP_KAFKA_BROKERS=redpanda:9092
+      - SHOP_KAFKA_TOPICREPLICATIONFACTOR=1
+      - SHOP_TRAFFIC_INTERVAL_RATE=1
+      - SHOP_TRAFFIC_INTERVAL_DURATION=0.1s
+    depends_on:
+      - redpanda

--- a/examples/hackernews/README.md
+++ b/examples/hackernews/README.md
@@ -1,0 +1,53 @@
+# Example to Load Hacker News to Proton via Bytewax
+[proton.py](https://github.com/timeplus-io/proton-python-driver/blob/develop/example/bytewax/proton.py) is a Bytewax output/sink for [Timeplus Proton](https://github.com/timeplus-io/proton) streaming database.
+
+Inspired by https://bytewax.io/blog/polling-hacker-news, you can call Hacker News HTTP API with Bytewax and send latest news to Proton for SQL-based analysis, such as
+
+```sql
+select raw:id as id, raw:by as by, to_time(raw:time) as time, raw:title as title from hn
+```
+
+## How to run the demo
+
+
+```shell
+python3.10 -m venv py310-env
+source py310-env/bin/activate
+#git clone and cd to this proton-python-driver/example/bytewax folder
+pip install bytewax
+pip install requests 
+pip install proton-driver
+
+python -m bytewax.run "hackernews:run_hn_flow(0)"
+```
+It will load ~100 items every 15 second and send the data to Proton.
+
+```python
+flow.output("out", ProtonOutput("hn"))
+```
+`hn` is an example stream name. The `ProtonOutput` will create the stream if it doesn't exist
+```python
+class _ProtonSink(StatelessSink):
+    def __init__(self, stream: str):
+        self.client=client.Client(host='127.0.0.1', port=8463)
+        self.stream=stream
+        sql=f"CREATE STREAM IF NOT EXISTS `{stream}` (raw string)"
+        self.client.execute(sql)
+```
+and batch insert data
+```python
+def write_batch(self, items):
+    rows=[]
+    for item in items:
+        rows.append([item]) # single column in each row
+    sql = f"INSERT INTO `{self.stream}` (raw) VALUES"
+    self.client.execute(sql,rows)
+```
+
+```python
+class ProtonOutput(DynamicOutput):
+    def __init__(self, stream: str):
+        self.stream=stream
+    def build(self, worker_index, worker_count):
+        return _ProtonSink(self.stream)
+```

--- a/examples/hackernews/hackernews.py
+++ b/examples/hackernews/hackernews.py
@@ -1,0 +1,80 @@
+import requests
+from datetime import datetime, timedelta
+import time, json
+from typing import Any, Optional
+
+from bytewax.connectors.periodic import SimplePollingInput
+from bytewax.dataflow import Dataflow
+
+import logging
+
+from proton import ProtonOutput
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
+
+class HNInput(SimplePollingInput):
+    def __init__(self, interval: timedelta, align_to: Optional[datetime] = None, init_item: Optional[int] = None):
+        super().__init__(interval, align_to)
+        '''
+        By default, only get the recent events
+        '''
+        if not init_item or init_item == 0:
+            self.max_id = int(requests.get("https://hacker-news.firebaseio.com/v0/maxitem.json").json()*0.999998)
+        else:
+            self.max_id = init_item
+        logger.info(f"received starting id: {init_item}")
+        
+
+    def next_item(self):
+        '''
+        Get all the items from hacker news API between the last max id and the current max id.
+        '''
+        new_max_id = requests.get("https://hacker-news.firebaseio.com/v0/maxitem.json").json()
+        logger.info(f"current id: {self.max_id}, new id: {new_max_id}. {new_max_id-self.max_id} items to fetch")
+        ids = [int(i) for i in range(self.max_id, new_max_id)]
+        self.max_id = new_max_id
+        logger.debug(ids)
+        return ids
+    
+def download_metadata(hn_id):
+    # Given an hacker news id returned from the api, fetch metadata
+    logger.info(f"Fetching https://hacker-news.firebaseio.com/v0/item/{hn_id}.json")
+    req = requests.get(
+        f"https://hacker-news.firebaseio.com/v0/item/{hn_id}.json"
+    )
+    if not req.json():
+        logger.warning(f"error getting payload from item {hn_id} trying again")
+        time.sleep(0.5)
+        return download_metadata(hn_id)
+    return req.json()
+
+def recurse_tree(metadata):
+    try:
+        parent_id = metadata["parent"]
+        parent_metadata = download_metadata(parent_id)
+        return recurse_tree(parent_metadata)
+    except KeyError:
+        return (metadata["id"], {**metadata, "key_id": metadata["id"]})
+
+def key_on_parent(metadata: dict) -> tuple:
+    key, metadata = recurse_tree(metadata)
+    return json.dumps(metadata, indent=4, sort_keys=True)
+    
+def run_hn_flow(init_item): 
+    flow = Dataflow()
+    flow.input("in", HNInput(timedelta(seconds=15), None, init_item)) # skip the align_to argument
+    flow.flat_map(lambda x: x)
+    # If you run this dataflow with multiple workers, downloads in
+    # the next `map` will be parallelized thanks to .redistribute()
+    flow.redistribute()
+    flow.map(download_metadata)
+    flow.inspect(logger.debug)
+
+    # We want to keep related data together so let's build a 
+    # traversal function to get the ultimate parent
+    flow.map(key_on_parent)
+
+    flow.output("out", ProtonOutput("hn"))
+    return flow

--- a/examples/hackernews/proton.py
+++ b/examples/hackernews/proton.py
@@ -1,0 +1,46 @@
+"""Output to Timeplus Proton."""
+from bytewax.outputs import DynamicOutput, StatelessSink
+from proton_driver import client
+import logging
+
+__all__ = [
+    "ProtonOutput",
+]
+logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
+
+class _ProtonSink(StatelessSink):
+    def __init__(self, stream: str):
+        self.client=client.Client(host='127.0.0.1', port=8463)
+        self.stream=stream
+        sql=f"CREATE STREAM IF NOT EXISTS `{stream}` (raw string)"
+        logger.debug(sql)
+        self.client.execute(sql)
+
+    def write_batch(self, items):
+        rows=[]
+        for item in items:
+            rows.append([item]) # single column in each row
+        sql = f"INSERT INTO `{self.stream}` (raw) VALUES"
+        # logger.debug(f"inserting data {sql}")
+        self.client.execute(sql,rows)
+
+class ProtonOutput(DynamicOutput):
+    def __init__(self, stream: str):
+        self.stream=stream
+    
+    """Write each output item to Proton on that worker.
+
+    Items consumed from the dataflow must look like a string. Use a
+    proceeding map step to do custom formatting.
+
+    Workers are the unit of parallelism.
+
+    Can support at-least-once processing. Messages from the resume
+    epoch will be duplicated right after resume.
+
+    """
+
+    def build(self, worker_index, worker_count):
+        """See ABC docstring."""
+        return _ProtonSink(self.stream)


### PR DESCRIPTION
No code change, just docker-compose yaml files and README.

We put a docker-compose file at the root folder as getstarted. A new folder `examples` are created, with subfolders for different docker compose file. Each subfolder has its own README

Currently 2 examples are provided
1.  the owlshop
2. carlivedata

we can add more example docker compose files such as Grafana.

Each docker compose file is created in the minimal way. The user just need to run `docker compose up` to start the stack. No need extra parameters or profiles.