### PR TITLE
Bugfix/issue 267 expose grok and users config

### DIFF
--- a/programs/server/embedded.xml
+++ b/programs/server/embedded.xml
@@ -22,18 +22,61 @@
     <mlock_executable>true</mlock_executable>
 
     <users>
-        <default>
-            <password></password>
+      <default>
+        <password></password>
 
-            <networks>
-                <ip>::/0</ip>
-            </networks>
+        <networks>
+          <ip>::/0</ip>
+        </networks>
 
-            <profile>default</profile>
-            <quota>default</quota>
-            <access_management>1</access_management>
-        </default>
+        <profile>default</profile>
+        <quota>default</quota>
+        <allow_databases>
+          <database>default</database>
+        </allow_databases>
+        <default_database>default</default_database>
+      </default>
+      <system>
+        <password>sys@t+</password>
+        <allow_databases>
+          <database>system</database>
+        </allow_databases>
+        <default_database>system</default_database>
+      </system>
+      <pgadmin>
+        <allow_databases>
+          <database>default</database>
+        </allow_databases>
+        <default_database>default</default_database>
+        <password>pgadmin</password>
+        <networks>
+          <ip>::/0</ip>
+        </networks>
+      </pgadmin>
+      <neutron>
+        <allow_databases>
+          <database>neutron</database>
+        </allow_databases>
+        <default_database>neutron</default_database>
+        <password>neutron@t+</password>
+        <networks>
+          <ip>::/0</ip>
+        </networks>
+      </neutron>
+      <proton>
+        <default_database>default</default_database>
+        <password>proton@t+</password>
+        <networks>
+          <ip>::1</ip>
+        </networks>
+        <networks>
+          <ip>127.0.0.1</ip>
+        </networks>
+        <access_management>1</access_management>
+      </proton>
     </users>
+
+    <grok_patterns_file>grok-patterns</grok_patterns_file>
 
     <profiles>
         <default/>

--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -143,10 +143,10 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool /*fallb
 struct ConfigReloader::FileWithTimestamp
 {
     std::string path;
-    time_t modification_time;
+    fs::file_time_type modification_time;
 
-    FileWithTimestamp(const std::string & path_, time_t modification_time_)
-        : path(path_), modification_time(modification_time_) {}
+    explicit FileWithTimestamp(const std::string & path_)
+        : path(path_), modification_time(fs::last_write_time(path_)) {}
 
     bool operator < (const FileWithTimestamp & rhs) const
     {
@@ -163,7 +163,7 @@ struct ConfigReloader::FileWithTimestamp
 void ConfigReloader::FilesChangesTracker::addIfExists(const std::string & path_to_add)
 {
     if (!path_to_add.empty() && fs::exists(path_to_add))
-        files.emplace(path_to_add, FS::getModificationTime(path_to_add));
+        files.emplace(path_to_add);
 }
 
 bool ConfigReloader::FilesChangesTracker::isDifferOrNewerThan(const FilesChangesTracker & rhs)

--- a/src/Common/Config/ExternalGrokPatterns.cpp
+++ b/src/Common/Config/ExternalGrokPatterns.cpp
@@ -89,7 +89,7 @@ void ExternalGrokPatterns::loadPatternsFromFile()
         LOG_WARNING(log, "External grok patterns file '{}' does not exist, trying embedded resource", file_name);
 
         /// Try to load the patterns from embedded resource
-        auto resource_data = getResource(file_name);
+        auto resource_data = getResource("grok-patterns");
         if (!resource_data.empty())
         {
             std::string resource_string(resource_data);

--- a/src/Common/Config/ExternalGrokPatterns.cpp
+++ b/src/Common/Config/ExternalGrokPatterns.cpp
@@ -87,15 +87,12 @@ void ExternalGrokPatterns::loadPatternsFromFile()
     if (!ifs)
     {
         LOG_WARNING(log, "External grok patterns file '{}' does not exist, trying embedded resource", file_name);
-        
-        // Try to load the patterns from embedded resource
+
+        /// Try to load the patterns from embedded resource
         auto resource_data = getResource(file_name);
         if (!resource_data.empty())
         {
-            // Convert std::string_view to std::string
             std::string resource_string(resource_data);
-
-            // Now create a std::istringstream from the std::string
             std::istringstream resource_stream(resource_string);
             loadPatternsFromStream(resource_stream);
         }
@@ -110,9 +107,8 @@ void ExternalGrokPatterns::loadPatternsFromFile()
     loadPatternsFromStream(ifs);
 }
 
-void ExternalGrokPatterns::loadPatternsFromStream(std::istream& stream)
+void ExternalGrokPatterns::loadPatternsFromStream(std::istream & stream)
 {
-
     int line_num = 0;
     String line;
 

--- a/src/Common/Config/ExternalGrokPatterns.h
+++ b/src/Common/Config/ExternalGrokPatterns.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Core/BackgroundSchedulePool.h>
-#include <Common/logger_useful.h>
 #include <Common/getResource.h>
+#include <Common/logger_useful.h>
 
 namespace DB
 {
@@ -38,7 +38,7 @@ private:
     ExternalGrokPatterns(ContextPtr context_);
     void reloadPatternsFromFile();
     void loadPatternsFromFile();
-    void loadPatternsFromStream(std::istream& stream);
+    void loadPatternsFromStream(std::istream & stream);
 
 private:
     std::atomic_flag is_shutdown;

--- a/src/Common/Config/ExternalGrokPatterns.h
+++ b/src/Common/Config/ExternalGrokPatterns.h
@@ -2,6 +2,7 @@
 
 #include <Core/BackgroundSchedulePool.h>
 #include <Common/logger_useful.h>
+#include <Common/getResource.h>
 
 namespace DB
 {
@@ -37,6 +38,7 @@ private:
     ExternalGrokPatterns(ContextPtr context_);
     void reloadPatternsFromFile();
     void loadPatternsFromFile();
+    void loadPatternsFromStream(std::istream& stream);
 
 private:
     std::atomic_flag is_shutdown;


### PR DESCRIPTION
_edit v1: update the pr link_

fix #267 
Please write user-readable short description of the changes:
1. porting https://github.com/ClickHouse/ClickHouse/pull/54065 to make config change more robust
2. exposed more user config in embeded.xml
3. make a route in grok_pattern loading.(if the file is not found, try to load from `getResource`) 
since the user may manual change the content, we check the file first and then load from embed source.
to better re-use code, I make a trans from `std::string_view getResource()` -> `std::string` -> `std::istream`.
the compiler is smart enough to optimization from `string_view` -> `string` I believe.