### PR TITLE
Bugfix/add subcolumns description for subquery inputs

### DIFF
--- a/src/Interpreters/IInterpreterUnionOrSelectQuery.h
+++ b/src/Interpreters/IInterpreterUnionOrSelectQuery.h
@@ -85,10 +85,6 @@ public:
     virtual bool hasStreamingWindowFunc() const = 0;
     virtual Streaming::DataStreamSemanticEx getDataStreamSemantic() const = 0;
 
-    /// Return the object column descriptions of the current query to provide subcolumns information to downstream
-    /// pipeline. If the current query doesn't have any object columns, return empty but non-nullptr ColumnsDescription.
-    virtual ColumnsDescriptionPtr getExtendedObjects() const { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "not implemented"); }
-
     virtual std::set<String> getGroupByColumns() const =0;
     /// proton: ends
 

--- a/src/Interpreters/IdentifierSemantic.cpp
+++ b/src/Interpreters/IdentifierSemantic.cpp
@@ -255,6 +255,36 @@ void IdentifierSemantic::setColumnLongName(ASTIdentifier & identifier, const Dat
     }
 }
 
+/// proton: starts.
+void IdentifierSemantic::setColumnLongNestedName(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table)
+{
+    String prefix = db_and_table.getQualifiedNamePrefix(false);
+    if (!prefix.empty())
+    {
+        auto match = IdentifierSemantic::canReferColumnToTable(identifier, db_and_table);
+        size_t to_strip = 0;
+        switch (match)
+        {
+            case IdentifierSemantic::ColumnMatch::TableName:
+            case IdentifierSemantic::ColumnMatch::AliasedTableName:
+            case IdentifierSemantic::ColumnMatch::TableAlias:
+                to_strip = 1;
+                break;
+            case IdentifierSemantic::ColumnMatch::DBAndTable:
+                to_strip = 2;
+                break;
+            default:
+                break;
+        }
+
+        identifier.name_parts.erase(identifier.name_parts.begin(), identifier.name_parts.begin() + to_strip);
+        identifier.name_parts.insert(identifier.name_parts.begin(), prefix);
+        identifier.resetFullName();
+        identifier.semantic->table = std::move(prefix);
+    }
+}
+/// proton: ends.
+
 std::optional<size_t> IdentifierSemantic::getIdentMembership(const ASTIdentifier & ident, const std::vector<TableWithColumnNamesAndTypes> & tables)
 {
     std::optional<size_t> table_pos = IdentifierSemantic::getMembership(ident);

--- a/src/Interpreters/IdentifierSemantic.h
+++ b/src/Interpreters/IdentifierSemantic.h
@@ -51,6 +51,9 @@ struct IdentifierSemantic
 
     static void setColumnShortName(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table);
     static void setColumnLongName(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table);
+    /// proton: starts.
+    static void setColumnLongNestedName(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table);
+    /// proton: ends.
     static bool canBeAlias(const ASTIdentifier & identifier);
     static void setMembership(ASTIdentifier &, size_t table_pos);
     static void coverName(ASTIdentifier &, const String & alias);

--- a/src/Interpreters/InterpreterSelectIntersectExceptQuery.cpp
+++ b/src/Interpreters/InterpreterSelectIntersectExceptQuery.cpp
@@ -219,22 +219,6 @@ Streaming::DataStreamSemanticEx InterpreterSelectIntersectExceptQuery::getDataSt
     return hash_semantic;
 }
 
-ColumnsDescriptionPtr InterpreterSelectIntersectExceptQuery::getExtendedObjects() const
-{
-    if (nested_interpreters.size() == 1)
-        return nested_interpreters.front()->getExtendedObjects();
-
-    std::vector<ColumnsDescriptionPtr> object_columns_list;
-    object_columns_list.reserve(nested_interpreters.size());
-    for (const auto & interpreter : nested_interpreters)
-        object_columns_list.emplace_back(interpreter->getExtendedObjects());
-
-    auto merged_object_columns = std::make_shared<ColumnsDescription>(*object_columns_list.front());
-    for (size_t i = 1; i < object_columns_list.size(); ++i)
-        DB::updateObjectColumns(*merged_object_columns, object_columns_list[i]->getAllPhysical());
-    return merged_object_columns;
-}
-
 std::set<String> InterpreterSelectIntersectExceptQuery::getGroupByColumns() const
 {
     std::set<String> group_by_columns;

--- a/src/Interpreters/InterpreterSelectIntersectExceptQuery.h
+++ b/src/Interpreters/InterpreterSelectIntersectExceptQuery.h
@@ -42,7 +42,6 @@ public:
     bool hasStreamingWindowFunc() const override;
     Streaming::DataStreamSemanticEx getDataStreamSemantic() const override;
 
-    ColumnsDescriptionPtr getExtendedObjects() const override;
     std::set<String> getGroupByColumns() const override;
     /// proton: ends
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -533,18 +533,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
         {
             interpreter_subquery = joined_tables.makeLeftTableSubquery(options.subquery());
             if (interpreter_subquery)
-            {
                 source_header = interpreter_subquery->getSampleBlock();
-
-                /// proton: starts. Add extended subcolumns for subquery inputs
-                auto subcolumns = ColumnsDescription::getSubcolumns(source_header.getNamesAndTypesList());
-                for (auto & [name, type] : subcolumns)
-                {
-                    if (!source_header.has(name))
-                        source_header.insert({nullptr, std::move(type), std::move(name)});
-                }
-                /// proton: ends.
-            }
         }
 
         /// proton : starts. After resolving the tables and rewrite multiple joins

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -206,7 +206,6 @@ private:
     void checkAndPrepareStreamingFunctions();
     void checkUDA();
 
-    ColumnsDescriptionPtr getExtendedObjects() const override;
     void resolveDataStreamSemantic(const JoinedTables & joined_tables);
     /// proton: ends
 

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -469,30 +469,6 @@ Streaming::DataStreamSemanticEx InterpreterSelectWithUnionQuery::getDataStreamSe
     return data_semantic;
 }
 
