### PR TITLE
Bugfix/fix _tp_delta column order in header issue for ChangelogConvertTransform

### DIFF
--- a/tests/stream/test_stream_smoke/0099_fixed_issues.json
+++ b/tests/stream/test_stream_smoke/0099_fixed_issues.json
@@ -477,6 +477,27 @@
           [2, 1, 2.2, 2.2]]
         }
       ]
+    },
+    {
+      "id": 17,
+      "tags": ["changelog"],
+      "name": "#172",
+      "description": "Covering query json subcolumn and _tp_delta over changelog(stream)",
+      "steps":[
+        {
+          "statements": [
+            {"client":"python", "query_type": "table", "query": "drop stream if exists test_stream_17"},
+            {"client":"python", "query_type": "table", "exist": "test_stream_17", "exist_wait":2, "wait":1, "query": "create stream test_stream_17(id int, raw json)"},
+            {"client":"python", "query_type": "table", "depends_on_stream":"test_stream_17", "wait":1, "query": "insert into test_stream_17(id, raw) values (1, '{\"projectId\": \"111\"}')"},
+            {"client":"python", "query_type": "stream", "query_id":"9900", "wait":1, "query_end_timer":3, "query":"select id, raw.projectId AS projectId_json, _tp_delta from changelog(test_stream_17, id) where _tp_time > earliest_ts()"}
+          ]
+        }
+      ],
+      "expected_results": [
+        {"query_id":"9900", "expected_results":[
+          [1, "111", 1]
+        ]}
+      ]
     }
   ]
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
This close #172, the change log:
- The ChangelogConvertTransform always add `_tp_delta` at back of output to avoid access invalid column by incorrect pos