### PR TITLE
support two level hash table for global aggregation

### DIFF
--- a/src/Common/HashTable/TwoLevelHashMap.h
+++ b/src/Common/HashTable/TwoLevelHashMap.h
@@ -29,11 +29,20 @@ public:
     }
 
     /// proton: starts.
+    using Self = TwoLevelHashMapTable;
+
     template <typename Func>
     void ALWAYS_INLINE forEachValue(Func && func)
     {
         for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
             this->impls[i].forEachValue(func);
+    }
+
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
+    {
+        for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
+            this->impls[i].mergeToViaEmplace(that.impls[i], func);
     }
     /// proton: ends.
 

--- a/src/Common/HashTable/TwoLevelHashTable.h
+++ b/src/Common/HashTable/TwoLevelHashTable.h
@@ -350,9 +350,9 @@ public:
     }
 
     /// proton : starts
-    std::vector<size_t> buckets() const
+    std::vector<Int64> buckets() const
     {
-        std::vector<size_t> bucket_ids(NUM_BUCKETS);
+        std::vector<Int64> bucket_ids(NUM_BUCKETS);
         std::iota(bucket_ids.begin(), bucket_ids.end(), 0);
         return bucket_ids;
     }

--- a/src/Common/HashTable/TwoLevelStringHashMap.h
+++ b/src/Common/HashTable/TwoLevelStringHashMap.h
@@ -28,6 +28,13 @@ public:
         for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
             this->impls[i].forEachValue(func);
     }
+
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
+    {
+        for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
+            this->impls[i].mergeToViaEmplace(that.impls[i], func);
+    }
     /// proton: ends.
 
     TMapped & ALWAYS_INLINE operator[](const Key & x)

--- a/src/Common/HashTable/TwoLevelStringHashTable.h
+++ b/src/Common/HashTable/TwoLevelStringHashTable.h
@@ -235,9 +235,9 @@ public:
         return res;
     }
 
-    std::vector<size_t> buckets() const
+    std::vector<Int64> buckets() const
     {
-        std::vector<size_t> bucket_ids(256);
+        std::vector<Int64> bucket_ids(NUM_BUCKETS);
         std::iota(bucket_ids.begin(), bucket_ids.end(), 0);
         return bucket_ids;
     }

