### PR TITLE
feature: kafka external stream partitioning

### DIFF
--- a/src/Core/BlockWithShard.h
+++ b/src/Core/BlockWithShard.h
@@ -14,3 +14,4 @@ struct BlockWithShard
 
 using BlocksWithShard = std::vector<BlockWithShard>;
 }
+

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -64,6 +64,9 @@
 
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Common/logger_useful.h>
+#include "Parsers/ASTFunction.h"
+#include "Parsers/ExpressionElementParsers.h"
+#include "Server/RestRouterHandlers/ColumnDefinition.h"
 
 #include <base/ClockUtils.h>
 
@@ -884,8 +887,6 @@ void InterpreterCreateQuery::handleStreamCreation(const String & current_databas
 
     if (create.getDatabase().empty())
         create.setDatabase(current_database);
-
-    return;
 }
 
 /// external stream is always created locally in the DDL request accepting node
@@ -894,12 +895,31 @@ void InterpreterCreateQuery::handleExternalStreamCreation(ASTCreateQuery & creat
     if (!create.is_external)
         return;
 
+    auto sharding_expr_field = Field("");
+    String sharding_expr;
+
     /// ExternalStreamStorage
     if (!create.storage)
         create.set(create.storage, std::make_shared<ASTStorage>());
+    else
+        create.storage->settings->changes.tryGet("sharding_expr", sharding_expr_field);
 
-    if (!create.storage->engine)
-        create.storage->set(create.storage->engine, makeASTFunction("ExternalStream"));
+    sharding_expr_field.tryGet<String>(sharding_expr);
+
+    ASTPtr sharding_expr_ast;
+    if (sharding_expr.empty())
+    {
+        sharding_expr_ast = makeASTFunction("rand");
+    }
+    else
+    {
+        ParserFunction parser;
+        const char * begin{sharding_expr.data()};
+        const char * end{begin + sharding_expr.size()};
+        sharding_expr_ast = parseQuery(parser, begin, end, "", 0, 0);
+    }
+
+    create.storage->set(create.storage->engine, makeASTFunction("ExternalStream", sharding_expr_ast));
 
     if (create.storage->engine->name != "ExternalStream")
         throw Exception(ErrorCodes::INCORRECT_QUERY, "External stream requires ExternalStream engine");

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -64,9 +64,6 @@
 
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Common/logger_useful.h>
-#include "Parsers/ASTFunction.h"
-#include "Parsers/ExpressionElementParsers.h"
-#include "Server/RestRouterHandlers/ColumnDefinition.h"
 
 #include <base/ClockUtils.h>
 

--- a/src/Storages/ExternalStream/ExternalStreamSettings.h
+++ b/src/Storages/ExternalStream/ExternalStreamSettings.h
@@ -16,6 +16,7 @@ class ASTStorage;
     M(String, username, "", "The username of external logstore", 0) \
     M(String, password, "", "The password of external logstore", 0) \
     M(String, properties, "", "A semi-colon-separated key-value pairs for configuring the kafka client used by the external stream. A key-value pair is separated by a equal sign. Example: 'client.id=my-client-id;group.id=my-group-id'. Note, not all properties are supported, please check the document for supported properties.", 0) \
+    M(String, sharding_expr, "", "An expression which will be evaluated on each row of data returned by the query to calculate the an integer which will be used to determine the ID of the partition to which the row of data will be sent. If not set, data are sent to any partition randomly.", 0) \
     /* those are log related settings */ \
     M(String, log_files, "", "A comma-separated list of log files", 0) \
     M(String, log_dir, "", "log root directory", 0) \

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -13,7 +13,7 @@ class IStorage;
 class Kafka final : public StorageExternalStreamImpl
 {
 public:
-    Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, bool attach);
+    Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, ASTPtr partitioning_expr, bool attach);
     ~Kafka() override = default;
 
     void startup() override { }
@@ -40,6 +40,7 @@ public:
     const String & username() const { return settings->username.value; }
     const String & password() const { return settings->password.value; }
     const klog::KConfParams & properties() const { return kafka_properties; }
+    const ASTPtr & partitioning_expr_ast() const { return partitioning_expr; }
 
 private:
     void calculateDataFormat(const IStorage * storage);
@@ -58,6 +59,7 @@ private:
 
     NamesAndTypesList virtual_column_names_and_types;
     klog::KConfParams kafka_properties;
