### PR TITLE
Bugfix/issue 94 fix mac build warn and error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,9 +340,9 @@ if (COMPILER_CLANG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-absolute-paths")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-absolute-paths")
 
-    if (NOT ENABLE_TESTS AND NOT SANITIZE)
+    if (NOT ENABLE_TESTS AND NOT SANITIZE AND OS_LINUX)
         # https://clang.llvm.org/docs/ThinLTO.html
-        # Applies to clang only.
+        # Applies to clang and linux only.
         # Disabled when building with tests or sanitizers.
         option(ENABLE_THINLTO "Clang-specific link time optimization" ON)
     endif()

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -145,3 +145,17 @@ if (STRIP_PATH)
 else ()
     message (FATAL_ERROR "Cannot find strip.")
 endif ()
+
+if (OS_DARWIN AND NOT CMAKE_TOOLCHAIN_FILE)
+    # utils/list-licenses/list-licenses.sh (which generates system table system.licenses) needs the GNU versions of find and grep. These are
+    # not available out-of-the-box on Mac. As a special case, Darwin builds in CI are cross-compiled from x86 Linux where the GNU userland is
+    # available.
+    find_program(GFIND_PATH NAMES "gfind")
+    if (NOT GFIND_PATH)
+        message (FATAL_ERROR "GNU find not found. You can install it with 'brew install findutils'.")
+    endif()
+    find_program(GGREP_PATH NAMES "ggrep")
+    if (NOT GGREP_PATH)
+        message (FATAL_ERROR "GNU grep not found. You can install it with 'brew install grep'.")
+    endif()
+endif ()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -13,7 +13,7 @@ include(../cmake/limit_jobs.cmake)
 add_subdirectory (report)
 
 # Not used in package
-if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
+if (ENABLE_UTILS)
     add_subdirectory (compressor)
     add_subdirectory (iotest)
     add_subdirectory (corrector_utf8)

--- a/utils/list-licenses/list-licenses.sh
+++ b/utils/list-licenses/list-licenses.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # use GNU versions, their presence is ensured in cmake/tools.cmake
+    GREP_CMD=ggrep
+    FIND_CMD=gfind
+else
+    FIND_CMD=find
+    GREP_CMD=grep
+fi
+
 ROOT_PATH="$(git rev-parse --show-toplevel)"
 LIBS_PATH="${ROOT_PATH}/contrib"
 