-ColumnsDescriptionPtr InterpreterSelectWithUnionQuery::getExtendedObjects() const
-{
-    if (nested_interpreters.size() == 1)
-        return nested_interpreters.front()->getExtendedObjects();
-
-    std::vector<ColumnsDescriptionPtr> object_columns_list;
-    object_columns_list.reserve(nested_interpreters.size());
-    for (const auto & interpreter : nested_interpreters)
-        object_columns_list.emplace_back(interpreter->getExtendedObjects());
-
-    /// We only merged the same objects based on the first interpreter objects, and get the least common type,
-    /// because union/intersect/except must be same output for each interpreter, for example:
-    /// interpreter-1 objects:
-    /// json a => tuple(x int, y int), json b => tuple(m string)
-    /// interpreter-2 objects:
-    /// json a => tuple(x double, y int64), json b => tuple(m int), json c => tuple(n string)
-    /// merged:
-    /// json a => tuple(x double, y int64), json b => tuple(m string)
-    auto merged_object_columns = std::make_shared<ColumnsDescription>(*object_columns_list.front());
-    for (size_t i = 1; i < object_columns_list.size(); ++i)
-        DB::updateObjectColumns(*merged_object_columns, object_columns_list[i]->getAllPhysical());
-    return merged_object_columns;
-}
-
 std::set<String> InterpreterSelectWithUnionQuery::getGroupByColumns() const
 {
     std::set<String> group_by_columns;

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.h
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.h
@@ -55,7 +55,6 @@ public:
     bool hasStreamingWindowFunc() const override;
     Streaming::DataStreamSemanticEx getDataStreamSemantic() const override;
 
-    ColumnsDescriptionPtr getExtendedObjects() const override;
     std::set<String> getGroupByColumns() const override;
     /// proton: ends
 

--- a/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -150,6 +150,10 @@ void TranslateQualifiedNamesMatcher::visit(ASTIdentifier & identifier, ASTPtr &,
             const auto & table = data.tables[table_pos].table;
             if (table_pos && (data.hasColumn(short_name) || !isValidIdentifierBegin(short_name.at(0))))
                 IdentifierSemantic::setColumnLongName(identifier, table);
+            /// proton: starts. Supports nested column name such as `t2.raw.id` when the joined table `t2` have columns `raw`, `raw.id`                
+            else if (table_pos && data.hasColumn(IdentifierSemantic::extractNestedName(identifier, table)))
+                IdentifierSemantic::setColumnLongNestedName(identifier, table);
+            /// proton: ends.   
             else
                 IdentifierSemantic::setColumnShortName(identifier, table);
         }

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -947,6 +947,13 @@ void TreeRewriterResult::collectSourceColumns(bool add_special)
         else
             source_columns.insert(source_columns.end(), columns_from_storage.begin(), columns_from_storage.end());
     }
+    /// proton: starts. Add extended subcolumns for subquery inputs
+    else
+    {
+        if (!source_columns.empty())
+            source_columns.splice(source_columns.end(), ColumnsDescription::getSubcolumns(source_columns));
+    }
+    /// proton: ends.
 
     source_columns_set = removeDuplicateColumns(source_columns);
 }

--- a/src/Interpreters/getTableExpressions.cpp
+++ b/src/Interpreters/getTableExpressions.cpp
@@ -191,6 +191,7 @@ TablesWithColumns getDatabaseAndTablesWithColumns(
             table.addMaterializedColumns(materialized);
 
         /// proton : starts
+        table.addHiddenColumns(ColumnsDescription::getSubcolumns(table.columns));
         table.setOutputDataStreamSemantic(output_date_stream_semantic);
         /// proton : ends
     }

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -827,5 +827,20 @@ void ColumnsDescription::addOrUpdateSubcolumns(
                 it, [moved_subcolumn = std::move(subcolumn)](auto & column) { column = std::move(moved_subcolumn); }); /// NOLINT(performance-move-const-arg)
     }
 }