+    ASTPtr partitioning_expr;
 
     std::mutex shards_mutex;
     int32_t shards = 0;

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -38,7 +38,11 @@ ChunkPartitioner::ChunkPartitioner(ContextPtr context, const Block & header, con
     if (auto * shard_func = partitioning_expr_ast->as<ASTFunction>())
     {
         if (shard_func->name == "rand" || shard_func->name == "RAND")
+        {
             random_partitioning = true;
+            std::random_device r;
+            rand = std::minstd_rand(r());
+        }
     }
 }
 

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -187,7 +187,6 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
     }
 
     wb = std::make_unique<WriteBufferFromKafka>();
-    rd_kafka_conf_set_opaque(conf, this);
 
     auto * topic_conf = rd_kafka_conf_get_default_topic_conf(conf);
     if (!topic_conf)
@@ -197,7 +196,10 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
         rd_kafka_conf_set_default_topic_conf(conf, topic_conf);
     }
 
-    /// Even though the partition
+    rd_kafka_conf_set_opaque(conf, this);
+    rd_kafka_topic_conf_set_opaque(topic_conf, this);
+
+    /// With partitioner callback, we can get the up-to-date partition count w/o additional effort.
     rd_kafka_topic_conf_set_partitioner_cb(topic_conf, [](const rd_kafka_topic_t * /*rkt*/,
 						const void * /*keydata*/,
 						size_t /*keylen*/,

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -73,6 +73,7 @@ BlocksWithShard ChunkPartitioner::doParition(Block block, Int32 partition_cnt) c
     }
 
     BlocksWithShard blocks_with_shard;
+    blocks_with_shard.reserve(partitioned_blocks.size());
 
     /// Filter out empty blocks
     for (size_t i = 0; i < partitioned_blocks.size(); ++i)

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <random>
+
+#include <Core/BlockWithShard.h>
 #include <Formats/FormatFactory.h>
 #include <Processors/Sinks/SinkToStorage.h>
 #include <Storages/ExternalStream/Kafka/Kafka.h>
@@ -14,10 +17,33 @@ class Logger;
 namespace DB
 {
 
+namespace KafkaStream
+{
+/// Partition Chunk's to paritions (i.e. shards) by the partitioning expression.
+class ChunkPartitioner
+{
+public:
+    ChunkPartitioner(ContextPtr context, const Block & header, const ASTPtr & partitioning_expr_ast);
+    BlocksWithShard partition(Block block, Int32 partition_cnt) const;
+
+private:
+    Int32 getNextShardIndex(Int32 partition_cnt) const noexcept { return static_cast<Int32>(rand()) % partition_cnt; }
+
+    BlocksWithShard doParition(Block block, Int32 partition_cnt) const;
+
+    IColumn::Selector createSelector(const Block & block, Int32 partition_cnt) const;
+
+    ExpressionActionsPtr partitioning_expr;
+    String partitioning_key_column_name;
+    bool random_partitioning = false;
+    mutable std::minstd_rand rand;
+};
+}
+
 class KafkaSink final : public SinkToStorage
 {
 public:
-    KafkaSink(const Kafka * kafka, const Block & header, ContextPtr context, Poco::Logger * log_);
+    KafkaSink(const Kafka * kafka, const Block & header, ContextPtr context, Int32 initial_partition_cnt, Poco::Logger * log_);
     ~KafkaSink() override;
 
     String getName() const override { return "KafkaSink"; }
@@ -30,10 +56,13 @@ private:
     static const int POLL_TIMEOUT_MS = 500;
 
     klog::KafkaPtr producer;
+    klog::KTopicPtr topic;
     std::unique_ptr<WriteBufferFromKafka> wb;
     OutputFormatPtr writer;
     ThreadPool polling_threads;
     std::atomic_flag is_finished;
+    Int32 partition_cnt;
+    std::unique_ptr<KafkaStream::ChunkPartitioner> partitioner;
 
     Poco::Logger * log;
 };

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.h
@@ -33,11 +33,10 @@ private:
 
     IColumn::Selector createSelector(Block block, Int32 partition_cnt) const;
 
-    static inline std::minstd_rand rand{std::random_device()()};
-
     ExpressionActionsPtr partitioning_expr;
     String partitioning_key_column_name;
     bool random_partitioning = false;
+    mutable std::minstd_rand rand;
 };
 }
 
@@ -71,8 +70,7 @@ private:
         auto * sink = static_cast<KafkaSink *>(rkt_opaque);
         sink->partition_cnt = partition_count;
 
