### PR TITLE
Added UT for `parseProperties`.

### DIFF
--- a/src/KafkaLog/KafkaWALCommon.h
+++ b/src/KafkaLog/KafkaWALCommon.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "NativeLog/Record/Record.h"
+#include "KafkaWALProperties.h"
 #include "Results.h"
+
+#include <NativeLog/Record/Record.h>
 
 #include <librdkafka/rdkafka.h>
 
@@ -27,7 +29,6 @@ using KTopicPtr = std::unique_ptr<rd_kafka_topic_t, decltype(rd_kafka_topic_dest
 using KConfPtr = std::unique_ptr<rd_kafka_conf_t, decltype(rd_kafka_conf_destroy) *>;
 using KTopicConfPtr = std::unique_ptr<rd_kafka_topic_conf_t, decltype(rd_kafka_topic_conf_destroy) *>;
 using KConfCallback = std::function<void(rd_kafka_conf_t *)>;
-using KConfParams = std::vector<std::pair<String, String>>;
 
 std::unique_ptr<struct rd_kafka_s, void (*)(rd_kafka_t *)>
 initRdKafkaHandle(rd_kafka_type_t type, KConfParams & params, KafkaWALStats * stats, KConfCallback cb_setup);

--- a/src/KafkaLog/KafkaWALProperties.cpp
+++ b/src/KafkaLog/KafkaWALProperties.cpp
@@ -1,0 +1,43 @@
+#include "KafkaWALProperties.h"
+
+#include <base/defines.h>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+namespace klog
+{
+KConfParams parseProperties(const String & properties)
+{
+    KConfParams result;
+
+    if (properties.empty())
+        return result;
+
+    std::vector<String> parts;
+    boost::split(parts, properties, boost::is_any_of(";"));
+    result.reserve(parts.size());
+
+    for (const auto & part : parts)
+    {
+        /// skip empty part, this happens when there are redundant / trailing ';'
+        if (unlikely(std::all_of(part.begin(), part.end(), [](char ch) { return isspace(static_cast<unsigned char>(ch)); })))
+            continue;
+
+        auto equal_pos = part.find('=');
+        if (unlikely(equal_pos == std::string::npos || equal_pos == 0 || equal_pos == part.size() - 1))
+            throw std::invalid_argument("Invalid property `" + part + "`, expected format: <key>=<value>.");
+
+        auto key = part.substr(0, equal_pos);
+        auto value = part.substr(equal_pos + 1);
+
+        /// no spaces are supposed be around `=`, thus only need to
+        /// remove the leading spaces of keys and trailing spaces of values
+        boost::trim_left(key);
+        boost::trim_right(value);
+        result.push_back(std::make_pair(key, value));
+    }
+
+    return result;
+}
+}

--- a/src/KafkaLog/KafkaWALProperties.h
+++ b/src/KafkaLog/KafkaWALProperties.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <base/types.h>
+
+namespace klog
+{
+using KConfParams = std::vector<std::pair<String, String>>;
+
+/// Parses the `properties` setting for Kafka external streams.
+/// properties example:
+/// message.max.bytes=1024;max.in.flight=1000;group.id=my-group
+KConfParams parseProperties(const String & properties);
+}

--- a/src/KafkaLog/tests/gtest_parse_properties.cpp
+++ b/src/KafkaLog/tests/gtest_parse_properties.cpp
@@ -1,0 +1,83 @@
+#include <KafkaLog/KafkaWALProperties.h>
+
+#include <gtest/gtest.h>
+
+#include <unordered_set>
+
+TEST(ParseProperties, empty)
+{
+    String exp;
+    auto p = klog::parseProperties(exp);
+    EXPECT_EQ(0, p.size());
+}
+
+TEST(ParseProperties, justSemicolons)
+{
+    String exp = ";;;;";
+    auto p = klog::parseProperties(exp);
+    EXPECT_EQ(0, p.size());
+}
+
+TEST(ParseProperties, singleProperty)
+{
+    std::unordered_set<String> cases{
+        "key.1=value.1",
+        ";key.1=value.1",
+        "key.1=value.1;",
+        ";key.1=value.1;",
+        ";;key.1=value.1",
+        "key.1=value.1;;",
+        ";;key.1=value.1;;",
+    };
+
+    for (const auto & exp : cases)
+    {
+        auto p = klog::parseProperties(exp);
+        EXPECT_EQ(1, p.size());
+
+        auto kv = p.at(0);
+        EXPECT_EQ("key.1", kv.first);
+        EXPECT_EQ("value.1", kv.second);
+    }
+}
+
+TEST(ParseProperties, multipleProperties)
+{
+    std::unordered_set<String> cases{
+        "key.1=value.1;        key.2=value.2;key.3=value.3",
+        "     key.1=value.1;   ;key.2=value.2     ;     key.3=value.3        ",
+        "key.1=value.1;key.2=value.2;key.3=value.3;",
+        ";;key.1=value.1;key.2=value.2;key.3=value.3;;",
+    };
+
+    for (const auto & exp : cases)
+    {
+        auto p = klog::parseProperties(exp);
+        EXPECT_EQ(3, p.size());
+
+        auto kv = p.at(0);
+        EXPECT_EQ("key.1", kv.first);
+        EXPECT_EQ("value.1", kv.second);
+        kv = p.at(1);
+        EXPECT_EQ("key.2", kv.first);
+        EXPECT_EQ("value.2", kv.second);
+        kv = p.at(2);
+        EXPECT_EQ("key.3", kv.first);
+        EXPECT_EQ("value.3", kv.second);
+    }
+}
+
+TEST(ParseProperties, errorCases)
+{
+    std::unordered_set<String> cases{
+        "key",
+        "key=",
+        "=value",
+        "=",
+    };
+
+    for (const auto & exp : cases)
+    {
+        EXPECT_THROW(klog::parseProperties(exp), std::invalid_argument);
+    }
+}

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -42,8 +42,6 @@ public:
     const klog::KConfParams & properties() const { return kafka_properties; }
 
 private:
-    static klog::KConfParams parseProperties(String & properties);
-
     void calculateDataFormat(const IStorage * storage);
     void cacheVirtualColumnNamesAndTypes();
     std::vector<Int64> getOffsets(const SeekToInfoPtr & seek_to_info) const;

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -226,7 +226,7 @@ public:
     /// However, not all storages need this feature, for example, external streams
     /// likely have their own ways to do buffering. This function allows an implementation
     /// to skip using squashing.
-    virtual bool squashInsert() const noexcept { return false; }
+    virtual bool squashInsert() const noexcept { return true; }
     /// proton: ends.
 
     /// Return list of virtual columns (like _part, _table, etc). In the vast


### PR DESCRIPTION
The `parseProperties` function has been extract out from `DB::Kafka` and moved to `klog` namespace under `KafkaLog`. And UT has been added for the function.

Closes #195 

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
