### PR TITLE
Enhancement/issue 241 mark the replay operation end

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2345,14 +2345,13 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
             {
                 if (const auto * proxy = storage->as<Streaming::ProxyStream>())
                 {
-                    const auto & variant_storage_or_subquery = proxy->getProxyStorageOrSubquery();
-                    const auto * nested_storage = std::get_if<StoragePtr>(&variant_storage_or_subquery);
+                    const auto & proxyed = proxy->getProxyStorageOrSubquery();
+                    const auto * nested_storage = std::get_if<StoragePtr>(&proxyed);
                     if (nested_storage)
-                        storagestream = storage->as<StorageStream>();
+                        storagestream = (*nested_storage)->as<StorageStream>();
                 }
                 else
                     storagestream = storage->as<StorageStream>();
-                    // [[maybe_unused]] std::shared_ptr<StorageStream> tmp= storage->as<StorageStream>();
 
                 if (!storagestream)
                     throw Exception("Replay Stream is only support append-only stream", ErrorCodes::NOT_IMPLEMENTED);

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -5,8 +5,8 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTOrderByElement.h>
-#include <Parsers/ASTSelectIntersectExceptQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSelectIntersectExceptQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/parseQuery.h>
@@ -18,23 +18,24 @@
 
 #include <Interpreters/ApplyWithAliasVisitor.h>
 #include <Interpreters/ApplyWithSubqueryVisitor.h>
-#include <Interpreters/CrossToInnerJoinVisitor.h>
-#include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/InterpreterSetQuery.h>
+#include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/convertFieldToType.h>
+#include <Interpreters/addTypeConversionToAST.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/getTableExpressions.h>
 #include <Interpreters/JoinToSubqueryTransformVisitor.h>
+#include <Interpreters/CrossToInnerJoinVisitor.h>
+#include <Interpreters/TableJoin.h>
 #include <Interpreters/JoinedTables.h>
 #include <Interpreters/OpenTelemetrySpanLog.h>
 #include <Interpreters/QueryAliasesVisitor.h>
-#include <Interpreters/TableJoin.h>
-#include <Interpreters/UnnestSubqueryVisitor.h>
-#include <Interpreters/addTypeConversionToAST.h>
-#include <Interpreters/convertFieldToType.h>
-#include <Interpreters/evaluateConstantExpression.h>
-#include <Interpreters/getTableExpressions.h>
 #include <Interpreters/replaceAliasColumnsInQuery.h>
+#include <Interpreters/UnnestSubqueryVisitor.h>
 
+#include <QueryPipeline/Pipe.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/ArrayJoinStep.h>
 #include <Processors/QueryPlan/CreatingSetsStep.h>
@@ -47,42 +48,41 @@
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/LimitByStep.h>
 #include <Processors/QueryPlan/LimitStep.h>
+#include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/MergingAggregatedStep.h>
 #include <Processors/QueryPlan/OffsetStep.h>
-#include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/QueryPlan/RollupStep.h>
-#include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/TotalsHavingStep.h>
 #include <Processors/QueryPlan/WindowStep.h>
+#include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/Sources/NullSource.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Processors/Transforms/FilterTransform.h>
-#include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 
 #include <Storages/MergeTree/MergeTreeWhereOptimizer.h>
-#include <Storages/StorageDistributed.h>
 #include <Storages/StorageView.h>
+#include <Storages/StorageDistributed.h>
 
-#include <Columns/Collator.h>
-#include <Core/ColumnNumbers.h>
-#include <Core/Field.h>
 #include <Functions/IFunction.h>
+#include <Core/Field.h>
+#include <base/types.h>
+#include <base/sort.h>
+#include <Columns/Collator.h>
+#include <Common/FieldVisitorsAccurateComparison.h>
+#include <Common/FieldVisitorToString.h>
+#include <Common/typeid_cast.h>
+#include <Common/checkStackSize.h>
+#include <Core/ColumnNumbers.h>
 #include <Interpreters/Aggregator.h>
 #include <Interpreters/IJoin.h>
 #include <QueryPipeline/SizeLimits.h>
 #include <base/map.h>
-#include <base/sort.h>
-#include <base/types.h>
-#include <Common/FieldVisitorToString.h>
-#include <Common/FieldVisitorsAccurateComparison.h>
-#include <Common/checkStackSize.h>
 #include <Common/scope_guard_safe.h>
-#include <Common/typeid_cast.h>
 
 /// proton: starts
 #include <DataTypes/ObjectUtils.h>
@@ -114,7 +114,6 @@
 #include <Storages/Streaming/StorageStream.h>
 #include <Storages/Streaming/storageUtil.h>
 #include <Common/ProtonCommon.h>
-#include "Storages/IStorage_fwd.h"
 /// proton: ends
 
 namespace DB
@@ -122,27 +121,27 @@ namespace DB
 
 namespace ErrorCodes
 {
-extern const int TOO_DEEP_SUBQUERIES;
-extern const int SAMPLING_NOT_SUPPORTED;
-extern const int ILLEGAL_FINAL;
-extern const int ILLEGAL_PREWHERE;
-extern const int TOO_MANY_COLUMNS;
-extern const int LOGICAL_ERROR;
-extern const int NOT_IMPLEMENTED;
-extern const int PARAMETER_OUT_OF_BOUND;
-extern const int INVALID_LIMIT_EXPRESSION;
-extern const int INVALID_WITH_FILL_EXPRESSION;
-extern const int ACCESS_DENIED;
+    extern const int TOO_DEEP_SUBQUERIES;
+    extern const int SAMPLING_NOT_SUPPORTED;
+    extern const int ILLEGAL_FINAL;
+    extern const int ILLEGAL_PREWHERE;
+    extern const int TOO_MANY_COLUMNS;
+    extern const int LOGICAL_ERROR;
+    extern const int NOT_IMPLEMENTED;
+    extern const int PARAMETER_OUT_OF_BOUND;
+    extern const int INVALID_LIMIT_EXPRESSION;
+    extern const int INVALID_WITH_FILL_EXPRESSION;
+    extern const int ACCESS_DENIED;
 
-/// proton: starts
-extern const int WINDOW_COLUMN_NOT_REFERENCED;
-extern const int INVALID_STREAMING_FUNC_DESC;
-extern const int MISSING_GROUP_BY;
-extern const int UNSUPPORTED;
-extern const int FUNCTION_NOT_ALLOWED;
-extern const int DATABASE_ACCESS_DENIED;
-extern const int UDA_NOT_APPLICABLE;
-/// proton: ends
+    /// proton: starts
+    extern const int WINDOW_COLUMN_NOT_REFERENCED;
+    extern const int INVALID_STREAMING_FUNC_DESC;
+    extern const int MISSING_GROUP_BY;
+    extern const int UNSUPPORTED;
+    extern const int FUNCTION_NOT_ALLOWED;
+    extern const int DATABASE_ACCESS_DENIED;
+    extern const int UDA_NOT_APPLICABLE;
+    /// proton: ends
 }
 
 /// proton: starts.
@@ -247,8 +246,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     const SelectQueryOptions & options_,
     const Names & required_result_column_names_)
     : InterpreterSelectQuery(query_ptr_, context_, std::nullopt, nullptr, options_, required_result_column_names_)
-{
-}
+{}
 
 InterpreterSelectQuery::InterpreterSelectQuery(
     const ASTPtr & query_ptr_,
@@ -256,14 +254,15 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     const SelectQueryOptions & options_,
     const Names & required_result_column_names_)
     : InterpreterSelectQuery(query_ptr_, context_, std::nullopt, nullptr, options_, required_result_column_names_)