-        auto partition_id_ptr = reinterpret_cast<std::uintptr_t>(msg_opaque);
-        auto parition_id = static_cast<Int32>(partition_id_ptr);
+        auto parition_id = static_cast<Int32>(reinterpret_cast<std::uintptr_t>(msg_opaque));
         /// This should not really happen because Kafka does not support reducing partitions.
         /// However, KIP-694 is currently under discussion, so this might heppen in the future.
         if (parition_id >= partition_count)

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
@@ -10,8 +10,9 @@ namespace ErrorCodes
 extern const int CANNOT_WRITE_TO_KAFKA;
 }
 
-WriteBufferFromKafka::WriteBufferFromKafka(size_t buffer_size)
+WriteBufferFromKafka::WriteBufferFromKafka(rd_kafka_topic_t * topic_, size_t buffer_size)
     : BufferWithOwnMemory<WriteBuffer>(buffer_size)
+    , topic(topic_)
 {
 }
 

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
@@ -27,9 +27,9 @@ void WriteBufferFromKafka::nextImpl()
         RD_KAFKA_MSG_F_COPY | RD_KAFKA_MSG_F_BLOCK,
         working_buffer.begin(),
         offset(),
-        "" /* key, even though we don't use the key, but it's needed to trigger the partitioner_cb */,
-        0 /* keylen */,
-        reinterpret_cast<void *>(partition_id) /* opaque */);
+        /*key=*/ "", /// Even though we don't use the key, but it's needed to trigger the partitioner_cb
+        /*keylen=*/ 0,
+        /*msg_opaque=*/ reinterpret_cast<void *>(partition_id));
 
     if (unlikely(err))
         throw Exception(

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
@@ -32,7 +32,7 @@ void WriteBufferFromKafka::nextImpl()
         RD_KAFKA_MSG_F_COPY | RD_KAFKA_MSG_F_BLOCK,
         working_buffer.begin(),
         offset(),
-        "unused" /* key, this key actually not used but for triggering the partitioner callback */,
+        "unused" /* key, even though we don't use the key, but it's needed to trigger the partitioner_cb */,
         6 /* keylen */,
         static_cast<void *>(part_id) /* opaque */);
 

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
@@ -32,8 +32,8 @@ void WriteBufferFromKafka::nextImpl()
         RD_KAFKA_MSG_F_COPY | RD_KAFKA_MSG_F_BLOCK,
         working_buffer.begin(),
         offset(),
-        nullptr /* key */,
-        0 /* keylen */,
+        "unused" /* key, this key actually not used but for triggering the partitioner callback */,
+        6 /* keylen */,
         static_cast<void *>(part_id) /* opaque */);
 
     if (unlikely(err))

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.h
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.h
@@ -10,7 +10,8 @@ namespace DB
 class WriteBufferFromKafka final : public BufferWithOwnMemory<WriteBuffer>
 {
 public:
-    explicit WriteBufferFromKafka(klog::KTopicPtr topic_, size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE);
+    // WriteBufferFromKafka does not take the ownership of `topic_`.
+    explicit WriteBufferFromKafka(size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE);
 
     ~WriteBufferFromKafka() override = default;
 
@@ -30,6 +31,14 @@ public:
     /// allows to reset the state after each checkpoint
     void resetState() { state.reset(); }
 
+    /// Configure the buffer to write data to the specific topic.
+    /// The buffer does not take the ownership of the topic pointer.
+    /// This allows us to create a buffer w/o creating the topic first.
+    void write_to_topic(rd_kafka_topic_t * topic_) { topic = topic_; }
+
+    /// Set the partition ID the buffer will write data to.
+    /// This makes it possible write data to different paritions.
+    void write_to_partition(Int32 id) { partition_id = id; }
 private:
     void nextImpl() override;
 
@@ -43,7 +52,9 @@ private:
         void reset();
     };
 
-    klog::KTopicPtr topic;
+    rd_kafka_topic_t * topic;
     State state;
