### PR TITLE
Improve performance of external aggregation with a lot of temporary f…

### DIFF
--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -1238,6 +1238,10 @@ public:
         return !buf[place_value].isZero(*this);
     }
 
+    bool ALWAYS_INLINE contains(const Key & x) const
+    {
+        return has(x);
+    }
 
     void write(DB::WriteBuffer & wb) const
     {

--- a/src/Processors/Transforms/MergingAggregatedMemoryEfficientTransform.cpp
+++ b/src/Processors/Transforms/MergingAggregatedMemoryEfficientTransform.cpp
@@ -17,35 +17,7 @@ GroupingAggregatedTransform::GroupingAggregatedTransform(
     , num_inputs(num_inputs_)
     , params(std::move(params_))
     , last_bucket_number(num_inputs, -1)
-    , read_from_input(num_inputs, false)
 {
-}
-
-void GroupingAggregatedTransform::readFromAllInputs()
-{
-    auto in = inputs.begin();
-    read_from_all_inputs = true;
-
-    for (size_t i = 0; i < num_inputs; ++i, ++in)
-    {
-        if (in->isFinished())
-            continue;
-
-        if (read_from_input[i])
-            continue;
-
-        in->setNeeded();
-
-        if (!in->hasData())
-        {
-            read_from_all_inputs = false;
-            continue;
-        }
-
-        auto chunk = in->pull();
-        read_from_input[i] = true;
-        addChunk(std::move(chunk), i);
-    }
 }
 
 void GroupingAggregatedTransform::pushData(Chunks chunks, Int32 bucket, bool is_overflows)
@@ -116,7 +88,7 @@ bool GroupingAggregatedTransform::tryPushOverflowData()
     return true;
 }
 
-IProcessor::Status GroupingAggregatedTransform::prepare()
+IProcessor::Status GroupingAggregatedTransform::prepare(const PortNumbers & updated_input_ports, const PortNumbers &)
 {
     /// Check can output.
     auto & output = outputs.front();
@@ -131,32 +103,15 @@ IProcessor::Status GroupingAggregatedTransform::prepare()
         return Status::Finished;
     }
 
-    /// Read first time from each input to understand if we have two-level aggregation.
-    if (!read_from_all_inputs)
+    if (!initialized_index_to_input)
     {
-        readFromAllInputs();
-        if (!read_from_all_inputs)
-            return Status::NeedData;
+        initialized_index_to_input = true;
+        auto in = inputs.begin();
+        index_to_input.resize(num_inputs);
+
+        for (size_t i = 0; i < num_inputs; ++i, ++in)
+            index_to_input[i] = in;
     }
-
-    /// Convert single level to two levels if have two-level input.
-    if (has_two_level && !single_level_chunks.empty())
-        return Status::Ready;
-
-    /// Check can push (to avoid data caching).
-    if (!output.canPush())
-    {
-        for (auto & input : inputs)
-            input.setNotNeeded();
-
-        return Status::PortFull;
-    }
-
-    bool pushed_to_output = false;
-
-    /// Output if has data.
-    if (has_two_level)
-        pushed_to_output = tryPushTwoLevelData();
 
     auto need_input = [this](size_t input_num)
     {
@@ -165,6 +120,51 @@ IProcessor::Status GroupingAggregatedTransform::prepare()
 
         return expect_several_chunks_for_single_bucket_per_source && last_bucket_number[input_num] == current_bucket;
     };
+
+    if (!wait_input_ports_numbers.empty())
+    {
+        for (const auto & updated_input_port_number : updated_input_ports)
+        {
+            if (!wait_input_ports_numbers.contains(updated_input_port_number))
+                continue;
+
+            auto & input = index_to_input[updated_input_port_number];
+            if (!input->hasData())
+            {
+                wait_input_ports_numbers.erase(updated_input_port_number);
+                continue;
+            }
+
+            auto chunk = input->pull();
+            addChunk(std::move(chunk), updated_input_port_number);
+
+            if (!input->isFinished() && need_input(updated_input_port_number))
+                continue;
+
+            wait_input_ports_numbers.erase(updated_input_port_number);
+        }
+
+        if (!wait_input_ports_numbers.empty())
+            return Status::NeedData;
+    }
+
+    if (!output.canPush())
+    {
+        for (auto & input : inputs)
+            input.setNotNeeded();
+
+        return Status::PortFull;
+    }
+
+    /// Convert single level to two levels if have two-level input.
+    if (has_two_level && !single_level_chunks.empty())
+        return Status::Ready;
+
+    bool pushed_to_output = false;
+
+    /// Output if has data.
+    if (has_two_level)
+        pushed_to_output = tryPushTwoLevelData();
 
     /// Read next bucket if can.
     for (; ; ++current_bucket)
@@ -187,6 +187,7 @@ IProcessor::Status GroupingAggregatedTransform::prepare()
 
             if (!in->hasData())
             {
+                wait_input_ports_numbers.insert(input_num);
                 need_data = true;
                 continue;
             }
@@ -194,12 +195,15 @@ IProcessor::Status GroupingAggregatedTransform::prepare()
             auto chunk = in->pull();
             addChunk(std::move(chunk), input_num);
 
-            if (has_two_level && !single_level_chunks.empty())
-                return Status::Ready;
-
             if (!in->isFinished() && need_input(input_num))
+            {
+                wait_input_ports_numbers.insert(input_num);
                 need_data = true;
+            }
         }
