### PR TITLE
enable backfill from historical store

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -800,6 +800,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, keep_windows, 0, "How many streaming windows to keep from recycling", 0) \
     M(String, seek_to, "", "Seeking to an offset of the streaming/historical store to seek", 0) \
     M(Bool, enable_backfill_from_historical_store, true, "Enable backfill data from historical data store", 0) \
+    M(Bool, emit_aggregated_during_backfill, true, "Enable emit intermediate aggr result during backfill historical data", 0) \
     M(Bool, include_internal_streams, false, "Show internal streams on SHOW streams query.", 0) \
 // End of GLOBAL_SETTINGS
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -799,7 +799,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_streaming_view_cached_block_bytes, 100 * 1024 * 1024, "Maximum bytes of block cached in streaming view", 0) \
     M(UInt64, keep_windows, 0, "How many streaming windows to keep from recycling", 0) \
     M(String, seek_to, "", "Seeking to an offset of the streaming/historical store to seek", 0) \
-    M(Bool, enable_backfill_from_historical_store, false, "Enable backfill data from historical data store", 0) \
+    M(Bool, enable_backfill_from_historical_store, true, "Enable backfill data from historical data store", 0) \
     M(Bool, include_internal_streams, false, "Show internal streams on SHOW streams query.", 0) \
 // End of GLOBAL_SETTINGS
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2343,6 +2343,11 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
         /// need replay operation
         if (settings.replay_speed > 0)
         {
+            if (settings.enable_backfill_from_historical_store.value)
+                throw Exception(
+                    ErrorCodes::NOT_IMPLEMENTED,
+                    "Only support replay from streaming store, but setting 'enable_backfill_from_historical_store=true'");
+
             /// So far, only support append-only stream (or proxyed)
             StorageStream * storagestream = nullptr;
             if (Streaming::isAppendStorage(storage->dataStreamSemantic()))

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -194,7 +194,7 @@ private:
     void executeStreamingPreLimit(QueryPlan & query_plan, bool do_not_skip_offset);
     void executeStreamingLimit(QueryPlan & query_plan);
     void executeStreamingOffset(QueryPlan & query_plan);
-    void checkForStreamingQuery() const;
+    void finalCheckAndOptimizeForStreamingQuery();
     bool shouldKeepState() const;
     void buildShufflingQueryPlan(QueryPlan & query_plan);
     void buildWatermarkQueryPlan(QueryPlan & query_plan) const;

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -278,6 +278,9 @@ public:
             chunk_ctx->setCheckpointContext(nullptr);
     }
 
+    bool isHistoricalDataStart() const { return chunk_ctx && chunk_ctx->isHistoricalDataStart(); }
+    bool isHistoricalDataEnd() const { return chunk_ctx && chunk_ctx->isHistoricalDataEnd(); }
+
     /// Dummy interface to make RefCountBlockList happy
     Int64 minTimestamp() const { return 0; }
     Int64 maxTimestamp() const { return 0;}

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -38,6 +38,9 @@
 
 /// proton : start
 #include <Processors/Sources/MarkSource.h>
+#include <Processors/Transforms/MergeSortingTransform.h>
+#include <Processors/Transforms/PartialSortingTransform.h>
+#include <Common/ProtonCommon.h>
 /// proton : ends
 
 namespace ProfileEvents
@@ -1181,6 +1184,40 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
 
         cur_header = pipe.getHeader();
         pipes.emplace_back(Pipe(std::make_shared<MarkSource>(cur_header, ChunkContext::HISTORICAL_DATA_START_FLAG)));
+
+        /// TODO: support optimized order for the stream with ordered by `_tp_time`
+        {
+            /// Copy basic code from `SortingStep::fullSort`
+            /// Sorting backfilled historical data by ascending event time
+            SortDescription sort_desc;
+            sort_desc.emplace_back(ProtonConsts::RESERVED_EVENT_TIME, /*ascending*/ 1);
+
+            pipe.addSimpleTransform(
+                [&](const Block & header) -> ProcessorPtr { return std::make_shared<PartialSortingTransform>(header, sort_desc); });
+
+            pipe.addSimpleTransform([&](const Block & header) -> ProcessorPtr {
+                return std::make_shared<MergeSortingTransform>(
+                    header,
+                    sort_desc,
+                    max_block_size,
+                    /*limits*/ 0,
+                    /// increase_sort_description_compile_attempts_current,
+                    settings.max_bytes_before_remerge_sort / pipe.numOutputPorts(),
+                    settings.remerge_sort_lowered_memory_bytes_ratio,
+                    settings.max_bytes_before_external_sort,
+                    context->getTemporaryVolume(),
+                    settings.min_free_disk_space_for_temporary_data);
+            });
+
+            /// If there are several streams, then we merge them into one
+            if (pipe.numOutputPorts() > 1)
+            {
+                auto transform = std::make_shared<MergingSortedTransform>(
+                    pipe.getHeader(), pipe.numOutputPorts(), sort_desc, max_block_size, SortingQueueStrategy::Batch, /*limits*/ 0);
+
+                pipe.addTransform(std::move(transform));
+            }
+        }
 
         pipes.emplace_back(std::move(pipe));
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1180,7 +1180,7 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
     /// proton : starts. Add streaming source after historical source
     if (create_streaming_source)
     {
-        if (query_info.requires_backfill_input_in_order)
+        if (query_info.require_in_order_backfill)
         {
             /// TODO: support optimized order for the stream with ordered by `_tp_time`
             /// Copy basic code from `SortingStep::fullSort`

--- a/src/Processors/QueryPlan/Streaming/WatermarkStep.cpp
+++ b/src/Processors/QueryPlan/Streaming/WatermarkStep.cpp
@@ -23,15 +23,19 @@ DB::ITransformingStep::Traits getTraits()
         }};
 }
 }
-WatermarkStep::WatermarkStep(const DataStream & input_stream_, WatermarkStamperParamsPtr params_, Poco::Logger * log_)
-    : ITransformingStep(input_stream_, input_stream_.header, getTraits()), params(std::move(params_)), log(log_)
+WatermarkStep::WatermarkStep(
+    const DataStream & input_stream_, WatermarkStamperParamsPtr params_, bool skip_stamping_for_backfill_data_, Poco::Logger * log_)
+    : ITransformingStep(input_stream_, input_stream_.header, getTraits())
+    , params(std::move(params_))
+    , skip_stamping_for_backfill_data(skip_stamping_for_backfill_data_)
+    , log(log_)
 {
 }
 
 void WatermarkStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & /* settings */)
 {
     pipeline.addSimpleTransform([&](const Block & header) { /// STYLE_CHECK_ALLOW_BRACE_SAME_LINE_LAMBDA
-        return std::make_shared<WatermarkTransform>(header, params, log);
+        return std::make_shared<WatermarkTransform>(header, params, skip_stamping_for_backfill_data, log);
     });
 }
 }

--- a/src/Processors/QueryPlan/Streaming/WatermarkStep.h
+++ b/src/Processors/QueryPlan/Streaming/WatermarkStep.h
@@ -11,7 +11,8 @@ namespace Streaming
 class WatermarkStep final : public ITransformingStep
 {
 public:
-    WatermarkStep(const DataStream & input_stream_, WatermarkStamperParamsPtr params_, Poco::Logger * log);
+    WatermarkStep(
+        const DataStream & input_stream_, WatermarkStamperParamsPtr params_, bool skip_stamping_for_backfill_data_, Poco::Logger * log);
 
     ~WatermarkStep() override = default;
 
@@ -20,6 +21,7 @@ public:
 
 private:
     WatermarkStamperParamsPtr params;
+    bool skip_stamping_for_backfill_data;
     Poco::Logger * log;
 };
 }

