### PR TITLE
Feature/issue 155 add space in describe <stream> output

### DIFF
--- a/src/Parsers/TablePropertiesQueriesASTs.h
+++ b/src/Parsers/TablePropertiesQueriesASTs.h
@@ -127,7 +127,7 @@ protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
         settings.ostr << (settings.hilite ? hilite_keyword : "")
-                      << "DESCRIBE STREAM" << (settings.hilite ? hilite_none : "");
+                      << "DESCRIBE STREAM " << (settings.hilite ? hilite_none : "");
         table_expression->formatImpl(settings, state, frame);
     }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
```
proton client version 1.3.15.
Connecting to localhost:8463 as user default.
Connected to proton server version 1.3.15 revision 54459.

Warnings:
 * Server was built in debug mode. It will work slowly.
 * Available memory at server startup is too low (2GiB).

timeplus :) show streams

SHOW STREAMS

Query id: a9405f3a-619a-4255-a794-87554396a671

┌─name──────────┐
│ mybaties_test │
│ test          │
│ test1         │
│ test2         │
└───────────────┘

4 rows in set. Elapsed: 0.016 sec. 

timeplus :) describe test1

DESCRIBE STREAM test1

Query id: bef4796f-80c0-4d97-ad2f-b5029f63e36a

┌─name─────┬─type─────────────────┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
│ a        │ nullable(int32)      │              │                    │         │                  │                │
│ b        │ nullable(float32)    │              │                    │         │                  │                │
│ _tp_time │ datetime64(3, 'UTC') │ DEFAULT      │ now64(3, 'UTC')    │         │ DoubleDelta, LZ4 │                │
└──────────┴──────────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘

3 rows in set. Elapsed: 0.008 sec. 

timeplus :) 
```