+
+        if (has_two_level && !single_level_chunks.empty())
+            return Status::Ready;
 
         if (finished)
         {

--- a/src/Processors/Transforms/MergingAggregatedMemoryEfficientTransform.h
+++ b/src/Processors/Transforms/MergingAggregatedMemoryEfficientTransform.h
@@ -1,9 +1,11 @@
 #pragma once
-#include <Processors/IProcessor.h>
+
+#include <Common/HashTable/HashSet.h>
 #include <Interpreters/Aggregator.h>
+#include <Processors/IProcessor.h>
 #include <Processors/ISimpleTransform.h>
-#include <Processors/Transforms/AggregatingTransform.h>
 #include <Processors/ResizeProcessor.h>
+#include <Processors/Transforms/AggregatingTransform.h>
 
 
 namespace DB
@@ -66,7 +68,7 @@ public:
     void allowSeveralChunksForSingleBucketPerSource() { expect_several_chunks_for_single_bucket_per_source = true; }
 
 protected:
-    Status prepare() override;
+    Status prepare(const PortNumbers & updated_input_ports, const PortNumbers &) override;
     void work() override;
 
 private:
@@ -82,15 +84,14 @@ private:
     bool has_two_level = false;
 
     bool all_inputs_finished = false;
-    bool read_from_all_inputs = false;
-    std::vector<bool> read_from_input;
+    bool initialized_index_to_input = false;
+    std::vector<InputPorts::iterator> index_to_input;
+    HashSet<uint64_t> wait_input_ports_numbers;
 
     bool expect_several_chunks_for_single_bucket_per_source = false;
 
     /// Add chunk read from input to chunks_map, overflow_chunks or single_level_chunks according to it's chunk info.
     void addChunk(Chunk chunk, size_t input);
-    /// Read from all inputs first chunk. It is needed to detect if any source has two-level aggregation.
-    void readFromAllInputs();
     /// Push chunks if all inputs has single level.
     bool tryPushSingleLevelData();
     /// Push chunks from ready bucket if has one.

--- a/tests/performance/aggregation_external.xml
+++ b/tests/performance/aggregation_external.xml
@@ -1,0 +1,10 @@
+<test>
+    <settings>
+        <max_threads>30</max_threads>
+        <max_bytes_before_external_group_by>10485760</max_bytes_before_external_group_by>
+    </settings>
+
+    <query>SELECT number, count() FROM numbers_mt(5000000) GROUP BY number FORMAT Null;</query>
+    <query>SELECT number, count() FROM numbers_mt(15000000) GROUP BY number FORMAT Null;</query>
+    <query>SELECT number, count() FROM numbers_mt(30000000) GROUP BY number FORMAT Null;</query>
+</test>


### PR DESCRIPTION
…iles

porting clickhouse/clickhouse#55489


I try this SQL `SELECT number, count() FROM numbers_mt(5000) GROUP BY number `

```markdown
| Implementation           | Elapsed Time | Processed Rows | Data Processed | Rows/s          | Data/s        |
|--------------------------|--------------|----------------|----------------|-----------------|---------------|
| Proton before this PR    | 0.007 sec    | 5.00 thousand  | 40.00 KB       | 665.96 thousand | 5.33 MB/s     |
| Proton after this PR     | 0.004 sec    | 5.00 thousand  | 40.00 KB       | 1.12 million    | 8.96 MB/s     |
| ClickHouse latest        | 0.003 sec    | 5.00 thousand  | 40.00 KB       | 1.97 million    | 15.78 MB/s    |
```




proton pipeline:
```
:) explain pipeline SELECT number, count() FROM numbers_mt(5000) GROUP BY number 

EXPLAIN PIPELINE
SELECT 
  number, count()
FROM 
  numbers_mt(5000)
GROUP BY 
  number

Query id: f25e0897-b550-476b-bfaa-133582a10464

┌─explain─────────────────┐
│ (Expression)            │
│ ExpressionTransform     │
│   (Aggregating)         │
│   AggregatingTransform  │
│     (Expression)        │
│     ExpressionTransform │
│       (ReadFromStorage) │
│       Limit             │
│         Numbers 0 → 1   │
└─────────────────────────┘

9 rows in set. Elapsed: 0.004 sec. 

:) 
```


clickhouse pipeline:
```
:) explain pipeline  SELECT number, count() FROM numbers_mt(5000) GROUP BY number

EXPLAIN PIPELINE
SELECT
    number,
    count()
FROM numbers_mt(5000)
GROUP BY number

Query id: 5ad3231d-0e56-4e04-adec-49a2beaaa0c8

┌─explain───────────────────┐
│ (Expression)              │
│ ExpressionTransform × 8   │
│   (Aggregating)           │
│   Resize 1 → 8            │
│     AggregatingTransform  │
│       (Expression)        │
│       ExpressionTransform │
│         (ReadFromStorage) │
│         Limit             │
│           Numbers 0 → 1   │
└───────────────────────────┘

10 rows in set. Elapsed: 0.002 sec. 

:) 

```


