### PR TITLE
fix ci testing. continue on #239

### DIFF
--- a/tests/queries_ported/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries_ported/0_stateless/02050_client_profile_events.reference
@@ -7,7 +7,7 @@ regression test for incorrect filtering out snapshots
 regression test for overlap profile events snapshots between queries
 [ 0 ] SelectedRows: 1 (increment)
 [ 0 ] SelectedRows: 1 (increment)
-regression test for overlap profile events snapshots between queries (clickhouse-local)
+regression test for overlap profile events snapshots between queries (proton-local)
 [ 0 ] SelectedRows: 1 (increment)
 [ 0 ] SelectedRows: 1 (increment)
 print everything


### PR DESCRIPTION
_edit v1: fix typo prooton -> proton_
Please write user-readable short description of the changes:

this test contains `.sh` and `.reference` as expected output. say the ci will run `.sh` and then compare the result with the previous `.reference`.

originally this test used `clickhouse-local` in the echo log, then I modified it to `proton-local` on `.sh` but forgot to modify the `.reference` 
thus the test is broken.
https://github.com/timeplus-io/proton/blob/1c17a1829304f723ae26b836ef7f095f0bd7beac/tests/queries_ported/0_stateless/02050_client_profile_events.sh#L20

```diff
-- echo 'regression test for overlap profile events snapshots between queries (clickhouse-local)'
++ echo 'regression test for overlap profile events snapshots between queries (proton-local)'

```


https://github.com/timeplus-io/proton/actions/runs/6817530985/job/18542937704#step:7:1417
```
2023-11-09 22:28:35 02050_client_profile_events:                                            [ FAIL ] - result differs with reference: 
2023-11-09 22:28:35 --- /proton_src/tests/queries_ported/0_stateless/02050_client_profile_events.reference	2023-11-09 22:18:45.128809182 +0000
2023-11-09 22:28:35 +++ /proton_src/tests/queries_ported/0_stateless/02050_client_profile_events.stdout	2023-11-09 22:28:35.357575570 +0000
2023-11-09 22:28:35 @@ -7,7 +7,7 @@
2023-11-09 22:28:35  regression test for overlap profile events snapshots between queries
2023-11-09 22:28:35  [ 0 ] SelectedRows: 1 (increment)
2023-11-09 22:28:35  [ 0 ] SelectedRows: 1 (increment)
2023-11-09 22:28:35 -regression test for overlap profile events snapshots between queries (clickhouse-local)
2023-11-09 22:28:35 +regression test for overlap profile events snapshots between queries (proton-local)
2023-11-09 22:28:35  [ 0 ] SelectedRows: 1 (increment)
2023-11-09 22:28:35  [ 0 ] SelectedRows: 1 (increment)
2023-11-09 22:28:35  print everything
2023-11-09 22:28:35 
```