--- a/src/Processors/QueryPlan/Streaming/WatermarkStepWithSubstream.cpp
+++ b/src/Processors/QueryPlan/Streaming/WatermarkStepWithSubstream.cpp
@@ -25,15 +25,18 @@ DB::ITransformingStep::Traits getTraits()
 }
 
 WatermarkStepWithSubstream::WatermarkStepWithSubstream(
-    const DataStream & input_stream_, WatermarkStamperParamsPtr params_, Poco::Logger * log_)
-    : ITransformingStep(input_stream_, input_stream_.header, getTraits()), params(std::move(params_)), log(log_)
+    const DataStream & input_stream_, WatermarkStamperParamsPtr params_, bool skip_stamping_for_backfill_data_, Poco::Logger * log_)
+    : ITransformingStep(input_stream_, input_stream_.header, getTraits())
+    , params(std::move(params_))
+    , skip_stamping_for_backfill_data(skip_stamping_for_backfill_data_)
+    , log(log_)
 {
 }
 
 void WatermarkStepWithSubstream::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & /* settings */)
 {
     pipeline.addSimpleTransform([&](const Block & header) { /// STYLE_CHECK_ALLOW_BRACE_SAME_LINE_LAMBDA
-        return std::make_shared<WatermarkTransformWithSubstream>(header, params, log);
+        return std::make_shared<WatermarkTransformWithSubstream>(header, params, skip_stamping_for_backfill_data, log);
     });
 }
 }

--- a/src/Processors/QueryPlan/Streaming/WatermarkStepWithSubstream.h
+++ b/src/Processors/QueryPlan/Streaming/WatermarkStepWithSubstream.h
@@ -11,7 +11,8 @@ namespace Streaming
 class WatermarkStepWithSubstream final : public ITransformingStep
 {
 public:
-    WatermarkStepWithSubstream(const DataStream & input_stream_, WatermarkStamperParamsPtr params_, Poco::Logger * log);
+    WatermarkStepWithSubstream(
+        const DataStream & input_stream_, WatermarkStamperParamsPtr params_, bool skip_stamping_for_backfill_data_, Poco::Logger * log);
 
     ~WatermarkStepWithSubstream() override = default;
 
@@ -20,6 +21,7 @@ public:
 
 private:
     WatermarkStamperParamsPtr params;
+    bool skip_stamping_for_backfill_data;
     Poco::Logger * log;
 };
 }

--- a/src/Processors/Transforms/Streaming/AggregatingHelper.cpp
+++ b/src/Processors/Transforms/Streaming/AggregatingHelper.cpp
@@ -83,15 +83,15 @@ ChunkPair AggregatingHelper::convertWithoutKeyToChangelog(
 ChunkPair AggregatingHelper::mergeAndConvertWithoutKeyToChangelog(
     ManyAggregatedDataVariants & data, ManyRetractedDataVariants & retracted_data, const AggregatingTransformParams & params)
 {
-    assert(data.at(0)->type == AggregatedDataVariants::Type::without_key);
-    assert(retracted_data.at(0)->type == AggregatedDataVariants::Type::without_key);
-
     auto prepared_data = params.aggregator.prepareVariantsToMerge(data);
     if (prepared_data->empty())
         return {};
 
     auto prepared_retracted_data = params.aggregator.prepareVariantsToMerge(retracted_data);
     assert(!prepared_retracted_data->empty());
+
+    assert(prepared_data->at(0)->type == AggregatedDataVariants::Type::without_key);
+    assert(prepared_retracted_data->at(0)->type == AggregatedDataVariants::Type::without_key);
 
     params.aggregator.mergeWithoutKeyDataImpl(*prepared_retracted_data, ConvertAction::RETRACTED_EMIT);
     params.aggregator.mergeWithoutKeyDataImpl(*prepared_data, ConvertAction::STREAMING_EMIT);
@@ -126,15 +126,15 @@ ChunkPair AggregatingHelper::convertSingleLevelToChangelog(
 ChunkPair AggregatingHelper::mergeAndConvertSingleLevelToChangelog(
     ManyAggregatedDataVariants & data, ManyRetractedDataVariants & retracted_data, const AggregatingTransformParams & params)
 {
-    assert(data.at(0)->type != AggregatedDataVariants::Type::without_key && !data.at(0)->isTwoLevel());
-    assert(retracted_data.at(0)->type != AggregatedDataVariants::Type::without_key && !retracted_data.at(0)->isTwoLevel());
-
     auto prepared_data = params.aggregator.prepareVariantsToMerge(data, /*always_merge_into_empty*/ true);
     if (prepared_data->empty())
         return {};
 
     auto prepared_retracted_data = params.aggregator.prepareVariantsToMerge(retracted_data, /*always_merge_into_empty*/ true);
     assert(!prepared_retracted_data->empty());
+
+    assert(prepared_data->at(0)->type != AggregatedDataVariants::Type::without_key && !prepared_data->at(0)->isTwoLevel());
+    assert(prepared_retracted_data->at(0)->type != AggregatedDataVariants::Type::without_key && !prepared_retracted_data->at(0)->isTwoLevel());
 
     /// To only emit changelog:
     /// 1) Merge retracted groups data into first one

--- a/src/Processors/Transforms/Streaming/WatermarkTransform.cpp
+++ b/src/Processors/Transforms/Streaming/WatermarkTransform.cpp
@@ -55,12 +55,12 @@ void WatermarkTransform::transform(Chunk & chunk)
     chunk.clearWatermark();
 
     if (chunk.isHistoricalDataStart())
-        is_backfill_data = true;
+        is_backfilling_data = true;
     else if (chunk.isHistoricalDataEnd())
-        is_backfill_data = false;
+        is_backfilling_data = false;
 
     bool avoid_watermark = chunk.avoidWatermark();
-    avoid_watermark |= is_backfill_data && skip_stamping_for_backfill_data;
+    avoid_watermark |= is_backfilling_data && skip_stamping_for_backfill_data;
     if (!avoid_watermark)
         watermark->process(chunk);
 }

--- a/src/Processors/Transforms/Streaming/WatermarkTransform.h
+++ b/src/Processors/Transforms/Streaming/WatermarkTransform.h
@@ -16,7 +16,7 @@ namespace Streaming
 class WatermarkTransform final : public ISimpleTransform
 {
 public:
-    WatermarkTransform(const Block & header, WatermarkStamperParamsPtr params_, Poco::Logger * log);
+    WatermarkTransform(const Block & header, WatermarkStamperParamsPtr params_, bool skip_stamping_for_backfill_data_, Poco::Logger * log);
 
     ~WatermarkTransform() override = default;
 
@@ -31,6 +31,9 @@ private:
 private:
     WatermarkStamperParamsPtr params;
     SERDE WatermarkStamperPtr watermark;
+
+    const bool skip_stamping_for_backfill_data;
+    bool is_backfill_data = false;
 };
 }
 }

--- a/src/Processors/Transforms/Streaming/WatermarkTransform.h
+++ b/src/Processors/Transforms/Streaming/WatermarkTransform.h
@@ -32,8 +32,8 @@ private:
     WatermarkStamperParamsPtr params;
     SERDE WatermarkStamperPtr watermark;
 
-    const bool skip_stamping_for_backfill_data;
-    bool is_backfill_data = false;
+    bool skip_stamping_for_backfill_data;
+    bool is_backfilling_data = false;
 };
 }
 }