-{
-}
+{}
 
 InterpreterSelectQuery::InterpreterSelectQuery(
-    const ASTPtr & query_ptr_, const ContextPtr & context_, Pipe input_pipe_, const SelectQueryOptions & options_)
-    : InterpreterSelectQuery(query_ptr_, context_, std::move(input_pipe_), nullptr, options_.copy().noSubquery())
-{
-}
+        const ASTPtr & query_ptr_,
+        const ContextPtr & context_,
+        Pipe input_pipe_,
+        const SelectQueryOptions & options_)
+        : InterpreterSelectQuery(query_ptr_, context_, std::move(input_pipe_), nullptr, options_.copy().noSubquery())
+{}
 
 InterpreterSelectQuery::InterpreterSelectQuery(
     const ASTPtr & query_ptr_,
@@ -272,14 +271,16 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     const StorageMetadataPtr & metadata_snapshot_,
     const SelectQueryOptions & options_)
     : InterpreterSelectQuery(query_ptr_, context_, std::nullopt, storage_, options_.copy().noSubquery(), {}, metadata_snapshot_)
-{
-}
+{}
 
 InterpreterSelectQuery::InterpreterSelectQuery(
-    const ASTPtr & query_ptr_, const ContextPtr & context_, const SelectQueryOptions & options_, PreparedSetsPtr prepared_sets_)
-    : InterpreterSelectQuery(query_ptr_, context_, std::nullopt, nullptr, options_, {}, {}, prepared_sets_)
-{
-}
+    const ASTPtr & query_ptr_,
+    const ContextPtr & context_,
+    const SelectQueryOptions & options_,
+    PreparedSetsPtr prepared_sets_)
+    : InterpreterSelectQuery(
+        query_ptr_, context_, std::nullopt, nullptr, options_, {}, {}, prepared_sets_)
+{}
 
 InterpreterSelectQuery::~InterpreterSelectQuery() = default;
 
@@ -352,8 +353,7 @@ static bool shouldIgnoreQuotaAndLimits(const StorageID & table_id)
 {
     if (table_id.database_name == DatabaseCatalog::SYSTEM_DATABASE)
     {
-        static const boost::container::flat_set<String> tables_ignoring_quota{
-            "quotas", "quota_limits", "quota_usage", "quotas_usage", "one"};
+        static const boost::container::flat_set<String> tables_ignoring_quota{"quotas", "quota_limits", "quota_usage", "quotas_usage", "one"};
         if (tables_ignoring_quota.contains(table_id.table_name))
             return true;
     }
@@ -378,8 +378,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
         required_result_column_names,
         metadata_snapshot_,
         prepared_sets_)
