### PR TITLE
Bugfix/fix get now64 nanosecond precision in os x

### DIFF
--- a/src/Functions/Streaming/StreamingNow64.cpp
+++ b/src/Functions/Streaming/StreamingNow64.cpp
@@ -7,8 +7,7 @@
 #include <DataTypes/DataTypeNullable.h>
 
 #include <Common/assert_cast.h>
-
-#include <ctime>
+#include <Common/timeScale.h>
 
 
 namespace DB
@@ -22,31 +21,6 @@ namespace ErrorCodes
 
 namespace
 {
-
-Field nowSubsecond(UInt32 scale)
-{
-    static constexpr Int32 fractional_scale = 9;
-
-    timespec spec{};
-    if (clock_gettime(CLOCK_REALTIME, &spec))
-        throwFromErrno("Cannot clock_gettime.", ErrorCodes::CANNOT_CLOCK_GETTIME);
-
-    DecimalUtils::DecimalComponents<DateTime64> components{spec.tv_sec, spec.tv_nsec};
-
-    // clock_gettime produces subsecond part in nanoseconds, but decimalFromComponents fractional is scale-dependent.
-    // Andjust fractional to scale, e.g. for 123456789 nanoseconds:
-    //   if scale is  6 (miscoseconds) => divide by 9 - 6 = 3 to get 123456 microseconds
-    //   if scale is 12 (picoseconds)  => multiply by abs(9 - 12) = 3 to get 123456789000 picoseconds
-    const auto adjust_scale = fractional_scale - static_cast<Int32>(scale);
-    if (adjust_scale < 0)
-        components.fractional *= intExp10(std::abs(adjust_scale));
-    else if (adjust_scale > 0)
-        components.fractional /= intExp10(adjust_scale);
-
-    return DecimalField(DecimalUtils::decimalFromComponents<DateTime64>(components, scale),
-                        scale);
-}
-
 /// Get the current time. (It is a constant, it is evaluated once for the entire query.)
 class ExecutableFunctionNow64 : public IExecutableFunction
 {

--- a/src/Functions/now64.cpp
+++ b/src/Functions/now64.cpp
@@ -7,9 +7,7 @@
 #include <DataTypes/DataTypeNullable.h>
 
 #include <Common/assert_cast.h>
-
-#include <ctime>
-
+#include <Common/timeScale.h>
 
 namespace DB
 {
@@ -22,31 +20,6 @@ namespace ErrorCodes
 
 namespace
 {
-
-Field nowSubsecond(UInt32 scale)
-{
-    static constexpr Int32 fractional_scale = 9;
-
-    timespec spec{};
-    if (clock_gettime(CLOCK_REALTIME, &spec))
-        throwFromErrno("Cannot clock_gettime.", ErrorCodes::CANNOT_CLOCK_GETTIME);
-
-    DecimalUtils::DecimalComponents<DateTime64> components{spec.tv_sec, spec.tv_nsec};
-
-    // clock_gettime produces subsecond part in nanoseconds, but decimalFromComponents fractional is scale-dependent.
-    // Andjust fractional to scale, e.g. for 123456789 nanoseconds:
-    //   if scale is  6 (miscoseconds) => divide by 9 - 6 = 3 to get 123456 microseconds
-    //   if scale is 12 (picoseconds)  => multiply by abs(9 - 12) = 3 to get 123456789000 picoseconds
-    const auto adjust_scale = fractional_scale - static_cast<Int32>(scale);
-    if (adjust_scale < 0)
-        components.fractional *= intExp10(std::abs(adjust_scale));
-    else if (adjust_scale > 0)
-        components.fractional /= intExp10(adjust_scale);
-
-    return DecimalField(DecimalUtils::decimalFromComponents<DateTime64>(components, scale),
-                        scale);
-}
-
 /// Get the current time. (It is a constant, it is evaluated once for the entire query.)
 class ExecutableFunctionNow64 : public IExecutableFunction
 {


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix #202 