### PR TITLE
Bugfix/issue-174 disable append-only stream left all join append-only stream

### DIFF
--- a/src/Interpreters/Streaming/HashJoin.cpp
+++ b/src/Interpreters/Streaming/HashJoin.cpp
@@ -781,7 +781,6 @@ size_t insertFromBlockImpl(
 const HashJoin::SupportMatrix HashJoin::support_matrix = {
     /// <left_stroage_semantic, join_kind, join_strictness, right_storage_semantic> - supported
     /// Append ...
-    {{StorageSemantic::Append, JoinKind::Left, JoinStrictness::All, StorageSemantic::Append}, true},
     {{StorageSemantic::Append, JoinKind::Left, JoinStrictness::All, StorageSemantic::ChangelogKV}, true},
     {{StorageSemantic::Append, JoinKind::Left, JoinStrictness::All, StorageSemantic::VersionedKV}, true},
     {{StorageSemantic::Append, JoinKind::Left, JoinStrictness::All, StorageSemantic::Changelog}, true},

--- a/src/Interpreters/tests/gtest_streaming_hash_join.cpp
+++ b/src/Interpreters/tests/gtest_streaming_hash_join.cpp
@@ -929,59 +929,6 @@ TEST(StreamingHashJoin, AppendLeftLatestJoinAppend)
         context);
 }
 
-TEST(StreamingHashJoin, AppendLeftAllJoinAppend)
-{
-    auto context = getContext().context;
-    Block left_header = prepareBlock(/*types*/ {"int", "datetime64(3, 'UTC')"}, /*no data*/ "", context);
-    Block right_header = prepareBlock(/*types*/ {"int", "datetime64(3, 'UTC')"}, /*no data*/ "", context);
-
-    /// stream(t1) left a;; join stream(t2) on t1.col_1 = t2.col_1
-    commonTest(
-        "left",
-        "all",
-        /*on_clause*/ "t1.col_1 = t2.col_1",
-        left_header,
-        Streaming::StorageSemantic::Append,
-        /*left_primary_key_column_indexes*/ std::nullopt,
-        right_header,
-        Streaming::StorageSemantic::Append,
-        /*right_primary_key_column_indexes*/ std::nullopt,
-        /*to_join_steps*/
-        {
-            {
-                /*to join pos*/ ToJoinStep::RIGHT,
-                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:00')", context),
-                /*expected join results*/ ExpectedJoinResults{},
-            },
-            {
-                /*to join pos*/ ToJoinStep::LEFT,
-                /*to join block*/ prepareBlockByHeader(left_header, "(2, '2023-1-1 00:00:00')", context),
-                /*expected join results*/
-                ExpectedJoinResults{
-                    /// output header: col_1, col_2, t2.col_2
-                    .values = "(2, '2023-1-1 00:00:00', '1970-1-1 00:00:00')",
-                },
-            },
-            {
-                /*to join pos*/ ToJoinStep::RIGHT,
-                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:01')", context),
-                /*expected join results*/
-                ExpectedJoinResults{},
-            },
-            {
-                /*to join pos*/ ToJoinStep::LEFT,
-                /*to join block*/ prepareBlockByHeader(left_header, "(1, '2023-1-1 00:00:01')", context),
-                /*expected join results*/
-                ExpectedJoinResults{
-                    /// output header: col_1, col_2, t2.col_2
-                    .values = "(1, '2023-1-1 00:00:01', '2023-1-1 00:00:00')"
-                              "(1, '2023-1-1 00:00:01', '2023-1-1 00:00:01')",
-                },
-            },
-        },
-        context);
-}
-
 TEST(StreamingHashJoin, AppendLeftAllJoinChangelog)
 {
     auto context = getContext().context;

--- a/tests/stream/test_stream_smoke/0009_stream_join_stream_case.json
+++ b/tests/stream/test_stream_smoke/0009_stream_join_stream_case.json
@@ -10,7 +10,7 @@
         {"client":"python", "query_type": "table", "wait":4, "exist":"test10_right_stream", "exist_wait":2, "query":"create stream if not exists test10_right_stream (ii int, ss string, tts datetime)"}
       ]
     },
-    "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["cluster_table_bug"]}}
+    "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample", "not_supported"],"cluster": ["cluster_table_bug"]}}
   },
   "comments": "Tests covering the stream query smoke cases.",
   "tests": [
@@ -67,7 +67,7 @@
     },
     {
       "id": 2,
-      "tags": ["stream_join_stream"],
+      "tags": ["stream_join_stream", "not_supported"],
       "name": "date_diff_within-left-join",
       "description": "stream to stream left join",
       "steps":[

--- a/tests/stream/test_stream_smoke/0009_stream_join_stream_case1.json
+++ b/tests/stream/test_stream_smoke/0009_stream_join_stream_case1.json
@@ -10,7 +10,7 @@
         {"client":"python", "query_type": "table", "wait":4,"exist":"test10_right_stream1", "exist_wait":2, "query":"create stream if not exists test10_right_stream1 (ii int, ss string, tts datetime)"}
       ]
     },