-{
-}
+{}
 
 InterpreterSelectQuery::InterpreterSelectQuery(
     const ASTPtr & query_ptr_,
@@ -420,7 +419,8 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     const Settings & settings = context->getSettingsRef();
 
     if (settings.max_subquery_depth && options.subquery_depth > settings.max_subquery_depth)
-        throw Exception("Too deep subqueries. Maximum: " + settings.max_subquery_depth.toString(), ErrorCodes::TOO_DEEP_SUBQUERIES);
+        throw Exception("Too deep subqueries. Maximum: " + settings.max_subquery_depth.toString(),
+            ErrorCodes::TOO_DEEP_SUBQUERIES);
 
     bool has_input = input_pipe.has_value();
     if (input_pipe)
@@ -450,9 +450,9 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     if (auto emit = getSelectQuery().emit())
     {
         Streaming::EmitInterpreter::handleRules(
-            /* streaming query */ query_ptr,
-            /* rules */ Streaming::EmitInterpreter::checkEmitAST,
-            Streaming::EmitInterpreter::LastXRule(settings, log));
+                    /* streaming query */ query_ptr,
+                    /* rules */ Streaming::EmitInterpreter::checkEmitAST,
+                                Streaming::EmitInterpreter::LastXRule(settings, log));
 
         /// Force emit changelog, for example: `select * from versioned_kv emit changelog`
         if (emit->as<ASTEmitQuery &>().stream_mode == ASTEmitQuery::StreamMode::CHANGELOG)
@@ -599,7 +599,11 @@ InterpreterSelectQuery::InterpreterSelectQuery(
 
             /// Rewrite select query to add back _tp_delta if it is not present
             Streaming::ChangelogQueryVisitorMatcher data(
-                data_stream_semantic_pair, tables, !required_result_column_names.empty(), options.is_subquery, query_info);
+                data_stream_semantic_pair,
+                tables,
+                !required_result_column_names.empty(),
+                options.is_subquery,
+                query_info);
 
             Streaming::ChangelogQueryVisitor(data).visit(query_ptr);
             if (data.queryInputIsRewritten())
@@ -616,8 +620,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
                 new_required_result_column_names = std::make_unique<Names>(required_result_column_names);
                 for (auto & new_required_column : new_required_columns)
                 {
-                    if (std::find(new_required_result_column_names->begin(), new_required_result_column_names->end(), new_required_column)
-                        == new_required_result_column_names->end())
+                    if (std::find(new_required_result_column_names->begin(), new_required_result_column_names->end(), new_required_column) == new_required_result_column_names->end())
                         new_required_result_column_names->emplace_back(std::move(new_required_column));
                 }
 
@@ -640,8 +643,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     /// proton : starts, only allow system.* access under a special setting
     if (storage)
     {
-        row_policy_filter
-            = context->getRowPolicyFilter(table_id.getDatabaseName(), table_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+        row_policy_filter = context->getRowPolicyFilter(table_id.getDatabaseName(), table_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
 
         if (table_id.getDatabaseName() == "system" && !settings._tp_internal_system_open_sesame.value)
             throw Exception(ErrorCodes::DATABASE_ACCESS_DENIED, "Have no permission to access system database");
@@ -652,7 +654,8 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     if (storage)
         view = dynamic_cast<StorageView *>(storage.get());
 
-    auto analyze = [&](bool try_move_to_prewhere) {
+    auto analyze = [&] (bool try_move_to_prewhere)
+    {
         /// Allow push down and other optimizations for VIEW: replace with subquery and rewrite it.
         ASTPtr view_table;
         if (view)
@@ -830,8 +833,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     analyze(shouldMoveToPrewhere());
 
     bool need_analyze_again = false;
-    if (analysis_result.prewhere_constant_filter_description.always_false
-        || analysis_result.prewhere_constant_filter_description.always_true)
+    if (analysis_result.prewhere_constant_filter_description.always_false || analysis_result.prewhere_constant_filter_description.always_true)
     {
         if (analysis_result.prewhere_constant_filter_description.always_true)
             query.setExpression(ASTSelectQuery::Expression::PREWHERE, {});
@@ -968,16 +970,16 @@ Block InterpreterSelectQuery::getSampleBlockImpl()
     /// Also note that with distributed_group_by_no_merge=1 or when there is
     /// only one remote server, it is equal to local query in terms of query
     /// stages (or when due to optimize_distributed_group_by_sharding_key the query was processed up to Complete stage).
-    bool first_stage
-        = from_stage < QueryProcessingStage::WithMergeableState && options.to_stage >= QueryProcessingStage::WithMergeableState;
+    bool first_stage = from_stage < QueryProcessingStage::WithMergeableState
+        && options.to_stage >= QueryProcessingStage::WithMergeableState;
     /// Do I need to execute the second part of the pipeline?
     /// Running on the initiating server during distributed processing or if query is not distributed.
     ///
     /// Also note that with distributed_group_by_no_merge=2 (i.e. when optimize_distributed_group_by_sharding_key takes place)
     /// the query on the remote server will be processed up to WithMergeableStateAfterAggregationAndLimit,
     /// So it will do partial second stage (second_stage=true), and initiator will do the final part.
-    bool second_stage
-        = from_stage <= QueryProcessingStage::WithMergeableState && options.to_stage > QueryProcessingStage::WithMergeableState;
+    bool second_stage = from_stage <= QueryProcessingStage::WithMergeableState
+        && options.to_stage > QueryProcessingStage::WithMergeableState;
 
     analysis_result = ExpressionAnalysisResult(
         *query_analyzer,
@@ -1036,7 +1038,7 @@ Block InterpreterSelectQuery::getSampleBlockImpl()
         Block res;
 
         if (analysis_result.use_grouping_set_key)
-            res.insert({nullptr, std::make_shared<DataTypeUInt64>(), "__grouping_set"});
+            res.insert({ nullptr, std::make_shared<DataTypeUInt64>(), "__grouping_set" });
 
         for (const auto & key : query_analyzer->aggregationKeys())
             res.insert({nullptr, header.getByName(key.name).type, key.name});
@@ -1074,8 +1076,7 @@ static Field getWithFillFieldValue(const ASTPtr & node, ContextPtr context)
     auto [field, type] = evaluateConstantExpression(node, context);
 
     if (!isColumnedAsNumber(type))
-        throw Exception(
-            "Illegal type " + type->getName() + " of WITH FILL expression, must be numeric type", ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
+        throw Exception("Illegal type " + type->getName() + " of WITH FILL expression, must be numeric type", ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
 
     return field;
 }
@@ -1090,8 +1091,7 @@ static std::pair<Field, std::optional<IntervalKind>> getWithFillStep(const ASTPt
     if (isColumnedAsNumber(type))
         return std::make_pair(std::move(field), std::nullopt);
 
-    throw Exception(
-        "Illegal type " + type->getName() + " of WITH FILL expression, must be numeric type", ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
+    throw Exception("Illegal type " + type->getName() + " of WITH FILL expression, must be numeric type", ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
 }
 
 static FillColumnDescription getWithFillDescription(const ASTOrderByElement & order_by_elem, const ContextPtr & context)
@@ -1114,28 +1114,26 @@ static FillColumnDescription getWithFillDescription(const ASTOrderByElement & or
     if (order_by_elem.direction == 1)
     {
         if (applyVisitor(FieldVisitorAccurateLess(), descr.fill_step, Field{0}))
-            throw Exception(
-                "WITH FILL STEP value cannot be negative for sorting in ascending direction", ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
+            throw Exception("WITH FILL STEP value cannot be negative for sorting in ascending direction",
+                ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
 
-        if (!descr.fill_from.isNull() && !descr.fill_to.isNull()
-            && applyVisitor(FieldVisitorAccurateLess(), descr.fill_to, descr.fill_from))
+        if (!descr.fill_from.isNull() && !descr.fill_to.isNull() &&
+            applyVisitor(FieldVisitorAccurateLess(), descr.fill_to, descr.fill_from))
         {
-            throw Exception(
-                "WITH FILL TO value cannot be less than FROM value for sorting in ascending direction",
+            throw Exception("WITH FILL TO value cannot be less than FROM value for sorting in ascending direction",
                 ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
         }
     }
     else
     {
         if (applyVisitor(FieldVisitorAccurateLess(), Field{0}, descr.fill_step))
-            throw Exception(
-                "WITH FILL STEP value cannot be positive for sorting in descending direction", ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
+            throw Exception("WITH FILL STEP value cannot be positive for sorting in descending direction",
+                ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
 
-        if (!descr.fill_from.isNull() && !descr.fill_to.isNull()
-            && applyVisitor(FieldVisitorAccurateLess(), descr.fill_from, descr.fill_to))
+        if (!descr.fill_from.isNull() && !descr.fill_to.isNull() &&
+            applyVisitor(FieldVisitorAccurateLess(), descr.fill_from, descr.fill_to))
         {
-            throw Exception(
-                "WITH FILL FROM value cannot be less than TO value for sorting in descending direction",
+            throw Exception("WITH FILL FROM value cannot be less than TO value for sorting in descending direction",
                 ErrorCodes::INVALID_WITH_FILL_EXPRESSION);
         }
     }
@@ -1251,8 +1249,9 @@ static bool hasWithTotalsInAnySubqueryInFromClause(const ASTSelectQuery & query)
             * the height of the AST tree can have any depth (each intersect/except adds a level), but the
             * number of children in those nodes is always 2.
             */
-            std::function<bool(ASTPtr)> traverse_recursively = [&](ASTPtr child_ast) -> bool {
-                if (const auto * select_child = child_ast->as<ASTSelectQuery>())
+            std::function<bool(ASTPtr)> traverse_recursively = [&](ASTPtr child_ast) -> bool
+            {
+                if (const auto * select_child = child_ast->as <ASTSelectQuery>())
                 {
                     if (hasWithTotalsInAnySubqueryInFromClause(select_child->as<ASTSelectQuery &>()))
                         return true;
@@ -1304,12 +1303,18 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
     bool from_aggregation_stage = false;
 
     /// Do I need to aggregate in a separate row that has not passed max_rows_to_group_by?
-    bool aggregate_overflow_row = expressions.need_aggregate && query.group_by_with_totals && settings.max_rows_to_group_by
-        && settings.group_by_overflow_mode == OverflowMode::ANY && settings.totals_mode != TotalsMode::AFTER_HAVING_EXCLUSIVE;
+    bool aggregate_overflow_row =
+        expressions.need_aggregate &&
+        query.group_by_with_totals &&
+        settings.max_rows_to_group_by &&
+        settings.group_by_overflow_mode == OverflowMode::ANY &&
+        settings.totals_mode != TotalsMode::AFTER_HAVING_EXCLUSIVE;
 
     /// Do I need to immediately finalize the aggregate functions after the aggregation?
-    bool aggregate_final = expressions.need_aggregate && options.to_stage > QueryProcessingStage::WithMergeableState
-        && !query.group_by_with_totals && !query.group_by_with_rollup && !query.group_by_with_cube;
+    bool aggregate_final =
+        expressions.need_aggregate &&
+        options.to_stage > QueryProcessingStage::WithMergeableState &&
+        !query.group_by_with_totals && !query.group_by_with_rollup && !query.group_by_with_cube;
 
     bool use_grouping_set_key = expressions.use_grouping_set_key;
 
@@ -1320,8 +1325,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "GROUPING SETS are not supported together with ROLLUP and CUBE");
 
     if (expressions.hasHaving() && query.group_by_with_totals && (query.group_by_with_rollup || query.group_by_with_cube))
-        throw Exception(
-            ErrorCodes::NOT_IMPLEMENTED, "WITH TOTALS and WITH ROLLUP or CUBE are not supported together in presence of HAVING");
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "WITH TOTALS and WITH ROLLUP or CUBE are not supported together in presence of HAVING");
 
     if (query_info.projection && query_info.projection->desc->type == ProjectionDescription::Type::Aggregate)
     {
@@ -1381,7 +1385,8 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
             query_plan.addInterpreterContext(context);
         }
 
-        if (from_stage == QueryProcessingStage::WithMergeableState && options.to_stage == QueryProcessingStage::WithMergeableState)
+        if (from_stage == QueryProcessingStage::WithMergeableState &&
+            options.to_stage == QueryProcessingStage::WithMergeableState)
             intermediate_stage = true;
 
         /// Support optimize_distributed_group_by_sharding_key
@@ -1400,13 +1405,17 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
 
     if (options.to_stage > QueryProcessingStage::FetchColumns)
     {
-        auto preliminary_sort = [&]() {
+        auto preliminary_sort = [&]()
+        {
             /** For distributed query processing,
               *  if no GROUP, HAVING set,
               *  but there is an ORDER or LIMIT,
               *  then we will perform the preliminary sorting and LIMIT on the remote server.
               */
-            if (!expressions.second_stage && !expressions.need_aggregate && !expressions.hasHaving() && !expressions.has_window)
+            if (!expressions.second_stage
+                && !expressions.need_aggregate
+                && !expressions.hasHaving()
+                && !expressions.has_window)
             {
                 if (expressions.has_order_by)
                     executeOrder(
@@ -1483,8 +1492,9 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
 
             if (expressions.before_join)
             {
-                QueryPlanStepPtr before_join_step
-                    = std::make_unique<ExpressionStep>(query_plan.getCurrentDataStream(), expressions.before_join);
+                QueryPlanStepPtr before_join_step = std::make_unique<ExpressionStep>(
+                    query_plan.getCurrentDataStream(),
+                    expressions.before_join);
                 before_join_step->setStepDescription("Before JOIN");
                 query_plan.addStep(std::move(before_join_step));
             }
@@ -1492,8 +1502,9 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
             /// Optional step to convert key columns to common supertype.
             if (expressions.converting_join_columns)
             {
-                QueryPlanStepPtr convert_join_step
-                    = std::make_unique<ExpressionStep>(query_plan.getCurrentDataStream(), expressions.converting_join_columns);
+                QueryPlanStepPtr convert_join_step = std::make_unique<ExpressionStep>(
+                    query_plan.getCurrentDataStream(),
+                    expressions.converting_join_columns);
                 convert_join_step->setStepDescription("Convert JOIN columns");
                 query_plan.addStep(std::move(convert_join_step));
             }
@@ -1502,8 +1513,10 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
             {
                 if (expressions.join->isFilled())
                 {
-                    QueryPlanStepPtr filled_join_step
-                        = std::make_unique<FilledJoinStep>(query_plan.getCurrentDataStream(), expressions.join, settings.max_block_size);
+                    QueryPlanStepPtr filled_join_step = std::make_unique<FilledJoinStep>(
+                        query_plan.getCurrentDataStream(),
+                        expressions.join,
+                        settings.max_block_size);
 
                     filled_join_step->setStepDescription("JOIN");
                     query_plan.addStep(std::move(filled_join_step));
@@ -1515,7 +1528,8 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                     if (!joined_plan)
                         throw Exception(ErrorCodes::LOGICAL_ERROR, "There is no joined plan for query");
 
-                    auto add_sorting = [&settings, this](QueryPlan & plan, const Names & key_names) {
+                    auto add_sorting = [&settings, this] (QueryPlan & plan, const Names & key_names)
+                    {
                         SortDescription order_descr;
                         order_descr.reserve(key_names.size());
                         for (const auto & key_name : key_names)
@@ -1650,12 +1664,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                     {
                         bool final = !query.group_by_with_rollup && !query.group_by_with_cube;
                         executeTotalsAndHaving(
-                            query_plan,
-                            expressions.hasHaving(),
-                            expressions.before_having,
-                            expressions.remove_having_filter,
-                            aggregate_overflow_row,
-                            final);
+                            query_plan, expressions.hasHaving(), expressions.before_having, expressions.remove_having_filter, aggregate_overflow_row, final);
                     }
 
                     if (query.group_by_with_rollup)
@@ -1663,17 +1672,14 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                     else if (query.group_by_with_cube)
                         executeRollupOrCube(query_plan, Modificator::CUBE);
 
-                    if ((query.group_by_with_rollup || query.group_by_with_cube || query.group_by_with_grouping_sets)
-                        && expressions.hasHaving())
+                    if ((query.group_by_with_rollup || query.group_by_with_cube || query.group_by_with_grouping_sets) && expressions.hasHaving())
                         executeHaving(query_plan, expressions.before_having, expressions.remove_having_filter);
                 }
                 else if (expressions.hasHaving())
                     executeHaving(query_plan, expressions.before_having, expressions.remove_having_filter);
             }
-            else if (
-                query.group_by_with_totals || query.group_by_with_rollup || query.group_by_with_cube || query.group_by_with_grouping_sets)
-                throw Exception(
-                    "WITH TOTALS, ROLLUP, CUBE or GROUPING SETS are not supported without aggregation", ErrorCodes::NOT_IMPLEMENTED);
+            else if (query.group_by_with_totals || query.group_by_with_rollup || query.group_by_with_cube || query.group_by_with_grouping_sets)
+                throw Exception("WITH TOTALS, ROLLUP, CUBE or GROUPING SETS are not supported without aggregation", ErrorCodes::NOT_IMPLEMENTED);
 
             // Now we must execute:
             // 1) expressions before window functions,
@@ -1691,7 +1697,8 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
             }
             else if (expressions.need_aggregate)
             {
-                executeExpression(query_plan, expressions.before_window, "Before window functions");
+                executeExpression(query_plan, expressions.before_window,
+                    "Before window functions");
                 executeWindow(query_plan);
                 executeExpression(query_plan, expressions.before_order_by, "Before ORDER BY");
                 executeDistinct(query_plan, true, expressions.selected_columns, true);
@@ -1724,11 +1731,12 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
 
                 if (from_aggregation_stage)
                     executeMergeSorted(query_plan, "after aggregation stage for ORDER BY");
-                else if (
-                    !expressions.first_stage && !expressions.need_aggregate && !expressions.has_window
+                else if (!expressions.first_stage
+                    && !expressions.need_aggregate
+                    && !expressions.has_window
                     && !(query.group_by_with_totals && !aggregate_final))
                     executeMergeSorted(query_plan, "for ORDER BY, without aggregation");
-                else /// Otherwise, just sort.
+                else    /// Otherwise, just sort.
                     executeOrder(
                         query_plan,
                         query_info.input_order_info ? query_info.input_order_info
@@ -1751,13 +1759,18 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
             }
 
             bool apply_limit = options.to_stage != QueryProcessingStage::WithMergeableStateAfterAggregation;
-            bool apply_prelimit = apply_limit && query.limitLength() && !query.limit_with_ties
-                && !hasWithTotalsInAnySubqueryInFromClause(query) && !query.arrayJoinExpressionList().first && !query.distinct
-                && !expressions.hasLimitBy() && !settings.extremes && !has_withfill;
+            bool apply_prelimit = apply_limit &&
+                                  query.limitLength() && !query.limit_with_ties &&
+                                  !hasWithTotalsInAnySubqueryInFromClause(query) &&
+                                  !query.arrayJoinExpressionList().first &&
+                                  !query.distinct &&
+                                  !expressions.hasLimitBy() &&
+                                  !settings.extremes &&
+                                  !has_withfill;
             bool apply_offset = options.to_stage != QueryProcessingStage::WithMergeableStateAfterAggregationAndLimit;
             if (apply_prelimit)
             {
-                executePreLimit(query_plan, /* do_not_skip_offset= */ !apply_offset);
+                executePreLimit(query_plan, /* do_not_skip_offset= */!apply_offset);
             }
 
             /** If there was more than one stream,
@@ -1869,18 +1882,19 @@ void InterpreterSelectQuery::addEmptySourceToQueryPlan(
 
         if (prewhere_info.row_level_filter)
         {
-            pipe.addSimpleTransform([&](const Block & header) {
-                return std::make_shared<FilterTransform>(
-                    header, std::make_shared<ExpressionActions>(prewhere_info.row_level_filter), prewhere_info.row_level_column_name, true);
+            pipe.addSimpleTransform([&](const Block & header)
+            {
+                return std::make_shared<FilterTransform>(header,
+                    std::make_shared<ExpressionActions>(prewhere_info.row_level_filter),
+                    prewhere_info.row_level_column_name, true);
             });
         }
 
-        pipe.addSimpleTransform([&](const Block & header) {
+        pipe.addSimpleTransform([&](const Block & header)
+        {
             return std::make_shared<FilterTransform>(
-                header,
-                std::make_shared<ExpressionActions>(prewhere_info.prewhere_actions),
-                prewhere_info.prewhere_column_name,
-                prewhere_info.remove_prewhere_column);
+                header, std::make_shared<ExpressionActions>(prewhere_info.prewhere_actions),
+                prewhere_info.prewhere_column_name, prewhere_info.remove_prewhere_column);
         });
     }
 
@@ -1944,7 +1958,8 @@ void InterpreterSelectQuery::addPrewhereAliasActions()
             {
                 /// Execute row level filter in prewhere as a part of "move to prewhere" optimization.
                 expressions.prewhere_info = std::make_shared<PrewhereInfo>(
-                    std::move(expressions.filter_info->actions), std::move(expressions.filter_info->column_name));
+                    std::move(expressions.filter_info->actions),
+                    std::move(expressions.filter_info->column_name));
                 expressions.prewhere_info->prewhere_actions->projectInput(false);
                 expressions.prewhere_info->remove_prewhere_column = expressions.filter_info->do_remove_column;
                 expressions.prewhere_info->need_filter = true;
@@ -2105,9 +2120,15 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
     const Settings & settings = context->getSettingsRef();
 
     /// Optimization for trivial query like SELECT count() FROM table.
-    bool optimize_trivial_count = syntax_analyzer_result->optimize_trivial_count && !syntax_analyzer_result->streaming
-        && (settings.max_parallel_replicas <= 1) && storage && !row_policy_filter && processing_stage == QueryProcessingStage::FetchColumns
-        && query_analyzer->hasAggregation() && (query_analyzer->aggregates().size() == 1)
+    bool optimize_trivial_count =
+        syntax_analyzer_result->optimize_trivial_count
+        && !syntax_analyzer_result->streaming
+        && (settings.max_parallel_replicas <= 1)
+        && storage
+        && !row_policy_filter
+        && processing_stage == QueryProcessingStage::FetchColumns
+        && query_analyzer->hasAggregation()
+        && (query_analyzer->aggregates().size() == 1)
         && typeid_cast<const AggregateFunctionCount *>(query_analyzer->aggregates()[0].function.get());
 
     if (optimize_trivial_count)
@@ -2200,9 +2221,19 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
      *  then as the block size we will use limit + offset (not to read more from the table than requested),
      *  and also set the number of threads to 1.
      */
-    if (!query.distinct && !query.limit_with_ties && !query.prewhere() && !query.where() && !query.groupBy() && !query.having()
-        && !query.orderBy() && !query.limitBy() && !query.join() && !query_analyzer->hasAggregation() && !query_analyzer->hasWindow()
-        && query.limitLength() && limit_length <= std::numeric_limits<UInt64>::max() - limit_offset
+    if (!query.distinct
+        && !query.limit_with_ties
+        && !query.prewhere()
+        && !query.where()
+        && !query.groupBy()
+        && !query.having()
+        && !query.orderBy()
+        && !query.limitBy()
+        && !query.join()
+        && !query_analyzer->hasAggregation()
+        && !query_analyzer->hasWindow()
+        && query.limitLength()
+        && limit_length <= std::numeric_limits<UInt64>::max() - limit_offset
         && limit_length + limit_offset < max_block_size)
     {
         max_block_size = std::max<UInt64>(1, limit_length + limit_offset);
@@ -2228,7 +2259,8 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
             throw Exception("Subquery expected", ErrorCodes::LOGICAL_ERROR);
 
         interpreter_subquery = std::make_unique<InterpreterSelectWithUnionQuery>(
-            subquery, getSubqueryContext(context), options.copy().subquery().noModify(), required_columns);
+            subquery, getSubqueryContext(context),
+            options.copy().subquery().noModify(), required_columns);
 
         interpreter_subquery->addStorageLimits(storage_limits);
 
@@ -2300,6 +2332,7 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
         }
 
         query_info.storage_limits = std::make_shared<StorageLimitsList>(storage_limits);
+
         query_info.settings_limit_offset_done = options.settings_limit_offset_done;
 
         /// proton: starts.
@@ -2307,38 +2340,39 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
         if (settings.replay_speed > 0)
         {
             /// So far, only support append-only stream (or proxyed)
+            StorageStream * storagestream = nullptr;
             if (Streaming::isAppendStorage(storage->dataStreamSemantic()))
             {
-                std::vector<Int64> shards_last_sns;
-                if (const auto * storagestream = storage->as<StorageStream>())
-                    shards_last_sns = storagestream->getLastSNs();
-                else if (const auto * proxy = storage->as<Streaming::ProxyStream>(); proxy)
+                if (const auto * proxy = storage->as<Streaming::ProxyStream>())
                 {
                     const auto & variant_storage_or_subquery = proxy->getProxyStorageOrSubquery();
                     const auto * nested_storage = std::get_if<StoragePtr>(&variant_storage_or_subquery);
                     if (nested_storage)
-                        if (const auto * nested_storage_stream = (*nested_storage)->as<StorageStream>())
-                            shards_last_sns = nested_storage_stream->getLastSNs();
+                        storagestream = storage->as<StorageStream>();
                 }
+                else
+                    storagestream = storage->as<StorageStream>();
+                    // [[maybe_unused]] std::shared_ptr<StorageStream> tmp= storage->as<StorageStream>();
 
-                if (!shards_last_sns.size())
+                if (!storagestream)
                     throw Exception("Replay Stream is only support append-only stream", ErrorCodes::NOT_IMPLEMENTED);
-
-                if (std::ranges::none_of(required_columns, [](const auto & name) { return name == ProtonConsts::RESERVED_APPEND_TIME; }))
-                    required_columns.emplace_back(ProtonConsts::RESERVED_APPEND_TIME);
-
-                if (std::ranges::none_of(
-                        required_columns, [](const auto & name) { return name == ProtonConsts::RESERVED_EVENT_SEQUENCE_ID; }))
-                    required_columns.emplace_back(ProtonConsts::RESERVED_EVENT_SEQUENCE_ID);
-
-                storage->read(
-                    query_plan, required_columns, storage_snapshot, query_info, context, processing_stage, max_block_size, max_streams);
-
-                auto replay_step = std::make_unique<Streaming::ReplayStreamStep>(
-                    query_plan.getCurrentDataStream(), settings.replay_speed, std::move(shards_last_sns));
-                replay_step->setStepDescription("Replay Stream");
-                query_plan.addStep(std::move(replay_step));
             }
+            assert(storagestream);
+
+            if (std::ranges::none_of(required_columns, [](const auto & name) { return name == ProtonConsts::RESERVED_APPEND_TIME; }))
+                required_columns.emplace_back(ProtonConsts::RESERVED_APPEND_TIME);
+
+            if (std::ranges::none_of(
+                    required_columns, [](const auto & name) { return name == ProtonConsts::RESERVED_EVENT_SEQUENCE_ID; }))
+                required_columns.emplace_back(ProtonConsts::RESERVED_EVENT_SEQUENCE_ID);
+
+            storage->read(
+                query_plan, required_columns, storage_snapshot, query_info, context, processing_stage, max_block_size, max_streams);
+
+            auto replay_step = std::make_unique<Streaming::ReplayStreamStep>(
+                query_plan.getCurrentDataStream(), settings.replay_speed, (storagestream)->getLastSNs());
+            replay_step->setStepDescription("Replay Stream");
+            query_plan.addStep(std::move(replay_step));
         }
         else
             storage->read(
@@ -2402,10 +2436,8 @@ static Aggregator::Params getAggregatorParams(
     const Block & current_data_stream_header,
     const ColumnNumbers & keys,
     const AggregateDescriptions & aggregates,
-    bool overflow_row,
-    const Settings & settings,
-    size_t group_by_two_level_threshold,
-    size_t group_by_two_level_threshold_bytes)
+    bool overflow_row, const Settings & settings,
+    size_t group_by_two_level_threshold, size_t group_by_two_level_threshold_bytes)
 {
     const auto stats_collecting_params = Aggregator::Params::StatsCollectingParams(
         query_ptr,
@@ -2413,7 +2445,8 @@ static Aggregator::Params getAggregatorParams(
         settings.max_entries_for_hash_table_stats,
         settings.max_size_to_preallocate_for_aggregation);
 
-    return Aggregator::Params{
+    return Aggregator::Params
+    {
         current_data_stream_header,
         keys,
         aggregates,
@@ -2432,11 +2465,15 @@ static Aggregator::Params getAggregatorParams(
         settings.compile_aggregate_expressions,
         settings.min_count_to_compile_aggregate_expression,
         Block{},
-        stats_collecting_params};
+        stats_collecting_params
+    };
 }
 
 static GroupingSetsParamsList getAggregatorGroupingSetsParams(
-    const SelectQueryExpressionAnalyzer & query_analyzer, const Block & header_before_aggregation, const ColumnNumbers & all_keys)
+    const SelectQueryExpressionAnalyzer & query_analyzer,
+    const Block & header_before_aggregation,
+    const ColumnNumbers & all_keys
+)
 {
     GroupingSetsParamsList result;
     if (query_analyzer.useGroupingSetKey())
@@ -2468,8 +2505,7 @@ static GroupingSetsParamsList getAggregatorGroupingSetsParams(
     return result;
 }
 
-void InterpreterSelectQuery::executeAggregation(
-    QueryPlan & query_plan, const ActionsDAGPtr & expression, bool overflow_row, bool final, InputOrderInfoPtr group_by_info)
+void InterpreterSelectQuery::executeAggregation(QueryPlan & query_plan, const ActionsDAGPtr & expression, bool overflow_row, bool final, InputOrderInfoPtr group_by_info)
 {
     /// proton: starts
     if (isStreaming())
@@ -2566,8 +2602,8 @@ void InterpreterSelectQuery::executeMergeAggregated(QueryPlan & query_plan, bool
 
 void InterpreterSelectQuery::executeHaving(QueryPlan & query_plan, const ActionsDAGPtr & expression, bool remove_filter)
 {
-    auto having_step = std::make_unique<FilterStep>(
-        query_plan.getCurrentDataStream(), expression, getSelectQuery().having()->getColumnName(), remove_filter);
+    auto having_step
+        = std::make_unique<FilterStep>(query_plan.getCurrentDataStream(), expression, getSelectQuery().having()->getColumnName(), remove_filter);
 
     having_step->setStepDescription("HAVING");
     query_plan.addStep(std::move(having_step));
@@ -2602,8 +2638,7 @@ void InterpreterSelectQuery::executeRollupOrCube(QueryPlan & query_plan, Modific
     for (const auto & key : query_analyzer->aggregationKeys())
         keys.push_back(header_before_transform.getPositionByName(key.name));
 
-    auto params = getAggregatorParams(
-        query_ptr, *query_analyzer, *context, header_before_transform, keys, query_analyzer->aggregates(), false, settings, 0, 0);
+    auto params = getAggregatorParams(query_ptr, *query_analyzer, *context, header_before_transform, keys, query_analyzer->aggregates(), false, settings, 0, 0);
     auto transform_params = std::make_shared<AggregatingTransformParams>(std::move(params), true);
 
     QueryPlanStepPtr step;
@@ -2654,7 +2689,8 @@ static bool windowDescriptionComparator(const WindowDescription * _left, const W
     return left.size() > right.size();
 }
 
-static bool sortIsPrefix(const WindowDescription & _prefix, const WindowDescription & _full)
+static bool sortIsPrefix(const WindowDescription & _prefix,
+    const WindowDescription & _full)
 {
     const auto & prefix = _prefix.full_sort_description;
     const auto & full = _full.full_sort_description;
@@ -2743,13 +2779,16 @@ void InterpreterSelectQuery::executeWindow(QueryPlan & query_plan)
 }
 
 
-void InterpreterSelectQuery::executeOrderOptimized(
-    QueryPlan & query_plan, InputOrderInfoPtr input_sorting_info, UInt64 limit, SortDescription & output_order_descr)
+void InterpreterSelectQuery::executeOrderOptimized(QueryPlan & query_plan, InputOrderInfoPtr input_sorting_info, UInt64 limit, SortDescription & output_order_descr)
 {
     const Settings & settings = context->getSettingsRef();
 
     auto finish_sorting_step = std::make_unique<SortingStep>(
-        query_plan.getCurrentDataStream(), input_sorting_info->order_key_prefix_descr, output_order_descr, settings.max_block_size, limit);
+        query_plan.getCurrentDataStream(),
+        input_sorting_info->order_key_prefix_descr,
+        output_order_descr,
+        settings.max_block_size,
+        limit);
 
     query_plan.addStep(std::move(finish_sorting_step));
 }
@@ -2803,8 +2842,7 @@ void InterpreterSelectQuery::executeMergeSorted(QueryPlan & query_plan, const st
     const UInt64 limit = getLimitForSorting(query, context);
     const auto max_block_size = context->getSettingsRef().max_block_size;
 
-    auto merging_sorted
-        = std::make_unique<SortingStep>(query_plan.getCurrentDataStream(), std::move(sort_description), max_block_size, limit);
+    auto merging_sorted = std::make_unique<SortingStep>(query_plan.getCurrentDataStream(), std::move(sort_description), max_block_size, limit);
     merging_sorted->setStepDescription("Merge sorted streams " + description);
     query_plan.addStep(std::move(merging_sorted));
 }
@@ -2836,7 +2874,12 @@ void InterpreterSelectQuery::executeDistinct(QueryPlan & query_plan, bool before
         SizeLimits limits(settings.max_rows_in_distinct, settings.max_bytes_in_distinct, settings.distinct_overflow_mode);
 
         auto distinct_step = std::make_unique<DistinctStep>(
-            query_plan.getCurrentDataStream(), limits, limit_for_distinct, columns, pre_distinct, settings.optimize_distinct_in_order);
+            query_plan.getCurrentDataStream(),
+            limits,
+            limit_for_distinct,
+            columns,
+            pre_distinct,
+            settings.optimize_distinct_in_order);
 
         if (pre_distinct)
             distinct_step->setStepDescription("Preliminary DISTINCT");
@@ -2960,7 +3003,8 @@ void InterpreterSelectQuery::executeLimit(QueryPlan & query_plan)
         }
 
         auto limit = std::make_unique<LimitStep>(
-            query_plan.getCurrentDataStream(), limit_length, limit_offset, always_read_till_end, query.limit_with_ties, order_descr);
+                query_plan.getCurrentDataStream(),
+                limit_length, limit_offset, always_read_till_end, query.limit_with_ties, order_descr);
 
         if (query.limit_with_ties)
             limit->setStepDescription("LIMIT WITH TIES");
@@ -3091,8 +3135,7 @@ void InterpreterSelectQuery::executeStreamingAggregation(
                 ++window_keys_num;
                 continue;
             }
-            else if (
-                (key.name == ProtonConsts::STREAMING_WINDOW_START) && (isDate(key.type) || isDateTime(key.type) || isDateTime64(key.type)))
+            else if ((key.name == ProtonConsts::STREAMING_WINDOW_START) && (isDate(key.type) || isDateTime(key.type) || isDateTime64(key.type)))
             {
                 keys.insert(keys.begin(), header_before_aggregation.getPositionByName(key.name));
                 streaming_group_by = Streaming::Aggregator::Params::GroupBy::WINDOW_START;
@@ -3390,7 +3433,7 @@ void InterpreterSelectQuery::buildWatermarkQueryPlan(QueryPlan & query_plan) con
 {
     assert(isStreaming());
     auto params = std::make_shared<Streaming::WatermarkStamperParams>(
-        query_info.query, query_info.syntax_analyzer_result, query_info.streaming_window_params);
+                query_info.query, query_info.syntax_analyzer_result, query_info.streaming_window_params);
     if (query_info.hasPartitionByKeys())
         query_plan.addStep(
             std::make_unique<Streaming::WatermarkStepWithSubstream>(query_plan.getCurrentDataStream(), std::move(params), log));
@@ -3406,7 +3449,7 @@ void InterpreterSelectQuery::buildStreamingProcessingQueryPlanBeforeJoin(QueryPl
     if (query_info.hasPartitionByKeys())
     {
         /// FIXME: Refactor watermark for substream
-        /// Normally, we should execute `partition by` after join, but current implementation of watermark
+        /// Normally, we should execute `partition by` after join, but current implementation of watermark 
         /// over substream depends on shuffled data.
         /// So we allow do shuffling ahead for some special cases:
         /// 1) Non-join query
@@ -3416,8 +3459,7 @@ void InterpreterSelectQuery::buildStreamingProcessingQueryPlanBeforeJoin(QueryPl
             bool is_stream_join_table = !typeid_cast<Streaming::IHashJoin *>(analysis_result.join.get());
             /// If all `partition by` key columns are from left stream
             const auto & header = query_plan.getCurrentDataStream().header;
-            bool only_shuffling_left_stream
-                = std::ranges::all_of(query_info.partition_by_keys, [&](const auto & key) { return header.has(key); });
+            bool only_shuffling_left_stream = std::ranges::all_of(query_info.partition_by_keys, [&](const auto & key) { return header.has(key); });
             if (!(is_stream_join_table && only_shuffling_left_stream))
                 throw Exception(
                     ErrorCodes::NOT_IMPLEMENTED,
@@ -3777,7 +3819,8 @@ void InterpreterSelectQuery::executeStreamingLimit(QueryPlan & query_plan)
         }
 
         auto limit = std::make_unique<Streaming::LimitStep>(
-            query_plan.getCurrentDataStream(), limit_length, limit_offset, always_read_till_end, query.limit_with_ties, order_descr);
+                query_plan.getCurrentDataStream(),
+                limit_length, limit_offset, always_read_till_end, query.limit_with_ties, order_descr);
 
         if (query.limit_with_ties)
             limit->setStepDescription("Streaming LIMIT WITH TIES");

--- a/src/Processors/QueryPlan/Streaming/ReplayStreamStep.cpp
+++ b/src/Processors/QueryPlan/Streaming/ReplayStreamStep.cpp
@@ -30,6 +30,7 @@ ReplayStreamStep::ReplayStreamStep(const DataStream & input_stream_, Float32 rep
 
 void ReplayStreamStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
+    /// FIXME: `StorageStream::getLastSNs()` result is invalid for multiple shards in cluster
     if (unlikely(pipeline.getNumStreams() != shards_last_sns.size()))
         throw Exception("Input Stream is not equal to the shard's num", ErrorCodes::LOGICAL_ERROR);
 

--- a/src/Processors/QueryPlan/Streaming/ReplayStreamStep.cpp
+++ b/src/Processors/QueryPlan/Streaming/ReplayStreamStep.cpp
@@ -1,6 +1,7 @@
 #include <Processors/QueryPlan/Streaming/ReplayStreamStep.h>
 #include <Processors/Streaming/ReplayStreamTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/Exception.h>
 
 
 namespace DB
@@ -22,14 +23,18 @@ static ITransformingStep::Traits getTraits()
         }};
 }
 
-ReplayStreamStep::ReplayStreamStep(const DataStream & input_stream_, Float32 replay_speed_)
-    : ITransformingStep(input_stream_, input_stream_.header, getTraits()), replay_speed(replay_speed_)
+ReplayStreamStep::ReplayStreamStep(const DataStream & input_stream_, Float32 replay_speed_, std::vector<Int64> shards_last_sns_)
+    : ITransformingStep(input_stream_, input_stream_.header, getTraits()), replay_speed(replay_speed_), shards_last_sns(std::move(shards_last_sns_))
 {
 }
 
 void ReplayStreamStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
-    pipeline.addSimpleTransform([&](const Block & header) { return std::make_shared<ReplayStreamTransform>(header, replay_speed); });
+    if (unlikely(pipeline.getNumStreams() != shards_last_sns.size()))
+        throw Exception("Input Stream is not equal to the shard's num", ErrorCodes::LOGICAL_ERROR);
+
+    size_t index = 0;
+    pipeline.addSimpleTransform([&](const Block & header) { return std::make_shared<ReplayStreamTransform>(header, replay_speed, shards_last_sns[index++]); });
 }
 
 }

--- a/src/Processors/QueryPlan/Streaming/ReplayStreamStep.h
+++ b/src/Processors/QueryPlan/Streaming/ReplayStreamStep.h
@@ -10,12 +10,13 @@ namespace Streaming
 class ReplayStreamStep final : public ITransformingStep
 {
 public:
-    ReplayStreamStep(const DataStream & input_stream_, Float32 replay_speed_);
+    ReplayStreamStep(const DataStream & input_stream_, Float32 replay_speed_, std::vector<Int64> shards_last_sns_);
     String getName() const override { return "ReplayStep"; }
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 
 private:
     Float32 replay_speed = 0;
+    std::vector<Int64> shards_last_sns;
 };
 }
 }

--- a/src/Processors/Streaming/ReplayStreamTransform.cpp
+++ b/src/Processors/Streaming/ReplayStreamTransform.cpp
@@ -16,19 +16,32 @@ namespace Streaming
 
 constexpr Int64 MAX_WAIT_INTERVAL_MS = 500;
 
-ReplayStreamTransform::ReplayStreamTransform(const Block & header, Float32 replay_speed_)
-    : ISimpleTransform(header, header, true, ProcessorID::ReplayStreamTransformID), replay_speed(replay_speed_)
+ReplayStreamTransform::ReplayStreamTransform(const Block & header, Float32 replay_speed_, const Int64 & shard_last_sn_)
+    : ISimpleTransform(header, header, true, ProcessorID::ReplayStreamTransformID)
+    , replay_speed(replay_speed_)
+    , shard_last_sn(shard_last_sn_)
 {
     append_time_index = header.getPositionByName(ProtonConsts::RESERVED_APPEND_TIME);
+    sn_index = header.getPositionByName(ProtonConsts::RESERVED_EVENT_SEQUENCE_ID);
+    if (shard_last_sn < 0)
+        enable_replay = false;
 }
 
 void ReplayStreamTransform::transform(Chunk & chunk)
 {
-    if (!chunk.rows())
+    if (!chunk.rows() || !enable_replay)
         return;
 
     /// get the time of this chunk.
     const auto & this_batch_time = chunk.getColumns()[append_time_index]->get64(0);
+    size_t size = chunk.getColumns()[sn_index]->size();
+    Int64 this_batch_last_sn = chunk.getColumns()[sn_index]->getInt(size - 1);
+
+    /// mark the historical data replay end and begin stream query.
+    if (this_batch_last_sn >= shard_last_sn)
+        enable_replay = false;
+
+
     wait_interval_ms
         = static_cast<Int64>(std::lround((last_batch_time.has_value() ? this_batch_time - last_batch_time.value() : 0) / replay_speed));
     last_batch_time = this_batch_time;

--- a/src/Processors/Streaming/ReplayStreamTransform.cpp
+++ b/src/Processors/Streaming/ReplayStreamTransform.cpp
@@ -16,31 +16,29 @@ namespace Streaming
 
 constexpr Int64 MAX_WAIT_INTERVAL_MS = 500;
 
-ReplayStreamTransform::ReplayStreamTransform(const Block & header, Float32 replay_speed_, const Int64 & shard_last_sn_)
+ReplayStreamTransform::ReplayStreamTransform(const Block & header, Float32 replay_speed_, Int64 last_sn_)
     : ISimpleTransform(header, header, true, ProcessorID::ReplayStreamTransformID)
     , replay_speed(replay_speed_)
-    , shard_last_sn(shard_last_sn_)
+    , last_sn(last_sn_)
+    , enable_replay(last_sn >= 0)
 {
     append_time_index = header.getPositionByName(ProtonConsts::RESERVED_APPEND_TIME);
     sn_index = header.getPositionByName(ProtonConsts::RESERVED_EVENT_SEQUENCE_ID);
-    if (shard_last_sn < 0)
-        enable_replay = false;
 }
 
 void ReplayStreamTransform::transform(Chunk & chunk)
 {
-    if (!chunk.rows() || !enable_replay)
+    if (!enable_replay || !chunk.rows())
         return;
 
     /// get the time of this chunk.
-    const auto & this_batch_time = chunk.getColumns()[append_time_index]->get64(0);
-    size_t size = chunk.getColumns()[sn_index]->size();
-    Int64 this_batch_last_sn = chunk.getColumns()[sn_index]->getInt(size - 1);
+    const auto & columns = chunk.getColumns();
+    auto this_batch_time = columns[append_time_index]->getInt(0);
+    auto this_batch_last_sn = columns[sn_index]->getInt(chunk.rows() - 1);
 
     /// mark the historical data replay end and begin stream query.
-    if (this_batch_last_sn >= shard_last_sn)
+    if (this_batch_last_sn >= last_sn)
         enable_replay = false;
-
 
     wait_interval_ms
         = static_cast<Int64>(std::lround((last_batch_time.has_value() ? this_batch_time - last_batch_time.value() : 0) / replay_speed));

--- a/src/Processors/Streaming/ReplayStreamTransform.h
+++ b/src/Processors/Streaming/ReplayStreamTransform.h
@@ -12,18 +12,19 @@ namespace Streaming
 class ReplayStreamTransform final : public ISimpleTransform
 {
 public:
-    ReplayStreamTransform(const Block & header, Float32 replay_speed_);
+    ReplayStreamTransform(const Block & header, Float32 replay_speed_, const Int64 & shard_last_sn_);
     String getName() const override { return "ReplayStreamTransform"; }
     void transform(Chunk & chunk) override;
 
 private:
     Float32 replay_speed = 0;
     size_t append_time_index = 0;
-
+    size_t sn_index = 0;
+    /// this shard's last sequence number;
+    Int64 shard_last_sn = 0;
     std::optional<Int64> last_batch_time;
     Int64 wait_interval_ms = 0;
-    /// TODO：mark the historical end
-    /// bool begin_stream = false;
+    bool enable_replay = true;
 };
 }
 }

--- a/src/Processors/Streaming/ReplayStreamTransform.h
+++ b/src/Processors/Streaming/ReplayStreamTransform.h
@@ -12,7 +12,7 @@ namespace Streaming
 class ReplayStreamTransform final : public ISimpleTransform
 {
 public:
-    ReplayStreamTransform(const Block & header, Float32 replay_speed_, const Int64 & shard_last_sn_);
+    ReplayStreamTransform(const Block & header, Float32 replay_speed_, Int64 last_sn_);
     String getName() const override { return "ReplayStreamTransform"; }
     void transform(Chunk & chunk) override;
 
@@ -21,7 +21,7 @@ private:
     size_t append_time_index = 0;
     size_t sn_index = 0;
     /// this shard's last sequence number;
-    Int64 shard_last_sn = 0;
+    Int64 last_sn = 0;
     std::optional<Int64> last_batch_time;
     Int64 wait_interval_ms = 0;
     bool enable_replay = true;

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -1937,4 +1937,13 @@ void StorageStream::checkReady() const
         throw Exception(
             ErrorCodes::RESOURCE_NOT_INITED, "Background resources of '{}' are initializing", getStorageID().getFullTableName());
 }
+std::vector<nlog::RecordSN> StorageStream::getLastSNs() const
+{
+    std::vector<nlog::RecordSN> lastsn;
+    for (const auto & stream_shard : stream_shards)
+        if (stream_shard->storage)
+            lastsn.emplace_back(stream_shard->lastSN());
+
+    return lastsn;
+}
 }

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -1939,11 +1939,10 @@ void StorageStream::checkReady() const
 }
 std::vector<nlog::RecordSN> StorageStream::getLastSNs() const
 {
-    std::vector<nlog::RecordSN> lastsn;
+    std::vector<nlog::RecordSN> lastsns;
     for (const auto & stream_shard : stream_shards)
-        if (stream_shard->storage)
-            lastsn.emplace_back(stream_shard->lastSN());
+        lastsns.emplace_back(stream_shard->lastSN());
 
-    return lastsn;
+    return lastsns;
 }
 }

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -1939,10 +1939,10 @@ void StorageStream::checkReady() const
 }
 std::vector<nlog::RecordSN> StorageStream::getLastSNs() const
 {
-    std::vector<nlog::RecordSN> lastsns;
+    std::vector<nlog::RecordSN> last_sns;
     for (const auto & stream_shard : stream_shards)
-        lastsns.emplace_back(stream_shard->lastSN());
+        last_sns.emplace_back(stream_shard->lastSN());
 
-    return lastsns;
+    return last_sns;
 }
 }

--- a/src/Storages/Streaming/StorageStream.h
+++ b/src/Storages/Streaming/StorageStream.h
@@ -262,6 +262,8 @@ public:
 
     bool isInmemory() const { return getSettings()->storage_type.value == "memory"; }
 
+    std::vector<nlog::RecordSN> getLastSNs() const;
+
     friend class StreamSink;
     friend class MergeTreeData;
 

--- a/tests/stream/test_stream_smoke/0028_replay_stream.yaml
+++ b/tests/stream/test_stream_smoke/0028_replay_stream.yaml
@@ -269,3 +269,66 @@ tests:
           - [2,1,2,5]
           - [2,2,2,3]
           - [2,2,2,5]
+
+  - id: 5
+    tags:
+      - replay_stream
+      - stream query
+    name: begin stream query after the replaying. 
+    description: begin stream query after the replaying.
+    steps:
+      - statements:
+          - client: python
+            query_type: table
+            query: drop stream if exists test29_stream
+
+          - client: python
+            query_type: table
+            exist: test29_stream
+            exist_wait: 2
+            wait: 1
+            query: create stream if not exists test29_stream (id int, value int);
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: insert into test29_stream(id, value) values (1, 2);
+
+          - client: python
+            query_type: table
+            wait: 2
+            query: insert into test29_stream(id, value) values (2, 2);
+
+          - client: python
+            query_type: table
+            wait: 1
+            query: insert into test29_stream(id, value) values (3, 1);
+
+          - client: python
+            query_type: stream
+            terminate: munual
+            query_id: '2905'
+            wait: 1
+            query: select id, value from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1;
+
+          - client: python
+            query_type: table
+            depends_on: '2905'
+            wait: 15
+            query: insert into test29_stream(id, value) values (4, 1);
+
+          - client: python
+            query_type: table
+            kill: '2905'
+            kill_wait: 1
+            wait: 1
+            query: insert into test29_stream(id, value) values (5, 1);
+
+    expected_results:
+      - query_id: '2905'
+        expected_results:
+          - [1, 2]
+          - [2, 2]
+          - [3, 1]
+          - [4, 1]
+          - [5, 1]


### PR DESCRIPTION
this close #241 
Enhancement about replay a stream. When all historical data has been output, end the replay and begin stream query.For example:
```sql
drop stream if exists test1;
create stream if not exists test1(id int, value int);
insert into test1(id, value) values(1, 2);
insert into test1(id, value) values(3, 2);
insert into test1(id, value) values(4, 2);
select  id, value, from  test1 where _tp_time > earliest_timestamp() settings replay_speed=1;
```
when the output the last historical data `(4, 2)`, it will end the replay and start stream query.At this time, the data you insert will be output immediately。
```sql
insert into test1(id, value) values(5, 2);
insert into test1(id, value) values(6, 2);
```
It will output `(5, 2)` and `(6, 2)`