--- a/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.cpp
@@ -115,12 +115,12 @@ void WatermarkTransformWithSubstream::work()
     process_chunk.clearWatermark();
 
     if (process_chunk.isHistoricalDataStart())
-        is_backfill_data = true;
+        is_backfilling_data = true;
     else if (process_chunk.isHistoricalDataEnd())
-        is_backfill_data = false;
+        is_backfilling_data = false;
 
     bool avoid_watermark = process_chunk.avoidWatermark();
-    avoid_watermark |= is_backfill_data && skip_stamping_for_backfill_data;
+    avoid_watermark |= is_backfilling_data && skip_stamping_for_backfill_data;
 
     if (unlikely(process_chunk.requestCheckpoint()))
     {

--- a/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.h
+++ b/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.h
@@ -16,7 +16,8 @@ namespace Streaming
 class WatermarkTransformWithSubstream final : public IProcessor
 {
 public:
-    WatermarkTransformWithSubstream(const Block & header, WatermarkStamperParamsPtr params_, Poco::Logger * log);
+    WatermarkTransformWithSubstream(
+        const Block & header, WatermarkStamperParamsPtr params_, bool skip_stamping_for_backfill_data_, Poco::Logger * log);
 
     ~WatermarkTransformWithSubstream() override = default;
 
@@ -38,6 +39,9 @@ private:
     WatermarkStamperParamsPtr params;
     WatermarkStamperPtr watermark_template;
     SERDE SubstreamHashMap<WatermarkStamperPtr> substream_watermarks;
+
+    const bool skip_stamping_for_backfill_data;
+    bool is_backfill_data = false;
 
     Poco::Logger * log;
 };

--- a/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.h
+++ b/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.h
@@ -40,8 +40,8 @@ private:
     WatermarkStamperPtr watermark_template;
     SERDE SubstreamHashMap<WatermarkStamperPtr> substream_watermarks;
 
-    const bool skip_stamping_for_backfill_data;
-    bool is_backfill_data = false;
+    bool skip_stamping_for_backfill_data;
+    bool is_backfilling_data = false;
 
     Poco::Logger * log;
 };

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1917,6 +1917,7 @@ QueryPlanPtr MergeTreeDataSelectExecutor::readConcat(
     const SelectQueryInfo & query_info,
     ContextPtr context,
     UInt64 max_block_size,
+    size_t num_streams,
     QueryProcessingStage::Enum processed_stage,
     std::shared_ptr<PartitionIdToMaxBlock> max_block_numbers_to_read,
     bool enable_parallel_reading,
@@ -1924,7 +1925,7 @@ QueryPlanPtr MergeTreeDataSelectExecutor::readConcat(
 {
     /// For concat read, we don't want more than 1 thread concurrency for historical data read and we want read the data in order
     return doRead(column_names, storage_snapshot, query_info, std::move(context), max_block_size,
-                  1, processed_stage, max_block_numbers_to_read, enable_parallel_reading, std::move(create_streaming_source));
+                  num_streams, processed_stage, max_block_numbers_to_read, enable_parallel_reading, std::move(create_streaming_source));
 }
 /// proton: ends
 }

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -84,6 +84,7 @@ public:
         const SelectQueryInfo & query_info,
         ContextPtr context,
         UInt64 max_block_size,
+        size_t num_streams,
         QueryProcessingStage::Enum processed_stage,
         std::shared_ptr<PartitionIdToMaxBlock> max_block_numbers_to_read = nullptr,
         bool enable_parallel_reading = false,

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -183,6 +183,9 @@ struct SelectQueryInfo
     SeekToInfoPtr seek_to_info; /// Rewind info for left streaming store in streaming query
     SeekToInfoPtr seek_to_info_of_right_stream; /// Rewind info for right streaming store in streaming query
 
+    /// if is true, means need sort backfill input by event time (ascending)
+    bool requires_backfill_input_in_order = true;
+
     Streaming::WindowParamsPtr streaming_window_params;
 
     bool left_input_tracking_changes = false;

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -184,7 +184,7 @@ struct SelectQueryInfo
     SeekToInfoPtr seek_to_info_of_right_stream; /// Rewind info for right streaming store in streaming query
 
     /// if is true, means need sort backfill input by event time (ascending)