--- a/src/Interpreters/Streaming/Aggregator.cpp
+++ b/src/Interpreters/Streaming/Aggregator.cpp
@@ -67,11 +67,8 @@ inline bool worthConvertToTwoLevel(
     size_t group_by_two_level_threshold, size_t result_size, size_t group_by_two_level_threshold_bytes, auto result_size_bytes)
 {
     /// params.group_by_two_level_threshold will be equal to 0 if we have only one thread to execute aggregation (refer to AggregatingStep::transformPipeline).
-    /// We like the unique key and state bytes both reach the threshold and then consider converting to two levels
-    /// For `partition by` streaming case, there may be lots of partitions and each partition may have only one key
-    /// but with more than `group_by_two_level_threshold_bytes` states.
     return (group_by_two_level_threshold && result_size >= group_by_two_level_threshold)
-        && (group_by_two_level_threshold_bytes && result_size_bytes >= static_cast<Int64>(group_by_two_level_threshold_bytes));
+        || (group_by_two_level_threshold_bytes && result_size_bytes >= static_cast<Int64>(group_by_two_level_threshold_bytes));
 }
 
 inline void initDataVariants(
@@ -124,7 +121,7 @@ AggregatedDataVariants::~AggregatedDataVariants()
 void AggregatedDataVariants::convertToTwoLevel()
 {
     if (aggregator)
-        LOG_TRACE(aggregator->log, "Converting aggregation data to two-level.");
+        LOG_INFO(aggregator->log, "Converting aggregation data to two-level.");
 
     switch (type)
     {
@@ -1268,57 +1265,39 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants) co
 
 
 template <typename Method>
-Block Aggregator::convertOneBucketToBlock(
+Block Aggregator::convertOneBucketToBlockImpl(
     AggregatedDataVariants & data_variants,
     Method & method,
     Arena * arena,
     bool final,
-    ConvertAction action,
+    bool clear_states,
     size_t bucket) const
 {
-    Block block = prepareBlockAndFill(data_variants, final, action, method.data.impls[bucket].size(),
+    Block block = prepareBlockAndFill(data_variants, final, clear_states, method.data.impls[bucket].size(),
         [bucket, &method, arena, this] (
             MutableColumns & key_columns,
             AggregateColumnsData & aggregate_columns,
             MutableColumns & final_aggregate_columns,
             bool final_,
-            ConvertAction action_)
+            bool clear_states_)
         {
             convertToBlockImpl(method, method.data.impls[bucket],
-                key_columns, aggregate_columns, final_aggregate_columns, arena, final_, action_);
+                key_columns, aggregate_columns, final_aggregate_columns, arena, final_, clear_states_);
         });
 
     block.info.bucket_num = static_cast<Int32>(bucket);
     return block;
 }
 
-Block Aggregator::convertOneBucketToBlockFinal(AggregatedDataVariants & variants, ConvertAction action, size_t bucket) const
+Block Aggregator::convertOneBucketToBlock(AggregatedDataVariants & variants, bool final, ConvertAction action, size_t bucket) const
 {
     auto method = variants.type;
     Block block;
-
+    bool clear_states = shouldClearStates(action, final);
     if (false) {} // NOLINT
 #define M(NAME) \
     else if (method == AggregatedDataVariants::Type::NAME) \
-        block = convertOneBucketToBlock(variants, *variants.NAME, variants.aggregates_pool, true, action, bucket);
-
-    APPLY_FOR_VARIANTS_TIME_BUCKET_TWO_LEVEL(M)
-#undef M
-    else
-        throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
-
-    return block;
-}
-
-Block Aggregator::convertOneBucketToBlockIntermediate(AggregatedDataVariants & variants, ConvertAction action, size_t bucket) const
-{
-    auto method = variants.type;
-    Block block;
-
-    if (false) {} // NOLINT
-#define M(NAME) \
-    else if (method == AggregatedDataVariants::Type::NAME) \
-        block = convertOneBucketToBlock(variants, *variants.NAME, variants.aggregates_pool, false, action, bucket);
+        block = convertOneBucketToBlockImpl(variants, *variants.NAME, variants.aggregates_pool, final, clear_states, bucket);
 
     APPLY_FOR_VARIANTS_TIME_BUCKET_TWO_LEVEL(M)
 #undef M
@@ -1329,25 +1308,24 @@ Block Aggregator::convertOneBucketToBlockIntermediate(AggregatedDataVariants & v
 }
 
 Block Aggregator::mergeAndConvertOneBucketToBlock(
-    ManyAggregatedDataVariants & variants,
-    Arena * arena,
-    bool final,
-    ConvertAction action,
-    size_t bucket,
-    std::atomic<bool> * is_cancelled) const
+    ManyAggregatedDataVariants & variants, bool final, ConvertAction action, size_t bucket) const
 {
-    auto & merged_data = *variants[0];
+    auto prepared_data_ptr = prepareVariantsToMerge(variants);
+    if (prepared_data_ptr->empty())
+        return {};
+
+    auto & merged_data = *prepared_data_ptr->at(0);
     auto method = merged_data.type;
+    Arena * arena = merged_data.aggregates_pool;
+    bool clear_states = shouldClearStates(action, final);
     Block block;
 
     if (false) {} // NOLINT
 #define M(NAME) \
     else if (method == AggregatedDataVariants::Type::NAME) \
     { \
-        mergeBucketImpl<decltype(merged_data.NAME)::element_type>(variants, final, action, bucket, arena); \
-        if (is_cancelled && is_cancelled->load(std::memory_order_seq_cst)) \
-            return {}; \
-        block = convertOneBucketToBlock(merged_data, *merged_data.NAME, arena, final, action, bucket); \
+        mergeBucketImpl<decltype(merged_data.NAME)::element_type>(*prepared_data_ptr, final, clear_states, bucket, arena); \
+        block = convertOneBucketToBlockImpl(merged_data, *merged_data.NAME, arena, final, clear_states, bucket); \
     }
 
     APPLY_FOR_VARIANTS_ALL_TWO_LEVEL(M)
@@ -1356,6 +1334,178 @@ Block Aggregator::mergeAndConvertOneBucketToBlock(
     return block;
 }
 
+BlocksList
+Aggregator::mergeAndConvertToBlocks(ManyAggregatedDataVariants & data_variants, bool final, ConvertAction action, size_t max_threads) const
+{
+    auto prepared_data_ptr = prepareVariantsToMerge(data_variants);
+    if (prepared_data_ptr->empty())
+        return {};
+
+    if (unlikely(params.overflow_row))
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Overflow row processing is not implemented in streaming aggregation");
+
+    bool clear_states = shouldClearStates(action, final);
+    BlocksList blocks;
+    auto & first = *prepared_data_ptr->at(0);
+    if (first.type == AggregatedDataVariants::Type::without_key)
+        blocks.emplace_back(mergeAndConvertWithoutKeyToBlock(*prepared_data_ptr, final, clear_states));
+    else if (first.isTwoLevel())
+        blocks.splice(blocks.end(), mergeAndConvertTwoLevelToBlocks(*prepared_data_ptr, final, max_threads, clear_states));
+    else
+        blocks.emplace_back(mergeAndConvertSingleLevelToBlock(*prepared_data_ptr, final, clear_states));
+
+    if (clear_states)
+        clearDataVariants(first);
+
+    return blocks;
+}
+
+Block Aggregator::mergeAndConvertWithoutKeyToBlock(ManyAggregatedDataVariants & non_empty_data, bool final, bool clear_states) const
+{
+    auto & first = *non_empty_data.at(0);
+    assert(first.type == AggregatedDataVariants::Type::without_key);
+    mergeWithoutKeyDataImpl(non_empty_data, clear_states);
+    return prepareBlockAndFillWithoutKey(first, final, false, clear_states);
+}
+
+Block Aggregator::mergeAndConvertSingleLevelToBlock(ManyAggregatedDataVariants & non_empty_data, bool final, bool clear_states) const
+{
+    auto & first = *non_empty_data.at(0);
+    if (false)
+    {
+    } // NOLINT
+#define M(NAME) \
+    else if (first.type == AggregatedDataVariants::Type::NAME) \
+        mergeSingleLevelDataImpl<decltype(first.NAME)::element_type>(non_empty_data, clear_states);
+
+    APPLY_FOR_VARIANTS_SINGLE_LEVEL_STREAMING(M)
+#undef M
+    else throw Exception("Unknown single level aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
+
+    return prepareBlockAndFillSingleLevel(first, final, clear_states);
+}
+
+BlocksList Aggregator::mergeAndConvertTwoLevelToBlocks(
+    ManyAggregatedDataVariants & non_empty_data, bool final, size_t max_threads, bool clear_states) const
+{
+    auto & first = *non_empty_data.at(0);
+    assert(first.isTwoLevel());
+#define M(NAME) \
+    else if (first.type == AggregatedDataVariants::Type::NAME) return mergeAndConvertTwoLevelToBlocksImpl< \
+        decltype(first.NAME)::element_type>(non_empty_data, final, max_threads, clear_states);
+
+    if (false)
+    {
+    } // NOLINT
+    APPLY_FOR_VARIANTS_ALL_TWO_LEVEL(M)
+#undef M
+    else throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
+}
+
+template <typename Method>
+BlocksList Aggregator::mergeAndConvertTwoLevelToBlocksImpl(
+    ManyAggregatedDataVariants & non_empty_data, bool final, size_t max_threads, bool clear_states) const
+{
+    auto & first = *non_empty_data.at(0);
+    std::vector<Int64> buckets;
+    if (first.isStaticBucketTwoLevel())
+        buckets = getDataVariant<Method>(first).data.buckets();
+    else
+    {
+        assert(first.isTimeBucketTwoLevel());
+        std::set<Int64> buckets_set;
+        for (auto & data_variants : non_empty_data)
+        {
+            auto tmp_buckets = getDataVariant<Method>(*data_variants).data.buckets();
+            buckets_set.insert(tmp_buckets.begin(), tmp_buckets.end());
+        }
+        buckets.assign(buckets_set.begin(), buckets_set.end());
+    }
+
+    std::unique_ptr<ThreadPool> thread_pool;
+    auto num_threads = std::min(max_threads, buckets.size());
+    if (num_threads > 1)
+        thread_pool = std::make_unique<ThreadPool>(num_threads);
+
+    /// proton FIXME : separate final vs non-final converting. For non-final converting, we don't need
+    /// each arena for each thread.
+    for (size_t i = first.aggregates_pools.size(); i < num_threads; ++i)
+        first.aggregates_pools.push_back(std::make_shared<Arena>());
+
+    std::atomic<size_t> next_bucket_idx_to_merge = 0;
+
+    auto converter = [&](size_t thread_id, ThreadGroupStatusPtr thread_group) {
+        SCOPE_EXIT_SAFE(if (thread_group) CurrentThread::detachQueryIfNotDetached(););
+        if (thread_group)
+            CurrentThread::attachToIfDetached(thread_group);
+
+        BlocksList blocks;
+        while (true)
+        {
+            UInt32 bucket_idx = next_bucket_idx_to_merge.fetch_add(1);
+            if (bucket_idx >= buckets.size())
+                break;
+
+            auto bucket = buckets[bucket_idx];
+
+            /// Merge one bucket into first one
+            Arena * arena = first.aggregates_pools.at(thread_id).get();
+            mergeBucketImpl<Method>(non_empty_data, final, clear_states, bucket, arena);
+            auto & method = getDataVariant<Method>(first);
+            if (method.data.impls[bucket].empty())
+                continue;
+
+            /// Convert one bucket of first one
+            blocks.emplace_back(convertOneBucketToBlockImpl(first, method, arena, final, clear_states, bucket));
+        }
+
+        if (clear_states)
+        {
+            for (size_t i = 1; i < non_empty_data.size(); ++i)
+                clearDataVariants(*non_empty_data[i]);
+        }
+
+        return blocks;
+    };
+
+    /// packaged_task is used to ensure that exceptions are automatically thrown into the main stream.
+    std::vector<std::packaged_task<BlocksList()>> tasks(num_threads);
+    try
+    {
+        for (size_t thread_id = 0; thread_id < num_threads; ++thread_id)
+        {
+            tasks[thread_id] = std::packaged_task<BlocksList()>(
+                [group = CurrentThread::getGroup(), thread_id, &converter] { return converter(thread_id, group); });
+
+            if (thread_pool)
+                thread_pool->scheduleOrThrowOnError([thread_id, &tasks] { tasks[thread_id](); });
+            else
+                tasks[thread_id]();
+        }
+    }
+    catch (...)
+    {
+        /// If this is not done, then in case of an exception, tasks will be destroyed before the threads are completed, and it will be bad.
+        if (thread_pool)
+            thread_pool->wait();
+
+        throw;
+    }
+
+    if (thread_pool)
+        thread_pool->wait();
+
+    BlocksList blocks;
+    for (auto & task : tasks)
+    {
+        if (!task.valid())
+            continue;
+
+        blocks.splice(blocks.end(), task.get_future().get());
+    }
+
+    return blocks;
+}
 
 template <typename Method>
 void Aggregator::writeToTemporaryFileImpl(
@@ -1379,14 +1529,14 @@ void Aggregator::writeToTemporaryFileImpl(
 
     for (auto bucket : method.data.buckets())
     {
-        Block block = convertOneBucketToBlock(data_variants, method, data_variants.aggregates_pool, false, ConvertAction::WRITE_TO_TEMP_FS, bucket);
+        Block block = convertOneBucketToBlockImpl(data_variants, method, data_variants.aggregates_pool, false, false, bucket);
         out.write(block);
         update_max_sizes(block);
     }
 
     if (params.overflow_row)
     {
-        Block block = prepareBlockAndFillWithoutKey(data_variants, false, true, ConvertAction::WRITE_TO_TEMP_FS);
+        Block block = prepareBlockAndFillWithoutKey(data_variants, false, true, false);
         out.write(block);
         update_max_sizes(block);
     }
@@ -1435,7 +1585,7 @@ void Aggregator::convertToBlockImpl(
     MutableColumns & final_aggregate_columns,
     Arena * arena,
     bool final,
-    ConvertAction action) const
+    bool clear_states) const
 {
     if (data.empty())
         return;
@@ -1454,12 +1604,12 @@ void Aggregator::convertToBlockImpl(
         if (compiled_aggregate_functions_holder)
         {
             static constexpr bool use_compiled_functions = !Method::low_cardinality_optimization;
-            convertToBlockImplFinal<Method, use_compiled_functions>(method, data, std::move(raw_key_columns), final_aggregate_columns, arena, action);
+            convertToBlockImplFinal<Method, use_compiled_functions>(method, data, std::move(raw_key_columns), final_aggregate_columns, arena, clear_states);
         }
         else
 #endif
         {
-            convertToBlockImplFinal<Method, false>(method, data, std::move(raw_key_columns), final_aggregate_columns, arena, action);
+            convertToBlockImplFinal<Method, false>(method, data, std::move(raw_key_columns), final_aggregate_columns, arena, clear_states);
         }
     }
     else
@@ -1469,7 +1619,7 @@ void Aggregator::convertToBlockImpl(
 
     /// In order to release memory early.
     /// proton: starts. For streaming aggr, we hold on to the states
-    if (shouldClearStates(action, final))
+    if (clear_states)
         data.clearAndShrink();
     /// proton: ends
 }
@@ -1559,7 +1709,7 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
     std::vector<IColumn *>  key_columns,
     MutableColumns & final_aggregate_columns,
     Arena * arena,
-    ConvertAction action) const
+    bool clear_states) const
 {
     if constexpr (Method::low_cardinality_optimization)
     {
@@ -1576,7 +1726,6 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
     PaddedPODArray<AggregateDataPtr> places;
     places.reserve(data.size());
 
-    auto clear_states = shouldClearStates(action, true);
     data.forEachValue([&](const auto & key, auto & mapped)
     {
         /// Ingore invalid mapped, there are two cases:
@@ -1785,7 +1934,7 @@ template <typename Filler>
 Block Aggregator::prepareBlockAndFill(
     AggregatedDataVariants & data_variants,
     bool final,
-    ConvertAction action,
+    bool clear_states,
     size_t rows,
     Filler && filler) const
 {
@@ -1847,7 +1996,7 @@ Block Aggregator::prepareBlockAndFill(
         }
     }
 
-    filler(key_columns, aggregate_columns_data, final_aggregate_columns, final, action);
+    filler(key_columns, aggregate_columns_data, final_aggregate_columns, final, clear_states);
 
     Block res = header.cloneEmpty();
 
@@ -1868,11 +2017,6 @@ Block Aggregator::prepareBlockAndFill(
     for (size_t i = 0; i < columns; ++i)
         if (isColumnConst(*res.getByPosition(i).column))
             res.getByPosition(i).column = res.getByPosition(i).column->cut(0, rows);
-
-    /// proton: starts
-    if (shouldClearStates(action, final))
-        clearDataVariants(data_variants);
-    /// proton: ends
 
     return res;
 }
@@ -1917,7 +2061,7 @@ void Aggregator::createStatesAndFillKeyColumnsWithSingleKey(
     }
 }
 
-Block Aggregator::prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_variants, bool final, bool is_overflows, ConvertAction action) const
+Block Aggregator::prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_variants, bool final, bool is_overflows, bool clear_states) const
 {
     /// proton: starts.
     if (!data_variants.without_key)
@@ -1934,7 +2078,7 @@ Block Aggregator::prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_va
         AggregateColumnsData & aggregate_columns,
         MutableColumns & final_aggregate_columns,
         bool final_,
-        ConvertAction action_)
+        bool clear_states_)
     {
         if (data_variants.type == AggregatedDataVariants::Type::without_key || params.overflow_row)
         {
@@ -1949,7 +2093,7 @@ Block Aggregator::prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_va
                     aggregate_columns[i]->push_back(data + offsets_of_aggregate_states[i]);
 
                 /// proton: starts
-                if (shouldClearStates(action_, final_))
+                if (clear_states_)
                     data = nullptr;
                 /// proton: ends
             }
@@ -1965,7 +2109,7 @@ Block Aggregator::prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_va
         }
     };
 
-    Block block = prepareBlockAndFill(data_variants, final, action, rows, filler);
+    Block block = prepareBlockAndFill(data_variants, final, clear_states, rows, filler);
 
     if (is_overflows)
         block.info.is_overflows = true;
@@ -1973,7 +2117,7 @@ Block Aggregator::prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_va
     return block;
 }
 
-Block Aggregator::prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final, ConvertAction action) const
+Block Aggregator::prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final, bool clear_states) const
 {
     size_t rows = data_variants.sizeWithoutOverflowRow();
 
@@ -1982,12 +2126,12 @@ Block Aggregator::prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_v
         AggregateColumnsData & aggregate_columns,
         MutableColumns & final_aggregate_columns,
         bool final_,
-        ConvertAction action_)
+        bool clear_states_)
     {
     #define M(NAME) \
         else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
             convertToBlockImpl(*data_variants.NAME, data_variants.NAME->data, \
-                key_columns, aggregate_columns, final_aggregate_columns, data_variants.aggregates_pool, final_, action_);
+                key_columns, aggregate_columns, final_aggregate_columns, data_variants.aggregates_pool, final_, clear_states_);
 
         if (false) {} // NOLINT
         APPLY_FOR_VARIANTS_SINGLE_LEVEL_STREAMING(M)
