### PR TITLE
fix: cannot create MV with kafka external stream

### DIFF
--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -49,6 +49,8 @@ KafkaSource::KafkaSource(
     , virtual_col_types(header.columns(), nullptr)
     , ckpt_data(consume_ctx)
 {
+    is_streaming = true;
+
     calculateColumnPositions();
     initConsumer(kafka);
     initFormatExecutor(kafka);


### PR DESCRIPTION
`is_streaming = true` was deleted from `KafkaSource.cpp` by accident, which caused the issue reported in #229.

I tested the change with:
* creating an MV based on kafka external stream
* gracefully stopped proton, and started it again, make sure that the MV can pick up from where it left
* deleting the MV

Closes #229

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