-    bool requires_backfill_input_in_order = true;
+    bool require_in_order_backfill = true;
 
     Streaming::WindowParamsPtr streaming_window_params;
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -271,6 +271,7 @@ void StorageMergeTree::readConcat(
     ContextPtr local_context,
     QueryProcessingStage::Enum processed_stage,
     size_t max_block_size,
+    size_t num_streams,
     std::function<std::shared_ptr<ISource>(Int64 &)> create_streaming_source)
 {
     /// If true, then we will ask initiator if we can read chosen ranges
@@ -280,7 +281,7 @@ void StorageMergeTree::readConcat(
         LOG_TRACE(log, "Parallel reading from replicas enabled {}", enable_parallel_reading);
 
     if (auto plan = reader.readConcat(
-            column_names, storage_snapshot, query_info, std::move(local_context), max_block_size,
+            column_names, storage_snapshot, query_info, std::move(local_context), max_block_size, num_streams,
             processed_stage, nullptr, enable_parallel_reading, std::move(create_streaming_source)))
     {
         query_plan = std::move(*plan);

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -62,6 +62,7 @@ public:
         ContextPtr context,
         QueryProcessingStage::Enum processed_stage,
         size_t max_block_size,
+        size_t num_streams,
         std::function<std::shared_ptr<ISource>(Int64&)> create_streaming_source);
     /// proton: ends
 

--- a/src/Storages/Streaming/SeekToInfo.cpp
+++ b/src/Storages/Streaming/SeekToInfo.cpp
@@ -174,6 +174,9 @@ std::pair<int64_t, bool> tryParseAbsoluteTimeSeek(const String & seek_to)
 
 SeekToInfo::SeekToInfo(String seek_to_) : seek_to(std::move(seek_to_))
 {
+    if (seek_to == "latest")
+        seek_to = ""; /// latest, means don't need seek to
+
     std::tie(type, seek_points) = parse(seek_to, /*default utc*/ true);
     assert(!seek_points.empty());
 }

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -992,8 +992,8 @@ StorageStream::ShardsToRead StorageStream::getRequiredShardsToRead(ContextPtr co
         assert(query_info.seek_to_info);
         const auto & settings_ref = context_->getSettingsRef();
         bool require_back_fill_from_historical = !isInmemory()
-            && (Streaming::isChangelogKeyedStorage(dataStreamSemantic()) || Streaming::isVersionedKeyedStorage(dataStreamSemantic())
-                || (query_info.seek_to_info->getSeekTo() == "earliest" && settings_ref.enable_backfill_from_historical_store.value));
+            && (Streaming::isKeyedStorage(dataStreamSemantic())
+                || (!query_info.seek_to_info->getSeekTo().empty() && settings_ref.enable_backfill_from_historical_store.value));
         result.mode = require_back_fill_from_historical ? QueryMode::STREAMING_CONCAT : QueryMode::STREAMING;
     }
     else

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -477,8 +477,9 @@ void StorageStream::readConcat(
     else
         header = storage_snapshot->getSampleBlockForColumns({ProtonConsts::RESERVED_EVENT_TIME});
 
+    /// Specially, we always read by single thread for keyed storage
     auto shard_num_streams = num_streams / shards_to_read.size();
-    if (shard_num_streams == 0)
+    if (shard_num_streams == 0 || Streaming::isKeyedStorage(dataStreamSemantic()))
         shard_num_streams = 1;
 
     std::vector<QueryPlanPtr> plans;

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -462,6 +462,11 @@ void StorageStream::readConcat(
     auto description = makeFormattedNameOfConcatShards(shards_to_read);
     LOG_INFO(log, "Read local streaming concat {}", description);
 
+    /// If required backfill input in order, we will need read `_tp_time`.
+    if (query_info.requires_backfill_input_in_order
+        && std::ranges::none_of(column_names, [](const auto & name) { return name == ProtonConsts::RESERVED_EVENT_TIME; }))
+        column_names.emplace_back(ProtonConsts::RESERVED_EVENT_TIME);
+
     /// For queries like `SELECT count(*) FROM tumble(table, now(), 5s) GROUP BY window_end` don't have required column from table.
     /// We will need add one
     Block header;

--- a/src/Storages/Streaming/StorageStream.h
+++ b/src/Storages/Streaming/StorageStream.h
@@ -212,7 +212,8 @@ private:
         const StorageSnapshotPtr & storage_snapshot,
         ContextPtr context,
         QueryProcessingStage::Enum processed_stage,
-        size_t max_block_size);
+        size_t max_block_size,
+        size_t num_streams);
 
     void readHistory(
         const StreamShardPtrs & shards_to_read,

--- a/tests/stream/test_stream_smoke/0011_json_case.json
+++ b/tests/stream/test_stream_smoke/0011_json_case.json
@@ -31,8 +31,8 @@
             "description": "create a table test_topmax, 1 column for 1 type and ingest data top_k on int",
             "steps":[
                 {"statements": [
-                    {"client":"python", "query_type": "table","wait":1, "query":"drop view if exists json_hop_mv"},
-                    {"client":"python", "query_type": "table","wait":5, "query":"drop view if exists json_tumble_hop_mv"},
+                    {"client":"python", "query_type": "table","wait":1, "query":"drop view if exists json_tumble_hop_mv"},
+                    {"client":"python", "query_type": "table","wait":2, "query":"drop view if exists json_hop_mv"},
                     {"client":"python", "query_type": "table", "wait":1,"exist":"json_hop_mv", "exit_wait":2, "query":"create materialized view if not exists json_hop_mv as with transformed as (select a.json:data.id as id, to_int64(a.json:data.value) as value, to_datetime(a.json:data.create_time) as created_at, b.location:location from test_json_str as a join table(test_json_d) as b on a.json:data.id = b.location:id) select window_start as ws, window_end as we, count() from hop(transformed, created_at, 3s, 5s) group by window_start, window_end"},
                     {"client":"python","query_id":"1201", "wait":2,"exist":"json_tumble_hop_mv", "exit_wait":2, "query_type": "table", "query":"create materialized view if not exists json_tumble_hop_mv as select window_start as w_s, window_end as w_e, count() as cnt from tumble(json_hop_mv, we, 5s) group by window_start, window_end"},
                     {"client":"python","query_id":"1202","wait":2, "terinate":"manual", "query_type": "stream","drop_view":"json_tumble_hop_mv,json_hop_mv", "drop_view_wait":2, "query":"select cnt from json_tumble_hop_mv"},
@@ -55,8 +55,8 @@
             "description": "create a table test_topmax, 1 column for 1 type and ingest data top_k on int",
             "steps":[
                 {"statements": [
-                    {"client":"python", "query_type": "table","wait":1, "query":"drop view if exists json_hop_v"},
-                    {"client":"python", "query_type": "table","wait":5, "query":"drop view if exists json_tumble_hop_v"},
+                    {"client":"python", "query_type": "table","wait":1, "query":"drop view if exists json_tumble_hop_v"},
+                    {"client":"python", "query_type": "table","wait":2, "query":"drop view if exists json_hop_v"},
                     {"client":"python", "query_type": "table","wait":2,"exist":"json_hop_v", "exit_wait":2, "query":"create view if not exists json_hop_v as with transformed as (select a.json:data.id as id, to_int64(a.json:data.value) as value, a.json:data.create_time::datetime as created_at, b.location:location from test_json_str as a join table(test_json_d) as b on a.json:data.id = b.location:id where value >0) select window_start as ws, window_end as we, count() from hop(transformed, created_at, 3s, 5s) group by window_start, window_end"},
                     {"client":"python","query_id":"1201", "wait":2,"exist":"json_tumble_hop_v", "exit_wait":2, "query_type": "table", "query":"create view if not exists json_tumble_hop_v as select window_start as w_s, window_end as w_e, count() as cnt from tumble(json_hop_v, we, 5s) group by window_start, window_end"},
                     {"client":"python","query_id":"1202", "wait":2, "terinate":"manual", "query_type": "stream","drop_view":"json_tumble_hop_v,json_hop_v", "drop_view_wait":2, "query":"select cnt from json_tumble_hop_v"},

--- a/tests/stream/test_stream_smoke/0013_changelog_stream3.json
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream3.json
@@ -144,15 +144,11 @@
                     "statements": [
                         {"client":"python", "query_type":"table", "query":"drop stream if exists test14_append_stream_3"},
                         {"client":"python", "query_type": "table", "exist":"test14_append_stream_3", "exist_wait":2, "wait":1, "query":"create stream if not exists test14_append_stream_3 (id int, name string, val float)"},
-                        {"client":"python", "query_type": "stream", "query_id":"1455", "wait":1, "terminate":"manual", "query":"with subquery as (select id, count() as cnt, min(val) as min_val, max(val) as max_val from changelog(test14_append_stream_3, name) group by id) select count(*), sum(cnt), min(min_val), max(max_val) from subquery"},
-                        {"client":"python", "query_type": "table", "depends_on":"1455", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'a', 11.1)"},
-                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (2, 'a', 33.3)"},
-                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'b', 22.2)"},
-                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (2, 'b', 22.2)"},
-                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'c', 33.3)"},
-                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (2, 'c', 11.1)"},
-                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'b', 44.4)"},
-                        {"client":"python", "query_type": "table", "kill":"1455", "kill_wait":3, "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (2, 'b', 44.4)"}
+                        {"client":"python", "query_type": "stream", "query_id":"1455", "wait":1, "terminate":"manual", "query":"with subquery as (select id, count() as cnt, min(val) as min_val, max(val) as max_val from changelog(test14_append_stream_3, name) group by id emit periodic 1s) select count(*), sum(cnt), min(min_val), max(max_val) from subquery"},
+                        {"client":"python", "query_type": "table", "depends_on":"1455", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'a', 11.1)(2, 'a', 33.3)"},
+                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'b', 22.2)(2, 'b', 22.2)"},
+                        {"client":"python", "query_type": "table", "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'c', 33.3)(2, 'c', 11.1)"},
+                        {"client":"python", "query_type": "table", "kill":"1455", "kill_wait":3, "wait":1, "query": "insert into test14_append_stream_3 (id, name, val) values (1, 'b', 44.4)(2, 'b', 44.4)"}
                     ]
                 }
             ],
@@ -160,10 +156,10 @@
                 {
                     "query_id":"1455",
                     "expected_results":[
-                        [2, 1, 0.0, 33.29999923706055],
-                        [2, 2, 0.0, 33.29999923706055],
-                        [2, 3, 0.0, 33.29999923706055],
-                        [2, 3, 0.0, 44.400001525878906]
+                        [1, 1, 33.3, 33.3],
+                        [1, 2, 22.2, 33.3],
+                        [1, 3, 11.1, 33.3],
+                        [1, 3, 11.1, 44.4]
                     ]
                 }
             ]

--- a/tests/stream/test_stream_smoke/0013_changelog_stream3.json
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream3.json
@@ -71,8 +71,8 @@
         {
             "id": 53,
             "tags": ["changelog(table))", "subquery"],
-            "name": "subquery from materialized view, cover add，delete,update",
-            "description": "subquery from materialized view, cover add，delete,update",
+            "name": "subquery from materialized view, cover add/delete/update",
+            "description": "subquery from materialized view, cover add/delete/update",
             "steps": [
                 {
                     "statements": [

--- a/tests/stream/test_stream_smoke/0020_seek_to.json
+++ b/tests/stream/test_stream_smoke/0020_seek_to.json
@@ -24,8 +24,8 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='0' settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2190", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 0 settings enable_backfill_from_historical_store = false"}
+            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='0'"},
+            {"client":"python","query_id":"2190", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 0"}
           ]
         }
       ],
@@ -52,8 +52,8 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='1' settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2191", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 1 settings enable_backfill_from_historical_store = false"}
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='1'"},
+            {"client":"python","query_id":"2191", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 1"}
           ]
         }
       ],