+
+NamesAndTypesList ColumnsDescription::getSubcolumns(const NamesAndTypesList & name_and_type_list)
+{
+    NamesAndTypesList res;
+    for (const auto & name_and_type : name_and_type_list)
+    {
+        auto type_in_storage = name_and_type.getTypeInStorage();
+        IDataType::forEachSubcolumn(
+            [&](const auto &, const auto & subname, const auto & subdata) {
+                res.push_back(NameAndTypePair(name_and_type.getNameInStorage(), subname, type_in_storage, subdata.type));
+            },
+            ISerialization::SubstreamData(type_in_storage->getDefaultSerialization()).withType(type_in_storage));
+    }
+    return res;
+}
 /// proton: ends.
 }

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -141,6 +141,8 @@ public:
     void updateColumn(const String & column_name, const DataTypePtr & new_type);
 
     void addOrUpdateSubcolumns(const String & name_in_storage, const DataTypePtr & type_in_storage, const NamesAndTypes & subcolumns_list);
+
+    static NamesAndTypesList getSubcolumns(const NamesAndTypesList & name_and_type_list);
     /// proton: ends.
 
     template <typename F>

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -235,19 +235,6 @@ ASTPtr StorageView::restoreViewName(ASTSelectQuery & select_query, const ASTPtr 
 }
 
 /// proton: starts.
-StorageSnapshotPtr StorageView::getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const
-{
-    if (hasDynamicSubcolumns(metadata_snapshot->getColumns()))
-    {
-        auto object_columns
-            = InterpreterSelectWithUnionQuery(getInMemoryMetadataPtr()->getSelectQuery().inner_query, query_context, SelectQueryOptions().analyze())
-                .getExtendedObjects();
-        return std::make_shared<StorageSnapshot>(*this, metadata_snapshot, *object_columns);
-    }
-    else
-        return std::make_shared<StorageSnapshot>(*this, metadata_snapshot);
-}
-
 void StorageView::startup()
 {
     auto metadata_snapshot = getInMemoryMetadataPtr();

--- a/src/Storages/StorageView.h
+++ b/src/Storages/StorageView.h
@@ -42,7 +42,6 @@ public:
     /// proton: starts.
     bool supportsSubcolumns() const override { return true; }
     bool supportsDynamicSubcolumns() const override { return true; }
-    StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
     Streaming::DataStreamSemanticEx dataStreamSemantic() const override;
 
     NamesAndTypesList getVirtuals() const override;

--- a/tests/stream/test_stream_smoke/0099_fixed_issues.json
+++ b/tests/stream/test_stream_smoke/0099_fixed_issues.json
@@ -491,11 +491,25 @@
             {"client":"python", "query_type": "table", "depends_on_stream":"test_stream_17", "wait":1, "query": "insert into test_stream_17(id, raw) values (1, '{\"projectId\": \"111\"}')"},
             {"client":"python", "query_type": "stream", "query_id":"9900", "wait":1, "query_end_timer":3, "query":"select id, raw.projectId AS projectId_json, _tp_delta from changelog(test_stream_17, id) where _tp_time > earliest_ts()"}
           ]
+        },
+        {
+          "statements": [
+            {"client":"python", "query_type": "table", "query": "drop stream if exists test_stream_17_vk"},
+            {"client":"python", "query_type": "table", "exist": "test_stream_17_vk", "exist_wait":2, "wait":1, "query": "create stream test_stream_17_vk(id int, raw json) primary key id settings mode='versioned_kv'"},
+            {"client":"python", "query_type": "table", "depends_on_stream":"test_stream_17_vk", "wait":1, "query": "insert into test_stream_17_vk(id, raw) values (1, '{\"projectId\": \"111\"}')"},
+            {"client":"python", "query_type": "stream", "query_id":"9901", "wait":1, "query":"select t1.id, t1.raw.projectId, t2.raw.projectId, _tp_delta from changelog(test_stream_17, id) as t1 join changelog(test_stream_17_vk) as t2 on t1.id = t2.id where t1._tp_time > earliest_ts()"},
+            {"client":"python", "query_type": "table", "depends_on":"9901", "wait":1, "kill":"9901", "kill_wait":3, "query": "insert into test_stream_17_vk(id, raw) values (1, '{\"projectId\": \"222\"}')"}
+          ]
         }
       ],
       "expected_results": [
         {"query_id":"9900", "expected_results":[
           [1, "111", 1]
+        ]},
+        {"query_id":"9901", "expected_results":[
+          [1, "111", "111", 1],
+          [1, "111", "111", -1],
+          [1, "111", "222", 1]
         ]}
       ]
     }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
This fix #173, the change log:
- Support get subcolumns description for all types with subcolumns.
- Add subcolumns description for subquery inputs
- Clean up some trash code