+
+    Int32 partition_id;
 };
 }

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.h
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.h
@@ -11,7 +11,7 @@ class WriteBufferFromKafka final : public BufferWithOwnMemory<WriteBuffer>
 {
 public:
     // WriteBufferFromKafka does not take the ownership of `topic_`.
-    explicit WriteBufferFromKafka(size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE);
+    explicit WriteBufferFromKafka(rd_kafka_topic_t * topic_, size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE);
 
     ~WriteBufferFromKafka() override = default;
 
@@ -30,11 +30,6 @@ public:
     bool hasNoOutstandings() const { return state.outstandings == state.acked + state.error_count; }
     /// allows to reset the state after each checkpoint
     void resetState() { state.reset(); }
-
-    /// Configure the buffer to write data to the specific topic.
-    /// The buffer does not take the ownership of the topic pointer.
-    /// This allows us to create a buffer w/o creating the topic first.
-    void write_to_topic(rd_kafka_topic_t * topic_) { topic = topic_; }
 
     /// Set the partition ID the buffer will write data to.
     /// This makes it possible write data to different paritions.

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.h
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.h
@@ -33,7 +33,8 @@ public:
 
     /// Set the partition ID the buffer will write data to.
     /// This makes it possible write data to different paritions.
-    void write_to_partition(Int32 id) { partition_id = id; }
+    void setTargetPartition(Int32 id) { partition_id = id; }
+
 private:
     void nextImpl() override;
 

--- a/src/Storages/ExternalStream/StorageExternalStream.cpp
+++ b/src/Storages/ExternalStream/StorageExternalStream.cpp
@@ -1,15 +1,8 @@
 #include "StorageExternalStream.h"
-#include <algorithm>
-#include "Core/Types.h"
-#include "ExternalStreamSettings.h"
 #include "ExternalStreamTypes.h"
-#include "Interpreters/ExpressionAnalyzer.h"
-#include "Interpreters/TreeRewriter.h"
-#include "Parsers/ASTFunction.h"
-#include "Parsers/IAST_fwd.h"
-#include "Server/RestRouterHandlers/ColumnDefinition.h"
 #include "StorageExternalStreamImpl.h"
 
+#include <Interpreters/ExpressionAnalyzer.h>
 /// External stream storages
 #include <Storages/ExternalStream/Kafka/Kafka.h>
 #include <Storages/SelectQueryInfo.h>

--- a/src/Storages/ExternalStream/StorageExternalStream.cpp
+++ b/src/Storages/ExternalStream/StorageExternalStream.cpp
@@ -32,16 +32,14 @@ extern const int TYPE_MISMATCH;
 namespace
 {
 ExpressionActionsPtr
-buildShardingKeyExpression(const ASTPtr & sharding_key, ContextPtr context, const NamesAndTypesList & columns)
+buildShardingKeyExpression(ASTPtr sharding_key, ContextPtr context, const NamesAndTypesList & columns)
 {
-    ASTPtr query = sharding_key;
-    auto syntax_result = TreeRewriter(context).analyze(query, columns);
-    return ExpressionAnalyzer(query, syntax_result, context).getActions(true);
+    auto syntax_result = TreeRewriter(context).analyze(sharding_key, columns);
+    return ExpressionAnalyzer(sharding_key, syntax_result, context).getActions(true);
 }
 
 void validateEngineArgs(ContextPtr context, ASTs & engine_args, const ColumnsDescription & columns) {
-    const auto & sharding_expr_arg = engine_args[0];
-    auto sharding_expr = buildShardingKeyExpression(sharding_expr_arg, context, columns.getAllPhysical());
+    auto sharding_expr = buildShardingKeyExpression(engine_args[0], context, columns.getAllPhysical());
     const auto & block = sharding_expr->getSampleBlock();
     if (block.columns() != 1)
         throw Exception("Sharding expression must return exactly one column", ErrorCodes::INCORRECT_NUMBER_OF_COLUMNS);

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -3,7 +3,6 @@
 #include <Storages/IStorage.h>
 #include <base/shared_ptr_helper.h>
 #include <Common/SettingsChanges.h>
-#include "Server/RestRouterHandlers/ColumnDefinition.h"
 
 namespace DB
 {

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -3,6 +3,7 @@
 #include <Storages/IStorage.h>
 #include <base/shared_ptr_helper.h>
 #include <Common/SettingsChanges.h>
+#include "Server/RestRouterHandlers/ColumnDefinition.h"
 
 namespace DB
 {
@@ -51,6 +52,7 @@ public:
 
 protected:
     StorageExternalStream(
+        const ASTPtr & sharding_key_,
         const StorageID & table_id_,
         ContextPtr context_,
         const ColumnsDescription & columns_,


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

A new feature that adds a new setting name `sharding_expr` for creating kafka external stream. `sharding_expr` accepts a SQL expression which is evaluated into an integer, and the value of that expression is used to decide to which partition the message is sent. For example:

```SQL
CREATE EXTERNAL STREAM foo (
a string,
b int32,
) type='kafka',brokers='localhost:9092',topic='foo',sharding_expr='to_int(b)'
```

The `KafkaSink` will use the expression to divide each in-coming `Chunk` into `Block`s by the sharding key value and then send the `Block`s to the Kafka topic.

closes #192