@@ -1996,11 +2140,11 @@ Block Aggregator::prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_v
             throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
     };
 
-    return prepareBlockAndFill(data_variants, final, action, rows, filler);
+    return prepareBlockAndFill(data_variants, final, clear_states, rows, filler);
 }
 
 
-BlocksList Aggregator::prepareBlocksAndFillTwoLevel(AggregatedDataVariants & data_variants, bool final, size_t max_threads, ConvertAction action) const
+BlocksList Aggregator::prepareBlocksAndFillTwoLevel(AggregatedDataVariants & data_variants, bool final, size_t max_threads, bool clear_states) const
 {
     std::unique_ptr<ThreadPool> thread_pool;
     if (max_threads > 1 && data_variants.sizeWithoutOverflowRow() > 100000 /// TODO Make a custom threshold.
@@ -2009,7 +2153,7 @@ BlocksList Aggregator::prepareBlocksAndFillTwoLevel(AggregatedDataVariants & dat
 
 #define M(NAME) \
     else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-        return prepareBlocksAndFillTwoLevelImpl(data_variants, *data_variants.NAME, final, action, thread_pool.get());
+        return prepareBlocksAndFillTwoLevelImpl(data_variants, *data_variants.NAME, final, clear_states, thread_pool.get());
 
     if (false) {} // NOLINT
     APPLY_FOR_VARIANTS_ALL_TWO_LEVEL(M)
@@ -2024,7 +2168,7 @@ BlocksList Aggregator::prepareBlocksAndFillTwoLevelImpl(
     AggregatedDataVariants & data_variants,
     Method & method,
     bool final,
-    ConvertAction action,
+    bool clear_states,
     ThreadPool * thread_pool) const
 {
     size_t max_threads = thread_pool ? thread_pool->getMaxThreads() : 1;
@@ -2059,7 +2203,7 @@ BlocksList Aggregator::prepareBlocksAndFillTwoLevelImpl(
 
             /// Select Arena to avoid race conditions
             Arena * arena = data_variants.aggregates_pools.at(thread_id).get();
-            blocks.emplace_back(convertOneBucketToBlock(data_variants, method, arena, final, action, bucket));
+            blocks.emplace_back(convertOneBucketToBlockImpl(data_variants, method, arena, final, clear_states, bucket));
         }
         return blocks;
     };
@@ -2119,22 +2263,29 @@ BlocksList Aggregator::convertToBlocks(AggregatedDataVariants & data_variants, b
     if (data_variants.empty())
         return blocks;
 
+    bool clear_states = shouldClearStates(action, final);
+
     if (data_variants.without_key)
         /// When without_key is setup, it doesn't necessary mean no GROUP BY keys, it may be overflow
         blocks.emplace_back(prepareBlockAndFillWithoutKey(
-            data_variants, final, data_variants.type != AggregatedDataVariants::Type::without_key, action));
+            data_variants, final, data_variants.type != AggregatedDataVariants::Type::without_key, clear_states));
 
     if (data_variants.type != AggregatedDataVariants::Type::without_key)
     {
         if (data_variants.isTwoLevel())
-            blocks.splice(blocks.end(), prepareBlocksAndFillTwoLevel(data_variants, final, max_threads, action));
+            blocks.splice(blocks.end(), prepareBlocksAndFillTwoLevel(data_variants, final, max_threads, clear_states));
         else
-            blocks.emplace_back(prepareBlockAndFillSingleLevel(data_variants, final, action));
+            blocks.emplace_back(prepareBlockAndFillSingleLevel(data_variants, final, clear_states));
     }
 
     /// proton: starts.
-    if (shouldClearStates(action, final))
+    if (clear_states)
+    {
+        /// `data_variants` will not destroy the states of aggregate functions in the destructor,
+        /// since already cleared up in `prepareBlocksAndFill...()`
         data_variants.aggregator = nullptr;
+        clearDataVariants(data_variants);
+    }
     /// proton: ends
 
     size_t rows = 0;
@@ -2365,12 +2516,9 @@ void NO_INLINE Aggregator::mergeDataOnlyExistingKeysImpl(
 }
 
 
-void NO_INLINE Aggregator::mergeWithoutKeyDataImpl(
-    ManyAggregatedDataVariants & non_empty_data, ConvertAction action) const
+void NO_INLINE Aggregator::mergeWithoutKeyDataImpl(ManyAggregatedDataVariants & non_empty_data, bool clear_states) const
 {
     AggregatedDataVariantsPtr & res = non_empty_data[0];
-
-    auto clear_states = shouldClearStates(action, true);
 
     /// We merge all aggregation results to the first.
     for (size_t result_num = 1, size = non_empty_data.size(); result_num < size; ++result_num)
@@ -2383,13 +2531,10 @@ void NO_INLINE Aggregator::mergeWithoutKeyDataImpl(
 
 
 template <typename Method>
-void NO_INLINE Aggregator::mergeSingleLevelDataImpl(
-    ManyAggregatedDataVariants & non_empty_data, ConvertAction action) const
+void NO_INLINE Aggregator::mergeSingleLevelDataImpl(ManyAggregatedDataVariants & non_empty_data, bool clear_states) const
 {
     AggregatedDataVariantsPtr & res = non_empty_data[0];
     bool no_more_keys = false;
-
-    auto clear_states = shouldClearStates(action, true);
 
     /// We merge all aggregation results to the first.
     for (size_t result_num = 1, size = non_empty_data.size(); result_num < size; ++result_num)
@@ -2450,16 +2595,14 @@ void NO_INLINE Aggregator::mergeSingleLevelDataImpl(
 
 #define M(NAME) \
     template void NO_INLINE Aggregator::mergeSingleLevelDataImpl<decltype(AggregatedDataVariants::NAME)::element_type>( \
-        ManyAggregatedDataVariants & non_empty_data, ConvertAction action) const;
+        ManyAggregatedDataVariants & non_empty_data, bool clear_states) const;
     APPLY_FOR_VARIANTS_SINGLE_LEVEL_STREAMING(M)
 #undef M
 
 template <typename Method>
 void NO_INLINE Aggregator::mergeBucketImpl(
-    ManyAggregatedDataVariants & data, bool final, ConvertAction action, size_t bucket, Arena * arena, std::atomic<bool> * is_cancelled) const
+    ManyAggregatedDataVariants & data, bool final, bool clear_states, Int64 bucket, Arena * arena, std::atomic<bool> * is_cancelled) const
 {
-    auto clear_states = shouldClearStates(action, final);
-
     /// We merge all aggregation results to the first.
     AggregatedDataVariantsPtr & res = data[0];
     for (size_t result_num = 1, size = data.size(); result_num < size; ++result_num)
@@ -2492,7 +2635,7 @@ void NO_INLINE Aggregator::mergeBucketImpl(
 ManyAggregatedDataVariantsPtr Aggregator::prepareVariantsToMerge(ManyAggregatedDataVariants & data_variants, bool always_merge_into_empty) const
 {
     if (data_variants.empty())
-        throw Exception("Empty data passed to Aggregator::mergeAndConvertToBlocks.", ErrorCodes::EMPTY_DATA_PASSED);
+        throw Exception("Empty data passed to Aggregator::prepareVariantsToMerge.", ErrorCodes::EMPTY_DATA_PASSED);
 
     LOG_TRACE(log, "Merging aggregated data");
 
@@ -2513,9 +2656,7 @@ ManyAggregatedDataVariantsPtr Aggregator::prepareVariantsToMerge(ManyAggregatedD
         /// at position 0.
         auto result_variants = std::make_shared<AggregatedDataVariants>(false);
         result_variants->aggregator = this;
-        result_variants->keys_size = params.keys_size;
-        result_variants->key_sizes = key_sizes;
-        result_variants->init(method_chosen);
+        initDataVariants(*result_variants, method_chosen, key_sizes, params);
         initStatesForWithoutKeyOrOverflow(*result_variants);
         non_empty_data->insert(non_empty_data->begin(), result_variants);
     }
@@ -2712,57 +2853,7 @@ bool Aggregator::mergeOnBlock(Block block, AggregatedDataVariants & result, bool
     else if (result.type != AggregatedDataVariants::Type::without_key)
         throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
 
-    size_t result_size = result.sizeWithoutOverflowRow();
-    Int64 current_memory_usage = 0;
-    if (auto * memory_tracker_child = CurrentThread::getMemoryTracker())
-        if (auto * memory_tracker = memory_tracker_child->getParent())
-            current_memory_usage = memory_tracker->get();
-
-    /// Here all the results in the sum are taken into account, from different threads.
-    auto result_size_bytes = current_memory_usage - memory_usage_before_aggregation;
-
-    bool worth_convert_to_two_level
-        = (params.group_by_two_level_threshold && result_size >= params.group_by_two_level_threshold)
-        || (params.group_by_two_level_threshold_bytes && result_size_bytes >= static_cast<Int64>(params.group_by_two_level_threshold_bytes));
-
-    /** Converting to a two-level data structure.
-      * It allows you to make, in the subsequent, an effective merge - either economical from memory or parallel.
-      */
-    if (result.isConvertibleToTwoLevel() && worth_convert_to_two_level)
-        result.convertToTwoLevel();
-
-    /// Checking the constraints.
-    if (!checkLimits(result_size, no_more_keys))
-        return false;
-
-    /** Flush data to disk if too much RAM is consumed.
-      * Data can only be flushed to disk if a two-level aggregation structure is used.
-      */
-    if (params.max_bytes_before_external_group_by
-        && result.isTwoLevel()
-        && current_memory_usage > static_cast<Int64>(params.max_bytes_before_external_group_by)
-        && worth_convert_to_two_level)
-    {
-        size_t size = current_memory_usage + params.min_free_disk_space;
-
-        std::string tmp_path = params.tmp_volume->getDisk()->getPath();
-
-        // enoughSpaceInDirectory() is not enough to make it right, since
-        // another process (or another thread of aggregator) can consume all
-        // space.
-        //
-        // But true reservation (IVolume::reserve()) cannot be used here since
-        // current_memory_usage does not take compression into account and
-        // will reserve way more that actually will be used.
-        //
-        // Hence, let's do a simple check.
-        if (!enoughSpaceInDirectory(tmp_path, size))
-            throw Exception("Not enough space for external aggregation in " + tmp_path, ErrorCodes::NOT_ENOUGH_SPACE);
-
-        writeToTemporaryFile(result, tmp_path);
-    }
-
-    return true;
+    return checkAndProcessResult(result, no_more_keys);
 }
 
 
@@ -2935,9 +3026,7 @@ Block Aggregator::mergeBlocks(BlocksList & blocks, bool final, ConvertAction act
     result.aggregator = this;
 
     /// proton: starts
-    result.keys_size = params.keys_size;
-    result.key_sizes = key_sizes;
-    result.init(merge_method);
+    initDataVariants(result, method_chosen, key_sizes, params);
     /// proton: ends
 
     for (Block & block : blocks)
@@ -2958,17 +3047,13 @@ Block Aggregator::mergeBlocks(BlocksList & blocks, bool final, ConvertAction act
             throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
     }
 
+    bool clear_states = shouldClearStates(action, final);
     Block block;
     if (result.type == AggregatedDataVariants::Type::without_key || is_overflows)
-        block = prepareBlockAndFillWithoutKey(result, final, is_overflows, action);
+        block = prepareBlockAndFillWithoutKey(result, final, is_overflows, clear_states);
     else
-        block = prepareBlockAndFillSingleLevel(result, final, action);
+        block = prepareBlockAndFillSingleLevel(result, final, clear_states);
     /// NOTE: two-level data is not possible here - chooseAggregationMethod chooses only among single-level methods.
-
-    /// proton : starts
-    if (shouldClearStates(action, final))
-        result.aggregator = nullptr;
-    /// proton : ends
 
     size_t rows = block.rows();
     size_t bytes = block.bytes();
@@ -3679,7 +3764,7 @@ void NO_INLINE Aggregator::spliceBucketsImpl(
     AggregatedDataVariants & data_dest,
     AggregatedDataVariants & data_src,
     bool final,
-    ConvertAction action,
+    bool clear_states,
     const std::vector<Int64> & gcd_buckets,
     Arena * arena) const
 {
@@ -3712,7 +3797,6 @@ void NO_INLINE Aggregator::spliceBucketsImpl(
         }
     };
 
-    auto clear_states = shouldClearStates(action, final);
     auto & table_dest = getDataVariant<Method>(data_dest).data.impls;
     auto & table_src = getDataVariant<Method>(data_src).data.impls;
 
@@ -3735,20 +3819,18 @@ Block Aggregator::spliceAndConvertBucketsToBlock(
 {
     AggregatedDataVariants result_variants;
     result_variants.aggregator = this;
-    result_variants.keys_size = params.keys_size;
-    result_variants.key_sizes = key_sizes;
-    result_variants.init(method_chosen);
+    initDataVariants(result_variants, method_chosen, key_sizes, params);
     initStatesForWithoutKeyOrOverflow(result_variants);
 
     auto method = result_variants.type;
     Arena * arena = result_variants.aggregates_pool;
-
+    bool clear_states = shouldClearStates(action, final);
     if (false) {} // NOLINT
 #define M(NAME) \
     else if (method == AggregatedDataVariants::Type::NAME) \
     { \
-        spliceBucketsImpl<decltype(result_variants.NAME)::element_type>(result_variants, variants, final, action, gcd_buckets, arena); \
-        return convertOneBucketToBlock(result_variants, *result_variants.NAME, arena, final, action, 0); \
+        spliceBucketsImpl<decltype(result_variants.NAME)::element_type>(result_variants, variants, final, clear_states, gcd_buckets, arena); \
+        return convertOneBucketToBlockImpl(result_variants, *result_variants.NAME, arena, final, clear_states, 0); \
     }
 
     APPLY_FOR_VARIANTS_TIME_BUCKET_TWO_LEVEL(M)
@@ -3759,23 +3841,39 @@ Block Aggregator::spliceAndConvertBucketsToBlock(
     UNREACHABLE();
 }
 
-void Aggregator::mergeBuckets(
-    ManyAggregatedDataVariants & variants, Arena * arena, bool final, ConvertAction action, const std::vector<Int64> & buckets) const
+Block Aggregator::mergeAndSpliceAndConvertBucketsToBlock(
+    ManyAggregatedDataVariants & variants, bool final, ConvertAction action, const std::vector<Int64> & gcd_buckets) const
 {
-    auto & merge_data = *variants[0];
+    auto prepared_data = prepareVariantsToMerge(variants);
+    if (prepared_data->empty())
+        return {};
+
+    AggregatedDataVariants result_variants;
+    result_variants.aggregator = this;
+    initDataVariants(result_variants, method_chosen, key_sizes, params);
+    initStatesForWithoutKeyOrOverflow(result_variants);
+
+    auto method = result_variants.type;
+    Arena * arena = result_variants.aggregates_pool;
+    bool clear_states = shouldClearStates(action, final);
 
     if (false) {} // NOLINT
 #define M(NAME) \
-    else if (merge_data.type == AggregatedDataVariants::Type::NAME) \
+    else if (method == AggregatedDataVariants::Type::NAME) \
     { \
-        for (auto bucket : buckets) \
-            mergeBucketImpl<decltype(merge_data.NAME)::element_type>(variants, final, action, bucket, arena); \
+        using Method = decltype(result_variants.NAME)::element_type; \
+        for (auto bucket : gcd_buckets) \
+            mergeBucketImpl<Method>(*prepared_data, final, clear_states, bucket, arena); \
+        spliceBucketsImpl<Method>(result_variants, *prepared_data->at(0), final, clear_states, gcd_buckets, arena); \
+        return convertOneBucketToBlockImpl(result_variants, *result_variants.NAME, arena, final, clear_states, 0); \
     }
 
     APPLY_FOR_VARIANTS_TIME_BUCKET_TWO_LEVEL(M)
+#undef M
     else
         throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
-#undef M
+
+    UNREACHABLE();
 }
 
 template <typename Method>
@@ -3924,7 +4022,6 @@ std::pair<bool, bool> Aggregator::executeAndRetractOnBlock(
     AggregateFunctionInstructions aggregate_functions_instructions;
     prepareAggregateInstructions(columns, aggregate_columns, materialized_columns, aggregate_functions_instructions, nested_columns_holder);
 
-    assert(!result.isTwoLevel());
     assert(!params.overflow_row && !no_more_keys);
 
     retracted_result.aggregator = this;
@@ -3951,6 +4048,9 @@ std::pair<bool, bool> Aggregator::executeAndRetractOnBlock(
         if (retracted_result.empty())
             initDataVariants(retracted_result, method_chosen, key_sizes, params);
 
+        if (result.isTwoLevel() && !retracted_result.isTwoLevel())
+            retracted_result.convertToTwoLevel();
+
         #define M(NAME, IS_TWO_LEVEL) \
             else if (result.type == AggregatedDataVariants::Type::NAME) \
                 need_finalization = executeAndRetractImpl(*result.NAME, result.aggregates_pool, *retracted_result.NAME, retracted_result.aggregates_pool, row_begin, row_end, key_columns, aggregate_functions_instructions.data());
@@ -3961,23 +4061,44 @@ std::pair<bool, bool> Aggregator::executeAndRetractOnBlock(
     }
 
     need_abort = checkAndProcessResult(result, no_more_keys);
+    /// it's possible for gloabl single level hash table was converted to two level table after `checkAndProcessResult`,
+    /// so we also convert retarcted data to two level.
+    if (result.isTwoLevel() && !retracted_result.isTwoLevel())
+        retracted_result.convertToTwoLevel();
+
     return return_result;
 }
 
-void Aggregator::mergeRetractedGroups(ManyAggregatedDataVariants & aggregated_data, ManyAggregatedDataVariants & retracted_data) const
+std::pair<AggregatedDataVariantsPtr, AggregatedDataVariantsPtr>
+Aggregator::mergeRetractedGroups(ManyAggregatedDataVariants & aggregated_data, ManyAggregatedDataVariants & retracted_data) const
 {
-    auto first = aggregated_data[0];
-#define M(NAME) \
-    else if (first->type == AggregatedDataVariants::Type::NAME) \
-        mergeRetractedGroupsImpl<decltype(first->NAME)::element_type>(aggregated_data, retracted_data);
+    auto prepared_data = prepareVariantsToMerge(aggregated_data, /*always_merge_into_empty*/ true);
+    if (prepared_data->empty())
+        return {};
 
-    if (false)
+    auto first = prepared_data->at(0);
+
+    auto prepared_retracted_data = prepareVariantsToMerge(retracted_data, first->type != AggregatedDataVariants::Type::without_key);
+    assert(!prepared_retracted_data->empty());
+
+    /// So far, only global aggregation support emit changelog, so time bucket two level is not possible
+
+#define M(NAME, ...) \
+    else if (first->type == AggregatedDataVariants::Type::NAME) \
+        mergeRetractedGroupsImpl<decltype(first->NAME)::element_type>(*prepared_data, *prepared_retracted_data);
+
+    if (first->type == AggregatedDataVariants::Type::without_key)
     {
-    } // NOLINT
+        mergeWithoutKeyDataImpl(*prepared_retracted_data, true);
+        mergeWithoutKeyDataImpl(*prepared_data, false);
+    }
     APPLY_FOR_VARIANTS_SINGLE_LEVEL_STREAMING(M)
+    APPLY_FOR_VARIANTS_STATIC_BUCKET_TWO_LEVEL(M)
 #undef M
     else
         throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
+
+    return {prepared_data->at(0), prepared_retracted_data->at(0)};
 }
 
 template <typename Method>

--- a/src/Interpreters/Streaming/Aggregator.h
+++ b/src/Interpreters/Streaming/Aggregator.h
@@ -739,6 +739,26 @@ public:
         ColumnRawPtrs & key_columns, AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
         bool & no_more_keys) const;
 
+    /// Execute and retracted state for changed groups:
+    /// 1) For new group:
+    ///     @p retracted_result: add an elem <group_key, null> if not exists
+    ///     @p result:           add an elem <group_key, curent_state>
+    /// 2) For updated group:
+    ///     @p retracted_result: add an elem <group_key, last_state> if not exists
+    ///     @p result:           update the elem <group_key, curent_state>
+    /// 3) For deleted group:
+    ///     @p retracted_result: add an elem <group_key, last_state> if not exists
+    ///     @p result:           delete the <group_key> group
+    std::pair<bool, bool> executeAndRetractOnBlock(
+        Columns columns,
+        size_t row_begin,
+        size_t row_end,
+        AggregatedDataVariants & result,
+        AggregatedDataVariants & retracted_result,
+        ColumnRawPtrs & key_columns,
+        AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
+        bool & no_more_keys) const;
+
     bool mergeOnBlock(Block block, AggregatedDataVariants & result, bool & no_more_keys) const;
 
     /** Convert the aggregation data structure into a block.
@@ -765,19 +785,27 @@ public:
       *          );
       */
     BlocksList convertToBlocks(AggregatedDataVariants & data_variants, bool final, ConvertAction action, size_t max_threads) const;
+    BlocksList mergeAndConvertToBlocks(ManyAggregatedDataVariants & data_variants, bool final, ConvertAction action, size_t max_threads) const;
 
-    BlocksList convertToBlocksFinal(AggregatedDataVariants & data_variants, ConvertAction action, size_t max_threads) const
-    {
-        return convertToBlocks(data_variants, true, action, max_threads);
-    }
+    Block convertOneBucketToBlock(AggregatedDataVariants & data_variants, bool final, ConvertAction action, size_t bucket) const;
+    Block mergeAndConvertOneBucketToBlock(ManyAggregatedDataVariants & variants, bool final, ConvertAction action, size_t bucket) const;
 
-    BlocksList convertToBlocksIntermediate(AggregatedDataVariants & data_variants, ConvertAction action, size_t max_threads) const
-    {
-        return convertToBlocks(data_variants, false, action, max_threads);
-    }
+    /// Used for hop window function, merge multiple gcd windows (buckets) to a hop window
+    /// For examples:
+    ///   gcd_bucket1 - [00:00, 00:02)
+    ///                            =>  result block - [00:00, 00:04)
+    ///   gcd_bucket2 - [00:02, 00:04)
+    Block spliceAndConvertBucketsToBlock(
+        AggregatedDataVariants & variants, bool final, ConvertAction action, const std::vector<Int64> & gcd_buckets) const;
+    Block mergeAndSpliceAndConvertBucketsToBlock(
+        ManyAggregatedDataVariants & variants, bool final, ConvertAction action, const std::vector<Int64> & gcd_buckets) const;
 
-    Block convertOneBucketToBlockFinal(AggregatedDataVariants & data_variants, ConvertAction action, size_t bucket) const;
-    Block convertOneBucketToBlockIntermediate(AggregatedDataVariants & data_variants, ConvertAction action, size_t bucket) const;
+    /// Used for merge changed groups into first one (retracted and aggregated)
+    std::pair<AggregatedDataVariantsPtr, AggregatedDataVariantsPtr>
+    mergeRetractedGroups(ManyAggregatedDataVariants & aggregated_data, ManyAggregatedDataVariants & retracted_data) const;
+
+    std::vector<Int64> bucketsBefore(const AggregatedDataVariants & result, Int64 max_bucket) const;
+    void removeBucketsBefore(AggregatedDataVariants & result, Int64 max_bucket) const;
 
     /// If @p always_merge_into_empty is true, always add an empty variants at front even if there is only one 
     ManyAggregatedDataVariantsPtr prepareVariantsToMerge(ManyAggregatedDataVariants & data_variants, bool always_merge_into_empty = false) const;
@@ -831,27 +859,6 @@ public:
 private:
 
     friend struct AggregatedDataVariants;
-    friend class ConvertingAggregatedToChunksTransform;
-    friend class ConvertingAggregatedToChunksSource;
-    friend class AggregatingInOrderTransform;
-
-    /// proton: starts
-    friend struct AggregatingHelper;
-    friend class StreamingConvertingAggregatedToChunksTransform;
-    friend class StreamingConvertingAggregatedToChunksSource;
-    friend class AggregatingTransform;
-    friend class GlobalAggregatingTransform;
-    friend class GlobalAggregatingTransformWithSubstream;
-    friend class WindowAggregatingTransform;
-    friend class WindowAggregatingTransformWithSubstream;
-    friend class TumbleAggregatingTransform;
-    friend class TumbleAggregatingTransformWithSubstream;
-    friend class HopAggregatingTransform;
-    friend class HopAggregatingTransformWithSubstream;
-    friend class SessionAggregatingTransform;
-    friend class SessionAggregatingTransformWithSubstream;
-    friend class UserDefinedEmitStrategyAggregatingTransform;
-    /// proton: ends
 
     Params params;
 
@@ -1019,12 +1026,10 @@ private:
         Arena * arena,
         bool clear_states) const;
 
-    void mergeWithoutKeyDataImpl(
-        ManyAggregatedDataVariants & non_empty_data, ConvertAction action) const;
+    void mergeWithoutKeyDataImpl(ManyAggregatedDataVariants & non_empty_data, bool clear_states) const;
 
     template <typename Method>
-    void mergeSingleLevelDataImpl(
-        ManyAggregatedDataVariants & non_empty_data, ConvertAction action) const;
+    void mergeSingleLevelDataImpl(ManyAggregatedDataVariants & non_empty_data, bool clear_states) const;
 
     template <typename Method, typename Table>
     void convertToBlockImpl(
@@ -1035,7 +1040,7 @@ private:
         MutableColumns & final_aggregate_columns,
         Arena * arena,
         bool final,
-        ConvertAction action) const;
+        bool clear_states) const;
 
     template <typename Mapped>
     void insertAggregatesIntoColumns(
@@ -1050,7 +1055,7 @@ private:
         std::vector<IColumn *> key_columns,
         MutableColumns & final_aggregate_columns,
         Arena * arena,
-        ConvertAction action) const;
+        bool clear_states) const;
 
     template <typename Method, typename Table>
     void convertToBlockImplNotFinal(
@@ -1063,26 +1068,18 @@ private:
     Block prepareBlockAndFill(
         AggregatedDataVariants & data_variants,
         bool final,
-        ConvertAction action,
+        bool clear_states,
         size_t rows,
         Filler && filler) const;
 
     template <typename Method>
-    Block convertOneBucketToBlock(
+    Block convertOneBucketToBlockImpl(
         AggregatedDataVariants & data_variants,
         Method & method,
         Arena * arena,
         bool final,
-        ConvertAction action,
+        bool clear_states,
         size_t bucket) const;
-
-    Block mergeAndConvertOneBucketToBlock(
-        ManyAggregatedDataVariants & variants,
-        Arena * arena,
-        bool final,
-        ConvertAction action,
-        size_t bucket,
-        std::atomic<bool> * is_cancelled = nullptr) const;
 
     /// proton: starts.
     template <typename Method>
@@ -1090,30 +1087,18 @@ private:
         AggregatedDataVariants & data_dest,
         AggregatedDataVariants & data_src,
         bool final,
-        ConvertAction action,
+        bool clear_states,
         const std::vector<Int64> & gcd_buckets,
         Arena * arena) const;
 
-    /// Used for hop window function, merge multiple gcd windows (buckets) to a hop window
-    /// For examples:
-    ///   gcd_bucket1 - [00:00, 00:02)
-    ///                            =>  result block - [00:00, 00:04)
-    ///   gcd_bucket2 - [00:02, 00:04)
-    Block spliceAndConvertBucketsToBlock(
-        AggregatedDataVariants & variants, bool final, ConvertAction action, const std::vector<Int64> & gcd_buckets) const;
+    template <typename Method>
+    BlocksList mergeAndConvertTwoLevelToBlocksImpl(
+        ManyAggregatedDataVariants & non_empty_data, bool final, size_t max_threads, bool clear_states) const;
 
-    void mergeBuckets(
-        ManyAggregatedDataVariants & variants, Arena * arena, bool final, ConvertAction action, const std::vector<Int64> & buckets) const;
-    
-    /// Used for emit changelog
-    std::pair<bool, bool> executeAndRetractOnBlock(
-        Columns columns,
-        size_t row_begin,
-        size_t row_end,
-        AggregatedDataVariants & result,
-        AggregatedDataVariants & retracted_result,
-        ColumnRawPtrs & key_columns, AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
-        bool & no_more_keys) const;
+    Block mergeAndConvertWithoutKeyToBlock(ManyAggregatedDataVariants & non_empty_data, bool final, bool clear_states) const;
+    Block mergeAndConvertSingleLevelToBlock(ManyAggregatedDataVariants & non_empty_data, bool final, bool clear_states) const;
+    BlocksList
+    mergeAndConvertTwoLevelToBlocks(ManyAggregatedDataVariants & non_empty_data, bool final, size_t max_threads, bool clear_states) const;
 
     template <typename Method>
     bool executeAndRetractImpl(
@@ -1125,8 +1110,6 @@ private:
         size_t row_end,
         ColumnRawPtrs & key_columns,
         AggregateFunctionInstruction * aggregate_instructions) const;
-
-    void mergeRetractedGroups(ManyAggregatedDataVariants & aggregated_data, ManyAggregatedDataVariants & retracted_data) const;
 
     template <typename Method>
     void mergeRetractedGroupsImpl(ManyAggregatedDataVariants & aggregated_data, ManyAggregatedDataVariants & retracted_data) const;
@@ -1144,16 +1127,16 @@ private:
     bool checkAndProcessResult(AggregatedDataVariants & result, bool & no_more_keys) const;
     /// proton: ends.
 
-    Block prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_variants, bool final, bool is_overflows, ConvertAction action) const;
-    Block prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final, ConvertAction action) const;
-    BlocksList prepareBlocksAndFillTwoLevel(AggregatedDataVariants & data_variants, bool final, size_t max_threads, ConvertAction action) const;
+    Block prepareBlockAndFillWithoutKey(AggregatedDataVariants & data_variants, bool final, bool is_overflows, bool clear_states) const;
+    Block prepareBlockAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final, bool clear_states) const;
+    BlocksList prepareBlocksAndFillTwoLevel(AggregatedDataVariants & data_variants, bool final, size_t max_threads, bool clear_states) const;
 
     template <typename Method>
     BlocksList prepareBlocksAndFillTwoLevelImpl(
         AggregatedDataVariants & data_variants,
         Method & method,
         bool final,
-        ConvertAction action,
+        bool clear_states,
         ThreadPool * thread_pool) const;
 
     template <bool no_more_keys, typename Method, typename Table>
@@ -1179,7 +1162,7 @@ private:
 
     template <typename Method>
     void mergeBucketImpl(
-        ManyAggregatedDataVariants & data, bool final, ConvertAction action, size_t bucket, Arena * arena, std::atomic<bool> * is_cancelled = nullptr) const;
+        ManyAggregatedDataVariants & data, bool final, bool clear_states, Int64 bucket, Arena * arena, std::atomic<bool> * is_cancelled = nullptr) const;
 
     template <typename Method>
     void convertBlockToTwoLevelImpl(
@@ -1226,8 +1209,6 @@ private:
 
     /// proton: starts
     void setupAggregatesPoolTimestamps(size_t row_begin, size_t row_end, const ColumnRawPtrs & key_columns, Arena * aggregates_pool) const;
-    void removeBucketsBefore(AggregatedDataVariants & result, Int64 max_bucket) const;
-    std::vector<Int64> bucketsBefore(const AggregatedDataVariants & result, Int64 max_bucket) const;
 
     inline bool shouldClearStates(ConvertAction action, bool final_) const;
 

--- a/src/Interpreters/Streaming/Aggregator.h
+++ b/src/Interpreters/Streaming/Aggregator.h
@@ -741,15 +741,15 @@ public:
 
     /// Execute and retract state for changed groups:
     /// 1) For new group:
-    ///     @p retracted_result: add an elem <group_key, null> if not exists
-    ///     @p result:           add an elem <group_key, curent_state>
+    ///     \retracted_result: add an elem <group_key, null> if not exists
+    ///     \result:           add an elem <group_key, curent_state>
     /// 2) For updated group:
-    ///     @p retracted_result: add an elem <group_key, last_state> if not exists
-    ///     @p result:           update the elem <group_key, curent_state>
+    ///     \retracted_result: add an elem <group_key, last_state> if not exists
+    ///     \result:           update the elem <group_key, curent_state>
     /// 3) For deleted group:
-    ///     @p retracted_result: add an elem <group_key, last_state> if not exists
-    ///     @p result:           delete the <group_key> group
-    /// @return {should_abort, need_finalization} pair
+    ///     \retracted_result: add an elem <group_key, last_state> if not exists
+    ///     \result:           delete the <group_key> group
+    /// \returns {should_abort, need_finalization} bool pair
     /// should_abort: if the processing should be aborted (with group_by_overflow_mode = 'break') return true, otherwise false.
     /// need_finalization : only for UDA aggregation. If there is no UDA, always false
     std::pair<bool, bool> executeAndRetractOnBlock(

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -183,6 +183,14 @@ void Chunk::append(const Chunk & chunk)
     setColumns(std::move(mutation), rows);
 }
 
+void Chunk::append(Chunk && chunk)
+{
+    if (!hasColumns())
+        this->operator=(std::move(chunk));
+    else
+        append(chunk);
+}
+
 void ChunkMissingValues::setBit(size_t column_idx, size_t row_idx)
 {
     RowsBitMask & mask = rows_mask_by_column_id[column_idx];

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -186,7 +186,7 @@ void Chunk::append(const Chunk & chunk)
 void Chunk::append(Chunk && chunk)
 {
     if (!hasColumns())
-        this->operator=(std::move(chunk));
+        *this = std::move(chunk);
     else
         append(chunk);
 }

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -199,6 +199,7 @@ public:
     std::string dumpStructure() const;
 
     void append(const Chunk & chunk);
+    void append(Chunk && chunk);
 
     /// proton : starts
     bool hasWatermark() const { return chunk_ctx && chunk_ctx->hasWatermark(); }

--- a/src/Processors/QueryPlan/Streaming/AggregatingStepWithSubstream.cpp
+++ b/src/Processors/QueryPlan/Streaming/AggregatingStepWithSubstream.cpp
@@ -57,6 +57,10 @@ void AggregatingStepWithSubstream::transformPipeline(QueryPipelineBuilder & pipe
     /// Forget about current totals and extremes. They will be calculated again after aggregation if needed.
     pipeline.dropTotalsAndExtremes();
 
+    /// Disable convert to two level group by, since the input stream already is shuffled substream data.
+    params.group_by_two_level_threshold = 0;
+    params.group_by_two_level_threshold_bytes = 0;
+
     auto transform_params = std::make_shared<AggregatingTransformParams>(std::move(params), final, emit_version, emit_changelog);
 
     /// If there are several sources, we perform aggregation separately (Assume it's shuffled data by substream keys)

--- a/src/Processors/Transforms/Streaming/AggregatingHelper.h
+++ b/src/Processors/Transforms/Streaming/AggregatingHelper.h
@@ -39,7 +39,11 @@ Chunk mergeAndSpliceAndConvertBucketsToChunk(
 
 /// Only used for emit changelog
 /// @brief Based on new/updated groups @p retracted_data , only convert the state of changed groups (retracted: last state, aggregated: current state)
+/// @p data: current aggregated state of all groups
+/// @p retracted_data: only have last state of changed groups (i.e. new/updated/deleted)
 /// @return <retracted_chunk, aggregated_chunk>
+/// retracted_chunk: just contains retracted data of changed groups
+/// aggregated_chunk: just contains aggregated data of changed groups
 ChunkPair
 convertToChangelogChunk(AggregatedDataVariants & data, RetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
 ChunkPair mergeAndConvertToChangelogChunk(

--- a/src/Processors/Transforms/Streaming/AggregatingHelper.h
+++ b/src/Processors/Transforms/Streaming/AggregatingHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <base/types.h>
+
 #include <vector>
 
 namespace DB
@@ -20,25 +22,29 @@ using ManyRetractedDataVariants = ManyAggregatedDataVariants;
 
 using ChunkPair = std::pair<Chunk, Chunk>;
 
-struct AggregatingHelper
+namespace AggregatingHelper
 {
-    static Chunk convertWithoutKey(AggregatedDataVariants & data, const AggregatingTransformParams & params);
-    static Chunk mergeAndConvertWithoutKey(ManyAggregatedDataVariants & data, const AggregatingTransformParams & params);
+/// Convert aggregated state to chunk
+Chunk convertToChunk(AggregatedDataVariants & data, const AggregatingTransformParams & params);
+/// Merge many aggregated state and convert them to chunk
+Chunk mergeAndConvertToChunk(ManyAggregatedDataVariants & data, const AggregatingTransformParams & params);
 
-    static Chunk convertSingleLevel(AggregatedDataVariants & data, const AggregatingTransformParams & params);
-    static Chunk mergeAndConvertSingleLevel(ManyAggregatedDataVariants & data, const AggregatingTransformParams & params);
+/// Only used for two level
+/// splice aggregatd state of multiple buckets and convert them to chunk
+Chunk spliceAndConvertBucketsToChunk(
+    AggregatedDataVariants & data, const AggregatingTransformParams & params, const std::vector<Int64> & buckets);
+/// Merge many aggregated state of multiple threads, then splice aggregatd state of multiple buckets and convert them to chunk
+Chunk mergeAndSpliceAndConvertBucketsToChunk(
+    ManyAggregatedDataVariants & data, const AggregatingTransformParams & params, const std::vector<Int64> & buckets);
 
-    /// Used for emit changelog
-    static ChunkPair convertWithoutKeyToChangelog(
-        AggregatedDataVariants & data, RetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
-    static ChunkPair mergeAndConvertWithoutKeyToChangelog(
-        ManyAggregatedDataVariants & data, ManyRetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
-
-    static ChunkPair convertSingleLevelToChangelog(
-        AggregatedDataVariants & data, RetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
-    static ChunkPair mergeAndConvertSingleLevelToChangelog(
-        ManyAggregatedDataVariants & data, ManyRetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
-};
+/// Only used for emit changelog
+/// @brief Based on new/updated groups @p retracted_data , only convert the state of changed groups (retracted: last state, aggregated: current state)
+/// @return <retracted_chunk, aggregated_chunk>
+ChunkPair
+convertToChangelogChunk(AggregatedDataVariants & data, RetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
+ChunkPair mergeAndConvertToChangelogChunk(
+    ManyAggregatedDataVariants & data, ManyRetractedDataVariants & retracted_data, const AggregatingTransformParams & params);
+}
 
 }
 }

--- a/src/Processors/Transforms/Streaming/AggregatingHelper.h
+++ b/src/Processors/Transforms/Streaming/AggregatingHelper.h
@@ -39,9 +39,9 @@ Chunk mergeAndSpliceAndConvertBucketsToChunk(
 
 /// Only used for emit changelog
 /// @brief Based on new/updated groups @p retracted_data , only convert the state of changed groups (retracted: last state, aggregated: current state)
-/// @p data: current aggregated state of all groups
-/// @p retracted_data: only have last state of changed groups (i.e. new/updated/deleted)
-/// @return <retracted_chunk, aggregated_chunk>
+///  \data: current aggregated state of all groups
+///  \retracted_data: only have last state of changed groups (i.e. new/updated/deleted)
+/// @returns <retracted_chunk, aggregated_chunk>
 /// retracted_chunk: just contains retracted data of changed groups
 /// aggregated_chunk: just contains aggregated data of changed groups
 ChunkPair

--- a/src/Processors/Transforms/Streaming/GlobalAggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/GlobalAggregatingTransform.cpp
@@ -130,7 +130,7 @@ void GlobalAggregatingTransform::finalize(const ChunkContextPtr & chunk_ctx)
         auto [retracted_chunk, chunk] = AggregatingHelper::mergeAndConvertToChangelogChunk(
             many_data->variants, many_data->getField<ManyRetractedDataVariants>(), *params);
 
-            setCurrentChunk(std::move(chunk), chunk_ctx, std::move(retracted_chunk));
+        setCurrentChunk(std::move(chunk), chunk_ctx, std::move(retracted_chunk));
     }
     else
     {

--- a/src/Processors/Transforms/Streaming/GlobalAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/GlobalAggregatingTransformWithSubstream.cpp
@@ -26,7 +26,7 @@ GlobalAggregatingTransformWithSubstream::GlobalAggregatingTransformWithSubstream
 SubstreamContextPtr GlobalAggregatingTransformWithSubstream::getOrCreateSubstreamContext(const SubstreamID & id)
 {
     auto substream_ctx = AggregatingTransformWithSubstream::getOrCreateSubstreamContext(id);
-    if (params->emit_changelog)
+    if (params->emit_changelog && !substream_ctx->hasField())
     {
         if (params->emit_version)
             throw Exception(ErrorCodes::UNSUPPORTED, "'emit_version()' is not supported in global aggregation emit changelog");

--- a/src/Processors/Transforms/Streaming/GlobalAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/GlobalAggregatingTransformWithSubstream.cpp
@@ -84,21 +84,16 @@ void GlobalAggregatingTransformWithSubstream::finalize(const SubstreamContextPtr
     if (variants.empty())
         return;
 
-    assert(variants.type != AggregatedDataVariants::Type::without_key);
-
-    if (unlikely(variants.isTwoLevel()))
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Two level merge is not implemented in global aggregation");
-
     auto start = MonotonicMilliseconds::now();
     if (params->emit_changelog)
     {
         auto [retracted_chunk, chunk]
-            = AggregatingHelper::convertSingleLevelToChangelog(variants, *substream_ctx->getField<RetractedDataVariantsPtr>(), *params);
+            = AggregatingHelper::convertToChangelogChunk(variants, *substream_ctx->getField<RetractedDataVariantsPtr>(), *params);
         setCurrentChunk(std::move(chunk), chunk_ctx, std::move(retracted_chunk));
     }
     else
     {
-        auto chunk = AggregatingHelper::convertSingleLevel(variants, *params);
+        auto chunk = AggregatingHelper::convertToChunk(variants, *params);
         if (params->final && params->emit_version)
             emitVersion(chunk, substream_ctx);
 

--- a/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransform.cpp
@@ -42,12 +42,7 @@ void UserDefinedEmitStrategyAggregatingTransform::finalize(const ChunkContextPtr
     if (variants.empty())
         return;
 
-    Chunk chunk;
-    if (variants.type == AggregatedDataVariants::Type::without_key)
-        chunk = AggregatingHelper::convertWithoutKey(variants, *params);
-    else
-        chunk = AggregatingHelper::convertSingleLevel(variants, *params);
-
+    Chunk chunk = AggregatingHelper::convertToChunk(variants, *params);
     if (params->emit_version && params->final)
         emitVersion(chunk);
 

--- a/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransformWithSubstream.cpp
@@ -30,11 +30,7 @@ void UserDefinedEmitStrategyAggregatingTransformWithSubstream::finalize(const Su
     if (variants.empty())
         return;
 
-    Chunk chunk;
-    if (variants.type == AggregatedDataVariants::Type::without_key)
-        chunk = AggregatingHelper::convertWithoutKey(variants, *params);
-    else
-        chunk = AggregatingHelper::convertSingleLevel(variants, *params);
+    Chunk chunk = AggregatingHelper::convertToChunk(variants, *params);
 
     if (params->emit_version && params->final)
         emitVersion(chunk, substream_ctx);

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransform.h
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransform.h
@@ -32,10 +32,6 @@ protected:
     std::vector<Int64> getBucketsBefore(Int64 max_buckets) const;
 
 private:
-    inline void initialize(ManyAggregatedDataVariantsPtr & data);
-
-    void convertTwoLevel(ManyAggregatedDataVariantsPtr & data, const ChunkContextPtr & chunk_ctx);
-
     virtual WindowsWithBuckets getLocalFinalizedWindowsWithBucketsImpl(Int64 watermark) const = 0;
     virtual void removeBucketsImpl(Int64 watermark) = 0;
     virtual bool needReassignWindow() const = 0;

--- a/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
+++ b/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
@@ -1,0 +1,245 @@
+test_suite_name: two_level_global_aggr
+tag: smoke
+test_suite_config:
+  setup:
+    statements:
+      - client: python
+        query_type: table
+        query: |
+          drop stream if exists test_31_rstream;
+      - client: python
+        query_type: table
+        exist: test_31_rstream
+        exist_wait: 2
+        wait: 1
+        query: |
+          create random stream if not exists test_31_rstream(i int default rand() % 100000 + 1, v string) settings eps=5000;
+
+  tests_2_run:
+    ids_2_run:
+      - all
+    tags_2_run: []
+    tags_2_skip:
+      default:
+        - todo
+        - to_support
+        - change
+        - bug
+        - sample
+      cluster:
+        - view
+        - cluster_table_bug
+comments: Tests covering the historical/streaming query with two level global aggregation smoke cases.
+
+tests:
+  - id: 0
+    tags:
+      - "two level"
+      - "global aggr"
+    name: two-level-global-aggr
+    description: global aggregation query with two level hash table, convering stremaing and historical query
+    steps:
+      - statements:
+        - client: python
+          query_type: stream
+          query_id: 3100
+          depends_on_stream: test_31_rstream
+          wait: 1
+          query_end_timer: 5
+          query: |
+            with cte as (select i % 100 + 1 as key, count() from test_31_rstream group by key settings group_by_two_level_threshold=50, max_block_size=100) select count() from cte limit 1;
+
+        - client: python
+          query_type: table
+          query_id: 3101
+          depends_on_stream: test_31_rstream
+          query: |
+            with cte as (select i % 100 + 1 as key, count() from table(test_31_rstream) group by key settings group_by_two_level_threshold=50, max_block_size=100, max_events=10000) select count() from cte;
+
+    expected_results:
+      - query_id: '3100'
+        expected_results:
+          - [100]
+      - query_id: '3101'
+        expected_results:
+          - [100]
+
+  - id: 1
+    tags:
+      - "global aggr"
+      - "emit changelog"
+      - "changelog aggr"
+    name: two-level-global-aggr
+    description: global aggregation query with two level hash table, covering aggregating changelog and emit changelog 
+    steps:
+      - statements:
+        - client: python
+          query_type: stream
+          query_id: 3100
+          depends_on_stream: test_31_rstream
+          query_end_timer: 5
+          query: |
+            with cte as (select i % 100 + 1 as key, count() from test_31_rstream group by key emit changelog settings group_by_two_level_threshold=50, max_block_size=100) select count() from cte limit 1;
+
+        - client: python
+          query_type: stream
+          query_id: 3101
+          depends_on_stream: test_31_rstream
+          query_end_timer: 5
+          query: |
+            with cte1 as (select i % 100 + 1 as key from test_31_rstream), cte2 as (select key, count() from changelog(cte1, key) group by key emit changelog settings group_by_two_level_threshold=50, max_block_size=100) select count() from cte2 limit 1;
+
+    expected_results:
+      - query_id: '3100'
+        expected_results:
+          - [100]
+      - query_id: '3101'
+        expected_results:
+          - [100]
+
+  - id: 2
+    tags:
+      - "two level"
+      - "global aggr"
+      - "query_state"
+    name: subscribe-and-recover-two-level-global-aggr
+    description: subscribe to two level global aggregation query, then recover from checkpointed.
+    steps:
+      - statements:
+        - client: python
+          query_type: table
+          query: |
+            drop stream if exists test_31_multishards_stream;
+
+        - client: python
+          query_type: table
+          exist: test_31_multishards_stream
+          exist_wait: 2
+          wait: 1
+          query: |
+            create stream if not exists test_31_multishards_stream(i int, v string) settings shards=3;
+
+        - client: python
+          query_type: table
+          depends_on_stream: test_31_multishards_stream
+          wait: 1
+          query: |
+            insert into test_31_multishards_stream(i, v) select i % 100 + 1, v from test_31_rstream settings max_block_size=100, max_events=10000;
+
+        - client: python
+          query_type: stream
+          query_id: 3100
+          depends_on_stream: test_31_multishards_stream
+          query: |
+            subscribe to with cte as (select i as key, count() from test_31_multishards_stream where _tp_time > earliest_ts() group by key settings group_by_two_level_threshold=50) select count() from cte settings checkpoint_interval=2, emit_aggregated_during_backfill=false;
+
+        - client: python
+          query_type: table
+          depends_on: 3100
+          wait: 6
+          query: |
+            kill query where query_id = '3100' sync;
+
+        - client: python
+          query_type: stream
+          query_id: 3100-1
+          depends_on_stream: test_31_multishards_stream
+          wait: 1
+          query: |
+            recover from '3100';
+
+        - client: python
+          query_type: table
+          depends_on_stream: test_31_multishards_stream
+          depends_on: 3100
+          wait: 1
+          query: |
+            insert into test_31_multishards_stream(i, v) values(101, 'test');
+
+        - client: python
+          query_table: table
+          wait: 5
+          query: |
+            unsubscribe to '3100';
+
+    expected_results:
+      - query_id: '3100'
+        expected_results:
+          - [100]
+      - query_id: '3100-1'
+        expected_results:
+          - [101]
+
+  - id: 3
+    tags:
+      - "two level"
+      - "global aggr"
+      - "emit changelog"
+      - "changelog aggr"
+      - "query_state"
+    name: subscribe-and-recover-two-level-global-aggr
+    description: subscribe to two level global aggregation query, then recover from checkpointed.
+    steps:
+      - statements:
+        - client: python
+          query_type: table
+          query: |
+            drop stream if exists test_31_multishards_stream;
+
+        - client: python
+          query_type: table
+          exist: test_31_multishards_stream
+          exist_wait: 2
+          wait: 1
+          query: |
+            create stream if not exists test_31_multishards_stream(i int, v string) settings shards=3;
+
+        - client: python
+          query_type: table
+          depends_on_stream: test_31_multishards_stream
+          wait: 1
+          query: |
+            insert into test_31_multishards_stream(i, v) select i % 100 + 1, v from test_31_rstream settings max_block_size=100, max_events=10000;
+
+        - client: python
+          query_type: stream
+          query_id: 3101
+          depends_on_stream: test_31_multishards_stream
+          wait: 1
+          query: |
+            subscribe to with cte as (select i as key, count() from changelog(test_31_multishards_stream, i) where _tp_time > earliest_ts() group by key emit changelog settings group_by_two_level_threshold=50) select count() from cte settings checkpoint_interval=2, emit_aggregated_during_backfill=false;
+
+        - client: python
+          query_type: table
+          depends_on: 3101
+          wait: 6
+          query: |
+            kill query where query_id = '3101' sync;
+
+        - client: python
+          query_type: stream
+          query_id: 3101-1
+          wait: 1
+          query: |
+            recover from '3101';
+
+        - client: python
+          query_type: table
+          depends_on: 3101
+          wait: 1
+          query: |
+            insert into test_31_multishards_stream(i, v) values(101, 'test');
+
+        - client: python
+          query_table: table
+          wait: 5
+          query: |
+            unsubscribe to '3101';
+
+    expected_results:
+      - query_id: '3101'
+        expected_results:
+          - [100]
+      - query_id: '3101-1'
+        expected_results:
+          - [101]


### PR DESCRIPTION
This resolve #185.

Please write user-readable short description of the changes:
- streaming global aggregation support process two level hash table (include serialization/deserialization)
- define some general logic function to simplify finalizing `AggregatedDataVairants`