-    "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["cluster_table_bug"]}}
+    "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample", "not_supported"],"cluster": ["cluster_table_bug"]}}
   },
   "comments": "Tests covering the stream query smoke cases.",
   "tests": [
@@ -489,7 +489,7 @@
     },
     {
       "id": 42,
-      "tags": ["stream_join_stream"],
+      "tags": ["stream_join_stream", "not_supported"],
       "name": "left-global",
       "description": "stream to stream left join globally",
       "steps":[

--- a/tests/stream/test_stream_smoke/0009_stream_join_stream_case2.json
+++ b/tests/stream/test_stream_smoke/0009_stream_join_stream_case2.json
@@ -2,7 +2,7 @@
     "test_suite_name": "stream_join_stream2",
     "tag":"smoke",
     "test_suite_config":{
-        "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["view", "cluster_table_bug"]}}
+        "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample", "not_supported"],"cluster": ["view", "cluster_table_bug"]}}
     },
     "comments": "Tests covering the stream query smoke cases.",
     "tests": [
@@ -190,7 +190,7 @@
         },
         {
             "id": 56,
-            "tags": ["data_enrichment_join", "left-join"],
+            "tags": ["bidirectional join", "left-join"],
             "name": "append-only_left_all_join_append-only",
             "description": "append-only left all join append-only",
             "steps":[
@@ -211,11 +211,7 @@
             "expected_results": [
                 {
                     "query_id":"1056",
-                    "expected_results":[
-                        [2, "a", 1, "a"],
-                        [2, "b", 1, "b"],
-                        [2, "c", 0, ""]
-                    ]
+                    "expected_results": "error_code:48"
                 }
             ]
         },

--- a/tests/stream/test_stream_smoke/0018_query_state12_streaming_join.json
+++ b/tests/stream/test_stream_smoke/0018_query_state12_streaming_join.json
@@ -273,7 +273,7 @@
         },
         {
             "id": 356,
-            "tags": ["query_state", "data_enrichment_join", "left-join"],
+            "tags": ["query_state", "bidirectional join", "left-join", "native_not_support"],
             "name": "append-only_left_all_join_append-only",
             "description": "append-only left all JOIN append-only state checkpoint",
             "steps":[

--- a/tests/stream/test_stream_smoke/0020_seek_to.json
+++ b/tests/stream/test_stream_smoke/0020_seek_to.json
@@ -12,7 +12,7 @@
         {"client":"python", "query_type": "table", "wait":1, "query": "insert into test21_limit_by_stream(i, s, t) values (4, 's4', '2022-12-01 00:00:04.111')"}
       ]
     },
-    "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample"],"cluster": ["view", "cluster_table_bug"]}}
+    "tests_2_run": {"ids_2_run": ["all"], "tags_2_run":[], "tags_2_skip":{"default":["todo", "to_support", "change", "bug", "sample", "not_supported"],"cluster": ["view", "cluster_table_bug"]}}
   },
   "comments": "Tests covering seek_to by sequence number",
   "tests": [
@@ -354,8 +354,8 @@
             {"client":"python", "depends_on_stream":"test21_limit_by_stream_2", "query_type": "table", "query":"insert into test21_limit_by_stream_2(i, s, t) values (2, 's2', '2022-12-01 00:00:04.111')"},
             {"client":"python", "wait":2, "query_id":"2100", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select a.i, b.s, c.t from test21_limit_by_stream as a join test21_limit_by_stream as b on a.i = b.i join test21_limit_by_stream as c on b.i = c.i where a._tp_time >= '2022-12-01 00:00:01.111' and b._tp_time >= '2022-12-01 00:00:02.111' and c._tp_time >= '2022-12-01 00:00:03.111'"},
             {"client":"python", "wait":2, "query_id":"2101", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select a.i, count() from test21_limit_by_stream as a join test21_limit_by_stream as b on a.i = b.i where a._tp_time >= '2022-12-01 00:00:01.111' and b._tp_time >= '2022-12-01 00:00:02.111' group by a.i emit periodic 1s"},
-            {"client":"python", "wait":2, "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select i, s from test21_limit_by_stream as a left join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 1 and default.test21_limit_by_stream_2._tp_sn > 2"},
-            {"client":"python", "wait":2, "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select count() from test21_limit_by_stream as a left join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 0 and default.test21_limit_by_stream_2._tp_sn < 4 emit periodic 1s"}
+            {"client":"python", "wait":2, "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select i, s from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 1 and default.test21_limit_by_stream_2._tp_sn > 2"},
+            {"client":"python", "wait":2, "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select count() from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 0 and default.test21_limit_by_stream_2._tp_sn < 4 emit periodic 1s"}
           ]
         }
       ],
@@ -373,17 +373,17 @@
           ]
         },
         {
-          "query_id":"2102",
-          "expected_results":[
-            [2, "s2"]
-          ]
-        },
-        {
-          "query_id":"2103",
-          "expected_results":[
-            [3]
-          ]
-        }
+            "query_id":"2102",
+            "expected_results":[
+              [2, "s2"]
+            ]
+          },
+          {
+            "query_id":"2103",
+            "expected_results":[
+              [3]
+            ]
+          }
       ]
     },
     {


### PR DESCRIPTION
Disable append-only stream left join append-only stream and block some smoke test about this.So far, the `left join` is only supported in `data enrichment join`.The join results can not be guaranteed.