@@ -80,8 +80,8 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='5' settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2192", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 5 settings enable_backfill_from_historical_store = false"}
+            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='5'"},
+            {"client":"python","query_id":"2192", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 5"}
           ]
         }
       ],
@@ -104,13 +104,13 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 1 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 5 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn < 2 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2103", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn <= 2 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn > 2 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 2 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn != 2 settings enable_backfill_from_historical_store = false"}
+            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 1"},
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 5"},
+            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn < 2"},
+            {"client":"python","query_id":"2103", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn <= 2"},
+            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn > 2"},
+            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 2"},
+            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn != 2"}
           ]
         }
       ],
@@ -227,7 +227,7 @@
         {
           "statements": [
             {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select t, s from (select * from test21_limit_by_stream) where _tp_time = '2022-12-01 00:00:01.111'"},
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select t, s from (select *, _tp_sn from test21_limit_by_stream) where _tp_sn = 0 settings enable_backfill_from_historical_store = false"}
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select t, s from (select *, _tp_sn from test21_limit_by_stream) where _tp_sn = 0"}
           ]
         }
       ],
@@ -255,9 +255,9 @@
         {
           "statements": [
             {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time as event_time from test21_limit_by_stream) select i, s from cte where event_time >= '2022-12-01 00:00:01.111'"},
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_sn as sn from test21_limit_by_stream) select i, s from cte where sn >= 0 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_sn as sn from test21_limit_by_stream) select i, s from cte where sn >= 0"},
             {"client":"python", "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time as event_time from test21_limit_by_stream) select window_start, count() from tumble(cte, event_time, 2s) where event_time >= '2022-12-01 00:00:01.111' group by window_start"},
-            {"client":"python", "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time, _tp_sn as sn from test21_limit_by_stream) select window_start, count() from tumble(cte, 2s) where sn >= 0 group by window_start settings enable_backfill_from_historical_store = false"}
+            {"client":"python", "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time, _tp_sn as sn from test21_limit_by_stream) select window_start, count() from tumble(cte, 2s) where sn >= 0 group by window_start"}
           ]
         }
       ],
@@ -303,9 +303,9 @@
             {"client":"python", "query_type": "table", "wait": 2, "query":"create view seek_to_view1 as select t, s, _tp_time as time from (select * from test21_limit_by_stream)"},
             {"client":"python", "query_type": "table", "query":"create view seek_to_view2 as select t, s, _tp_time, _tp_sn from (select *, _tp_sn from test21_limit_by_stream)"},
             {"client":"python", "query_id":"2100", "depends_on_stream":"seek_to_view1", "query_end_timer":2, "query_type": "stream", "query":"select t, s from seek_to_view1 where time = '2022-12-01 00:00:01.111'"},
-            {"client":"python", "query_id":"2101", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream", "query":"select t, s from seek_to_view2 where _tp_sn = 0 settings enable_backfill_from_historical_store = false"},
+            {"client":"python", "query_id":"2101", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream", "query":"select t, s from seek_to_view2 where _tp_sn = 0"},
             {"client":"python", "query_id":"2102", "depends_on_stream":"seek_to_view1", "query_end_timer":2, "query_type": "stream","drop_view":"seek_to_view1", "drop_view_wait":2, "query":"select window_start, count() from tumble(seek_to_view1, time, 2s) where time >= '2022-12-01 00:00:01.111' group by window_start"},
-            {"client":"python", "query_id":"2103", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream","drop_view":"seek_to_view2", "drop_view_wait":2, "query":"select window_start, count() from tumble(seek_to_view2, 2s) where _tp_sn >= 0 group by window_start settings enable_backfill_from_historical_store = false"}
+            {"client":"python", "query_id":"2103", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream","drop_view":"seek_to_view2", "drop_view_wait":2, "query":"select window_start, count() from tumble(seek_to_view2, 2s) where _tp_sn >= 0 group by window_start"}
           ]
         }
       ],
@@ -354,8 +354,8 @@
             {"client":"python", "depends_on_stream":"test21_limit_by_stream_2", "query_type": "table", "query":"insert into test21_limit_by_stream_2(i, s, t) values (2, 's2', '2022-12-01 00:00:04.111')"},
             {"client":"python", "wait":2, "query_id":"2100", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select a.i, b.s, c.t from test21_limit_by_stream as a join test21_limit_by_stream as b on a.i = b.i join test21_limit_by_stream as c on b.i = c.i where a._tp_time >= '2022-12-01 00:00:01.111' and b._tp_time >= '2022-12-01 00:00:02.111' and c._tp_time >= '2022-12-01 00:00:03.111'"},
             {"client":"python", "wait":2, "query_id":"2101", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select a.i, count() from test21_limit_by_stream as a join test21_limit_by_stream as b on a.i = b.i where a._tp_time >= '2022-12-01 00:00:01.111' and b._tp_time >= '2022-12-01 00:00:02.111' group by a.i emit periodic 1s"},
-            {"client":"python", "wait":2, "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select i, s from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 1 and default.test21_limit_by_stream_2._tp_sn > 2 settings enable_backfill_from_historical_store = false"},
-            {"client":"python", "wait":2, "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select count() from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 0 and default.test21_limit_by_stream_2._tp_sn < 4 emit periodic 1s settings enable_backfill_from_historical_store = false"}
+            {"client":"python", "wait":2, "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select i, s from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 1 and default.test21_limit_by_stream_2._tp_sn > 2"},
+            {"client":"python", "wait":2, "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select count() from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 0 and default.test21_limit_by_stream_2._tp_sn < 4 emit periodic 1s"}
           ]
         }
       ],
@@ -396,7 +396,7 @@
           "statements": [
             {"client":"python", "wait":2, "query_type": "table", "query":"drop view if exists seek_to_mv"},
             {"client":"python", "wait":2, "query_type": "table", "query":"create materialized view seek_to_mv as (select window_start as win_start, window_end as win_end, sum(i) as cnt from tumble(test21_limit_by_stream, 2s) where _tp_time >= '2022-12-01 00:00:01.111' group by window_start, window_end)"},
-            {"client":"python", "wait":5, "depends_on_stream":"seek_to_mv", "query_end_timer":3, "query_type": "stream", "query_id":"2100", "query":"select win_start, win_end, cnt from seek_to_mv where _tp_sn >= 0 settings enable_backfill_from_historical_store = false"},
+            {"client":"python", "wait":5, "depends_on_stream":"seek_to_mv", "query_end_timer":3, "query_type": "stream", "query_id":"2100", "query":"select win_start, win_end, cnt from seek_to_mv where _tp_sn >= 0"},
             {"client":"python", "depends_on_stream":"seek_to_mv", "wait":5, "query_type": "table", "query_id":"2101", "query":"select win_start, win_end, cnt from table(seek_to_mv)"},
             {"client":"python", "query_end_timer":4, "query_type": "stream", "query_id":"2102","drop_view":"seek_to_mv", "drop_view_wait":2, "query":"select window_start, sum(cnt) from tumble(seek_to_mv, win_start, 2s) where _tp_time >= now() - 1m group by window_start emit timeout 1s"}
           ]