-ls -1 -d ${LIBS_PATH}/*/ | grep -F -v -- '-cmake' | LC_ALL=C sort | while read LIB; do
+ls -1 -d ${LIBS_PATH}/*/ | ${GREP_CMD} -F -v -- '-cmake' | LC_ALL=C sort | while read LIB; do
     LIB_NAME=$(basename $LIB)
 
     LIB_LICENSE=$(
-        LC_ALL=C find "$LIB" -type f -and '(' -iname 'LICENSE*' -or -iname 'COPYING*' -or -iname 'COPYRIGHT*' ')' -and -not '(' -iname '*.html' -or -iname '*.htm' -or -iname '*.rtf' -or -name '*.cpp' -or -name '*.h' -or -iname '*.json' ')' -printf "%d\t%p\n" |
+        LC_ALL=C ${FIND_CMD} "$LIB" -type f -and '(' -iname 'LICENSE*' -or -iname 'COPYING*' -or -iname 'COPYRIGHT*' ')' -and -not '(' -iname '*.html' -or -iname '*.htm' -or -iname '*.rtf' -or -name '*.cpp' -or -name '*.h' -or -iname '*.json' ')' -printf "%d\t%p\n" |
             LC_ALL=C sort | LC_ALL=C awk '
                 BEGIN { IGNORECASE=1; min_depth = 0 }
                 /LICENSE/ { if (!min_depth || $1 <= min_depth) { min_depth = $1; license = $2 } }
@@ -17,34 +26,34 @@ ls -1 -d ${LIBS_PATH}/*/ | grep -F -v -- '-cmake' | LC_ALL=C sort | while read L
     if [ -n "$LIB_LICENSE" ]; then
 
         LICENSE_TYPE=$(
-        (grep -q -F 'Apache' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -F 'Apache' "$LIB_LICENSE" &&
          echo "Apache") ||
-        (grep -q -F 'Boost' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -F 'Boost' "$LIB_LICENSE" &&
          echo "Boost") ||
-        (grep -q -i -P 'public\s*domain' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -i -P 'public\s*domain' "$LIB_LICENSE" &&
          echo "Public Domain") ||
-        (grep -q -F 'BSD' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -F 'BSD' "$LIB_LICENSE" &&
          echo "BSD") ||
-        (grep -q -F 'Lesser General Public License' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -F 'Lesser General Public License' "$LIB_LICENSE" &&
          echo "LGPL") ||
-        (grep -q -i -F 'The origin of this software must not be misrepresented' "$LIB_LICENSE" &&
-         grep -q -i -F 'Altered source versions must be plainly marked as such' "$LIB_LICENSE" &&
-         grep -q -i -F 'This notice may not be removed or altered' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -i -F 'The origin of this software must not be misrepresented' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'Altered source versions must be plainly marked as such' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'This notice may not be removed or altered' "$LIB_LICENSE" &&
          echo "zLib") ||
-        (grep -q -i -F 'Permission is hereby granted, free of charge, to any person' "$LIB_LICENSE" &&
-         grep -q -i -F 'The above copyright notice and this permission notice shall be included' "$LIB_LICENSE" &&
-         grep -q -i -F 'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -i -F 'Permission is hereby granted, free of charge, to any person' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'The above copyright notice and this permission notice shall be included' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND' "$LIB_LICENSE" &&
          echo "MIT") ||
-        (grep -q -i -F 'Permission to use, copy, modify, and distribute this software for any purpose' "$LIB_LICENSE" &&
-         grep -q -i -F 'the name of a copyright holder shall not' "$LIB_LICENSE" &&
-         grep -q -i -F 'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -i -F 'Permission to use, copy, modify, and distribute this software for any purpose' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'the name of a copyright holder shall not' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND' "$LIB_LICENSE" &&
          echo "MIT/curl") ||
-        (grep -q -i -F 'Redistributions of source code must retain the above copyright' "$LIB_LICENSE" &&
-         grep -q -i -F 'Redistributions in binary form must reproduce' "$LIB_LICENSE" &&
-         grep -q -i -F 'Neither the name' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -i -F 'Redistributions of source code must retain the above copyright' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'Redistributions in binary form must reproduce' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'Neither the name' "$LIB_LICENSE" &&
          echo "BSD 3-clause") ||
-        (grep -q -i -F 'Redistributions of source code must retain the above copyright' "$LIB_LICENSE" &&
-         grep -q -i -F 'Redistributions in binary form must reproduce' "$LIB_LICENSE" &&
+        (${GREP_CMD} -q -i -F 'Redistributions of source code must retain the above copyright' "$LIB_LICENSE" &&
+         ${GREP_CMD} -q -i -F 'Redistributions in binary form must reproduce' "$LIB_LICENSE" &&
          echo "BSD 2-clause") ||
         echo "Unknown")
 


### PR DESCRIPTION
_edit 1: add pr summary_

Please write user-readable short description of the changes:
1. 171c9d0aa938df3370bfadb260432b18484d1ca2 utils has some build err with macOS, but after make the utils explicit build solve the default buid (cmake .. right now will not build utils). and this pr will save build/link time.
2.  f7d4ca7a419ad1e8f52978f9677c921a2491a024 fix warn
3. 7dfb41165fbdb664bf9a5a22e0df05c39ea6af34 this is a simple support macOS

In short: this PR cannot solve all the build warnings/errors, but make the original whole big PR review easier.