@@ -438,9 +438,9 @@
             {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time >= '2022-12-01 00:00:04.111' and _tp_time >= '2022-12-01 00:00:02.111'"},
             {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time < '2022-12-01 00:00:03.111' and _tp_time > '2022-12-01 00:00:01.111'"},
             {"client":"python","query_id":"2103", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time <= '2022-12-01 00:00:03.111' and _tp_time <= '2022-12-01 00:00:04.111'"},
-            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time > '2022-12-01 00:00:03.111' and _tp_sn >= 0 settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn > 0 and _tp_time < '2022-12-01 00:00:03.111' settings enable_backfill_from_historical_store = false"},
-            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn < 5 and _tp_sn < 8 and _tp_sn < 4 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time > '2022-12-01 00:00:03.111' and _tp_sn >= 0"},
+            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn > 0 and _tp_time < '2022-12-01 00:00:03.111'"},
+            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn < 5 and _tp_sn < 8 and _tp_sn < 4"},
             {"client":"python","query_id":"2107", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time != '2022-12-01 00:00:03.111' and _tp_time <= '2022-12-01 00:00:04.111' and _tp_time >= '2022-12-01 00:00:02.111'"}
           ]
         }

--- a/tests/stream/test_stream_smoke/0020_seek_to.json
+++ b/tests/stream/test_stream_smoke/0020_seek_to.json
@@ -24,8 +24,8 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='0'"},
-            {"client":"python","query_id":"2190", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 0"}
+            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='0' settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2190", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 0 settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -52,8 +52,8 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='1'"},
-            {"client":"python","query_id":"2191", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 1"}
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='1' settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2191", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 1 settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -80,8 +80,8 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='5'"},
-            {"client":"python","query_id":"2192", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 5"}
+            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream settings seek_to='5' settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2192", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 5 settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -104,13 +104,13 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 1"},
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 5"},
-            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn < 2"},
-            {"client":"python","query_id":"2103", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn <= 2"},
-            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn > 2"},
-            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 2"},
-            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn != 2"}
+            {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 1 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn = 5 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn < 2 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2103", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn <= 2 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn > 2 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn >= 2 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select i, s from test21_limit_by_stream where _tp_sn != 2 settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -227,7 +227,7 @@
         {
           "statements": [
             {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select t, s from (select * from test21_limit_by_stream) where _tp_time = '2022-12-01 00:00:01.111'"},
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select t, s from (select *, _tp_sn from test21_limit_by_stream) where _tp_sn = 0"}
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"select t, s from (select *, _tp_sn from test21_limit_by_stream) where _tp_sn = 0 settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -255,9 +255,9 @@
         {
           "statements": [
             {"client":"python","query_id":"2100", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time as event_time from test21_limit_by_stream) select i, s from cte where event_time >= '2022-12-01 00:00:01.111'"},
-            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_sn as sn from test21_limit_by_stream) select i, s from cte where sn >= 0"},
+            {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_sn as sn from test21_limit_by_stream) select i, s from cte where sn >= 0 settings enable_backfill_from_historical_store = false"},
             {"client":"python", "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time as event_time from test21_limit_by_stream) select window_start, count() from tumble(cte, event_time, 2s) where event_time >= '2022-12-01 00:00:01.111' group by window_start"},
-            {"client":"python", "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time, _tp_sn as sn from test21_limit_by_stream) select window_start, count() from tumble(cte, 2s) where sn >= 0 group by window_start"}
+            {"client":"python", "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":2, "query_type": "stream", "query":"with cte as (select i, s, _tp_time, _tp_sn as sn from test21_limit_by_stream) select window_start, count() from tumble(cte, 2s) where sn >= 0 group by window_start settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -303,9 +303,9 @@
             {"client":"python", "query_type": "table", "wait": 2, "query":"create view seek_to_view1 as select t, s, _tp_time as time from (select * from test21_limit_by_stream)"},
             {"client":"python", "query_type": "table", "query":"create view seek_to_view2 as select t, s, _tp_time, _tp_sn from (select *, _tp_sn from test21_limit_by_stream)"},
             {"client":"python", "query_id":"2100", "depends_on_stream":"seek_to_view1", "query_end_timer":2, "query_type": "stream", "query":"select t, s from seek_to_view1 where time = '2022-12-01 00:00:01.111'"},
-            {"client":"python", "query_id":"2101", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream", "query":"select t, s from seek_to_view2 where _tp_sn = 0"},
+            {"client":"python", "query_id":"2101", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream", "query":"select t, s from seek_to_view2 where _tp_sn = 0 settings enable_backfill_from_historical_store = false"},
             {"client":"python", "query_id":"2102", "depends_on_stream":"seek_to_view1", "query_end_timer":2, "query_type": "stream","drop_view":"seek_to_view1", "drop_view_wait":2, "query":"select window_start, count() from tumble(seek_to_view1, time, 2s) where time >= '2022-12-01 00:00:01.111' group by window_start"},
-            {"client":"python", "query_id":"2103", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream","drop_view":"seek_to_view2", "drop_view_wait":2, "query":"select window_start, count() from tumble(seek_to_view2, 2s) where _tp_sn >= 0 group by window_start"}
+            {"client":"python", "query_id":"2103", "depends_on_stream":"seek_to_view2", "query_end_timer":2, "query_type": "stream","drop_view":"seek_to_view2", "drop_view_wait":2, "query":"select window_start, count() from tumble(seek_to_view2, 2s) where _tp_sn >= 0 group by window_start settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -354,8 +354,8 @@
             {"client":"python", "depends_on_stream":"test21_limit_by_stream_2", "query_type": "table", "query":"insert into test21_limit_by_stream_2(i, s, t) values (2, 's2', '2022-12-01 00:00:04.111')"},
             {"client":"python", "wait":2, "query_id":"2100", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select a.i, b.s, c.t from test21_limit_by_stream as a join test21_limit_by_stream as b on a.i = b.i join test21_limit_by_stream as c on b.i = c.i where a._tp_time >= '2022-12-01 00:00:01.111' and b._tp_time >= '2022-12-01 00:00:02.111' and c._tp_time >= '2022-12-01 00:00:03.111'"},
             {"client":"python", "wait":2, "query_id":"2101", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select a.i, count() from test21_limit_by_stream as a join test21_limit_by_stream as b on a.i = b.i where a._tp_time >= '2022-12-01 00:00:01.111' and b._tp_time >= '2022-12-01 00:00:02.111' group by a.i emit periodic 1s"},
-            {"client":"python", "wait":2, "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select i, s from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 1 and default.test21_limit_by_stream_2._tp_sn > 2"},
-            {"client":"python", "wait":2, "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select count() from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 0 and default.test21_limit_by_stream_2._tp_sn < 4 emit periodic 1s"}
+            {"client":"python", "wait":2, "query_id":"2102", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select i, s from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 1 and default.test21_limit_by_stream_2._tp_sn > 2 settings enable_backfill_from_historical_store = false"},
+            {"client":"python", "wait":2, "query_id":"2103", "depends_on_stream":"test21_limit_by_stream", "query_end_timer":3, "query_type": "stream", "query":"select count() from test21_limit_by_stream as a  join test21_limit_by_stream_2 as b on a.i = b.i where test21_limit_by_stream._tp_sn > 0 and default.test21_limit_by_stream_2._tp_sn < 4 emit periodic 1s settings enable_backfill_from_historical_store = false"}
           ]
         }
       ],
@@ -396,7 +396,7 @@
           "statements": [
             {"client":"python", "wait":2, "query_type": "table", "query":"drop view if exists seek_to_mv"},
             {"client":"python", "wait":2, "query_type": "table", "query":"create materialized view seek_to_mv as (select window_start as win_start, window_end as win_end, sum(i) as cnt from tumble(test21_limit_by_stream, 2s) where _tp_time >= '2022-12-01 00:00:01.111' group by window_start, window_end)"},
-            {"client":"python", "wait":5, "depends_on_stream":"seek_to_mv", "query_end_timer":3, "query_type": "stream", "query_id":"2100", "query":"select win_start, win_end, cnt from seek_to_mv where _tp_sn >= 0"},
+            {"client":"python", "wait":5, "depends_on_stream":"seek_to_mv", "query_end_timer":3, "query_type": "stream", "query_id":"2100", "query":"select win_start, win_end, cnt from seek_to_mv where _tp_sn >= 0 settings enable_backfill_from_historical_store = false"},
             {"client":"python", "depends_on_stream":"seek_to_mv", "wait":5, "query_type": "table", "query_id":"2101", "query":"select win_start, win_end, cnt from table(seek_to_mv)"},
             {"client":"python", "query_end_timer":4, "query_type": "stream", "query_id":"2102","drop_view":"seek_to_mv", "drop_view_wait":2, "query":"select window_start, sum(cnt) from tumble(seek_to_mv, win_start, 2s) where _tp_time >= now() - 1m group by window_start emit timeout 1s"}
           ]
@@ -438,9 +438,9 @@
             {"client":"python","query_id":"2101", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time >= '2022-12-01 00:00:04.111' and _tp_time >= '2022-12-01 00:00:02.111'"},
             {"client":"python","query_id":"2102", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time < '2022-12-01 00:00:03.111' and _tp_time > '2022-12-01 00:00:01.111'"},
             {"client":"python","query_id":"2103", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time <= '2022-12-01 00:00:03.111' and _tp_time <= '2022-12-01 00:00:04.111'"},
-            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time > '2022-12-01 00:00:03.111' and _tp_sn >= 0"},
-            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn > 0 and _tp_time < '2022-12-01 00:00:03.111'"},
-            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn < 5 and _tp_sn < 8 and _tp_sn < 4"},
+            {"client":"python","query_id":"2104", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time > '2022-12-01 00:00:03.111' and _tp_sn >= 0 settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2105", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn > 0 and _tp_time < '2022-12-01 00:00:03.111' settings enable_backfill_from_historical_store = false"},
+            {"client":"python","query_id":"2106", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_sn < 5 and _tp_sn < 8 and _tp_sn < 4 settings enable_backfill_from_historical_store = false"},
             {"client":"python","query_id":"2107", "depends_on_stream":"test21_limit_by_stream","query_end_timer":1, "query_type": "stream", "query":"select s from test21_limit_by_stream where _tp_time != '2022-12-01 00:00:03.111' and _tp_time <= '2022-12-01 00:00:04.111' and _tp_time >= '2022-12-01 00:00:02.111'"}
           ]
         }

--- a/tests/stream/test_stream_smoke/0028_replay_stream.yaml
+++ b/tests/stream/test_stream_smoke/0028_replay_stream.yaml
@@ -57,7 +57,7 @@ tests:
             query_id: '2900'
             wait: 1
             query: with cte as (select id, value, date_diff('millisecond', to_datetime64(lag(_tp_append_time, 1)/1000, 3, 'UTC'), to_datetime64(_tp_append_time/1000, 3, 'UTC')) as insert_interval,
-                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1, enable_backfill_from_historical_store=false)
+                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1)
                     select id, value, abs(insert_interval-2000) < 200, abs(insert_interval-output_time_diff) < 200 from cte;
     expected_results:
       - query_id: '2900'
@@ -101,7 +101,7 @@ tests:
             query_id: '2901'
             wait: 1
             query: with cte as (select id, value, date_diff('millisecond', to_datetime64(lag(_tp_append_time, 1)/1000, 3, 'UTC'), to_datetime64(_tp_append_time/1000, 3, 'UTC')) as insert_interval,
-                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=0.5, enable_backfill_from_historical_store=false)
+                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=0.5)
                     select id, value, abs(insert_interval-2000) < 200, abs(2*insert_interval-output_time_diff) < 200 from cte;
     expected_results:
       - query_id: '2901'
@@ -165,7 +165,7 @@ tests:
             query_id: '2902'
             wait: 1
             query: select max(value), min(value), id from test29_stream where _tp_time >
-              earliest_timestamp() group by id settings replay_speed=1, enable_backfill_from_historical_store=false;
+              earliest_timestamp() group by id settings replay_speed=1;
     expected_results:
       - query_id: '2902'
         expected_results:
@@ -258,7 +258,7 @@ tests:
             query_id: '2904'
             wait: 1
             query: with cte as (select id, value from test29_stream_1 where _tp_time >
-              earliest_timestamp() settings replay_speed=1, enable_backfill_from_historical_store=false) select a.id,
+              earliest_timestamp() settings replay_speed=1) select a.id,
               a.value, b.id, b.value from cte as a join table(test29_stream_2)
               as b on a.id=b.id;
     expected_results:
@@ -309,7 +309,7 @@ tests:
             terminate: munual
             query_id: '2905'
             wait: 1
-            query: select id, value from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1, enable_backfill_from_historical_store=false;
+            query: select id, value from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1;
 
           - client: python
             query_type: table

--- a/tests/stream/test_stream_smoke/0028_replay_stream.yaml
+++ b/tests/stream/test_stream_smoke/0028_replay_stream.yaml
@@ -26,7 +26,7 @@ tests:
     tags:
       - replay_stream
     name: test replay_stream
-    description: Check if the interval for data insertion is equal to the interval for output，allowable error within 10ms.Also check the data interval whether equal to the insert interval,allowable error within 200ms(because you can't control the the insert interval accurately)
+    description: Check if the interval for data insertion is equal to the interval for output, allowable error within 10ms.Also check the data interval whether equal to the insert interval,allowable error within 200ms(because you can't control the the insert interval accurately)
     steps:
       - statements:
           - client: python
@@ -53,12 +53,12 @@ tests:
           - client: python
             query_type: stream
             terminate: auto
-            query_end_timer: 20
+            query_end_timer: 10
             query_id: '2900'
             wait: 1
             query: with cte as (select id, value, date_diff('millisecond', to_datetime64(lag(_tp_append_time, 1)/1000, 3, 'UTC'), to_datetime64(_tp_append_time/1000, 3, 'UTC')) as insert_interval,
-                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1)
-                    select id, value, abs(insert_interval-2000) < 200, abs(insert_interval-output_time_diff) < 10 from cte;
+                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1, enable_backfill_from_historical_store=false)
+                    select id, value, abs(insert_interval-2000) < 200, abs(insert_interval-output_time_diff) < 200 from cte;
     expected_results:
       - query_id: '2900'
         expected_results:
@@ -97,12 +97,12 @@ tests:
           - client: python
             query_type: stream
             terminate: auto
-            query_end_timer: 20
+            query_end_timer: 15
             query_id: '2901'
             wait: 1
             query: with cte as (select id, value, date_diff('millisecond', to_datetime64(lag(_tp_append_time, 1)/1000, 3, 'UTC'), to_datetime64(_tp_append_time/1000, 3, 'UTC')) as insert_interval,
-                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=0.5)
-                    select id, value, abs(insert_interval-2000) < 200, abs(2*insert_interval-output_time_diff) < 10 from cte;
+                    date_diff('millisecond',lag(now64(), 1), now64()) as output_time_diff, _tp_time from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=0.5, enable_backfill_from_historical_store=false)
+                    select id, value, abs(insert_interval-2000) < 200, abs(2*insert_interval-output_time_diff) < 200 from cte;
     expected_results:
       - query_id: '2901'
         expected_results:
@@ -165,7 +165,7 @@ tests:
             query_id: '2902'
             wait: 1
             query: select max(value), min(value), id from test29_stream where _tp_time >
-              earliest_timestamp() group by id settings replay_speed=1;
+              earliest_timestamp() group by id settings replay_speed=1, enable_backfill_from_historical_store=false;
     expected_results:
       - query_id: '2902'
         expected_results:
@@ -258,7 +258,7 @@ tests:
             query_id: '2904'
             wait: 1
             query: with cte as (select id, value from test29_stream_1 where _tp_time >
-              earliest_timestamp() settings replay_speed=1) select a.id,
+              earliest_timestamp() settings replay_speed=1, enable_backfill_from_historical_store=false) select a.id,
               a.value, b.id, b.value from cte as a join table(test29_stream_2)
               as b on a.id=b.id;
     expected_results:
@@ -309,7 +309,7 @@ tests:
             terminate: munual
             query_id: '2905'
             wait: 1
-            query: select id, value from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1;
+            query: select id, value from test29_stream where _tp_time > earliest_timestamp() settings replay_speed=1, enable_backfill_from_historical_store=false;
 
           - client: python
             query_type: table

--- a/tests/stream/test_stream_smoke/0099_fixed_issues.json
+++ b/tests/stream/test_stream_smoke/0099_fixed_issues.json
@@ -149,8 +149,8 @@
             {"client":"python", "query_type": "table", "depends_on_stream":"test_mv_1934", "wait":2, "query": "insert into test_stream_1934(value) values(1)"},
             {"client":"python", "query_type": "table", "wait":3, "query": "insert into test_stream_1934(value) values(2)"},
             {"client":"python", "query_type": "table", "wait":3, "query": "insert into test_stream_1934(value) values(3)"},
-            {"client":"python", "query_type": "stream", "query_id":"9900", "query_end_timer":3, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_sn >= 0"},
-            {"client":"python", "query_type": "stream", "query_id":"9901", "query_end_timer":3,"drop_view":"test_mv_1934", "drop_view_wait":2, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_time >= now() - 1m"}
+            {"client":"python", "query_type": "stream", "query_id":"9900", "query_end_timer":3, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_sn >= 0 settings enable_backfill_from_historical_store=false"},
+            {"client":"python", "query_type": "stream", "query_id":"9901", "query_end_timer":3,"drop_view":"test_mv_1934", "drop_view_wait":2, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_time >= now() - 1m settings enable_backfill_from_historical_store=false"}
           ]
         }
       ],
@@ -555,7 +555,7 @@
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(1, 2);"},
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(3, 2);"},
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(5, 2);"},
-              {"client":"python", "query_type": "stream", "depends_on_stream":"test_append_time", "query_id":"9919", "wait":5, "query":"with cte as (select *, _tp_append_time from test_append_time)select date_diff('millisecond', to_datetime64(_tp_append_time/1000, 3, 'UTC'), _tp_time) < 10 from cte where _tp_time > earliest_timestamp();"},
+              {"client":"python", "query_type": "stream", "depends_on_stream":"test_append_time", "query_id":"9919", "wait":5, "query":"with cte as (select *, _tp_append_time from test_append_time)select date_diff('millisecond', to_datetime64(_tp_append_time/1000, 3, 'UTC'), _tp_time) < 10 from cte where _tp_time > earliest_timestamp() settings enable_backfill_from_historical_store=false;"},
               {"client":"python", "query_type": "table", "depends_on":"9919", "wait":1, "query": "insert into test_append_time(id, value) values(5, 2);"},
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(6, 2);"},
               {"client":"python", "query_type": "table", "kill":9919, "kill_wait":3, "query": "insert into test_append_time(id, value) values(6, 2);"}

--- a/tests/stream/test_stream_smoke/0099_fixed_issues.json
+++ b/tests/stream/test_stream_smoke/0099_fixed_issues.json
@@ -149,8 +149,8 @@
             {"client":"python", "query_type": "table", "depends_on_stream":"test_mv_1934", "wait":2, "query": "insert into test_stream_1934(value) values(1)"},
             {"client":"python", "query_type": "table", "wait":3, "query": "insert into test_stream_1934(value) values(2)"},
             {"client":"python", "query_type": "table", "wait":3, "query": "insert into test_stream_1934(value) values(3)"},
-            {"client":"python", "query_type": "stream", "query_id":"9900", "query_end_timer":3, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_sn >= 0 settings enable_backfill_from_historical_store=false"},
-            {"client":"python", "query_type": "stream", "query_id":"9901", "query_end_timer":3,"drop_view":"test_mv_1934", "drop_view_wait":2, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_time >= now() - 1m settings enable_backfill_from_historical_store=false"}
+            {"client":"python", "query_type": "stream", "query_id":"9900", "query_end_timer":3, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_sn >= 0"},
+            {"client":"python", "query_type": "stream", "query_id":"9901", "query_end_timer":3,"drop_view":"test_mv_1934", "drop_view_wait":2, "query":"select `count()`, _tp_shard, _tp_sn from test_mv_1934 where _tp_time >= now() - 1m"}
           ]
         }
       ],
@@ -555,7 +555,7 @@
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(1, 2);"},
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(3, 2);"},
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(5, 2);"},
-              {"client":"python", "query_type": "stream", "depends_on_stream":"test_append_time", "query_id":"9919", "wait":5, "query":"with cte as (select *, _tp_append_time from test_append_time)select date_diff('millisecond', to_datetime64(_tp_append_time/1000, 3, 'UTC'), _tp_time) < 10 from cte where _tp_time > earliest_timestamp() settings enable_backfill_from_historical_store=false;"},
+              {"client":"python", "query_type": "stream", "depends_on_stream":"test_append_time", "query_id":"9919", "wait":5, "query":"with cte as (select *, _tp_append_time from test_append_time)select date_diff('millisecond', to_datetime64(_tp_append_time/1000, 3, 'UTC'), _tp_time) < 10 from cte where _tp_time > earliest_timestamp();"},
               {"client":"python", "query_type": "table", "depends_on":"9919", "wait":1, "query": "insert into test_append_time(id, value) values(5, 2);"},
               {"client":"python", "query_type": "table", "query": "insert into test_append_time(id, value) values(6, 2);"},
               {"client":"python", "query_type": "table", "kill":9919, "kill_wait":3, "query": "insert into test_append_time(id, value) values(6, 2);"}


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
This close #162 , the change log:
- Enable backfill from historical store by setting `enable_backfill_from_historical_store` (by default is true)
- Add a setting `emit_aggregated_during_backfill` to control whether need emit aggregated result during backfill (by default is true)
- Optimization: when `emit_aggregated_during_backfill=false`, global aggregation don't require backfilled data in order