### PR TITLE
make random stream eps be query time settings

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -782,6 +782,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, javascript_uda_max_concurrency, 1, "Control the concurrency of JavaScript UDA in a query", 0) \
     M(Float, replay_speed, 0., "Control the replay speed..0 < replay_speed < 1, means replay slower.replay_speed == 1, means replay by actual ingest interval.1 < replay_speed < <max_limit>, means replay faster", 0) \
     M(UInt64, max_events, 0, "Total events to generate for random stream", 0) \
+    M(Int64, generate_eps, -1, "control the random stream eps in query time, defalut value is -1, if it is 0 means no limit.", 0) \
     /** proton: ends. */
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.

--- a/tests/stream/test_stream_smoke/0021_random_stream.json
+++ b/tests/stream/test_stream_smoke/0021_random_stream.json
@@ -374,6 +374,50 @@
                 ]
               }
             ]
+          },
+          {
+            "id": 17,
+            "tags": ["random stream table query"],
+            "name": "test random stream table query, set max_events=1000",
+            "description": "test random stream table query",
+            "steps":[
+              {
+                "statements": [
+                  {"client":"python", "query_type": "table", "wait":2, "query": "drop stream if exists test22_create_random"},
+                  {"client":"python", "query_type": "table", "wait":2, "query": "create random stream test22_create_random(id int default rand()%4) engine Random() settings eps=100000"},
+                  {"client":"python", "query_type": "table", "query_id":"2226", "wait":2, "query":"select count(1) from table(test22_create_random) settings max_events=1000"}
+                ]
+              }
+            ],
+            "expected_results": [
+              {
+                "query_id":"2226", "expected_results":[
+                    ["1000"]
+                ]
+              }
+            ]
+          },
+          {
+            "id": 18,
+            "tags": ["random stream table query"],
+            "name": "test random stream stream query, set max_events=1000",
+            "description": "test random stream stream query",
+            "steps":[
+              {
+                "statements": [
+                  {"client":"python", "query_type": "table", "wait":2, "query": "drop stream if exists test22_create_random"},
+                  {"client":"python", "query_type": "table", "wait":2, "query": "create random stream test22_create_random(id int default rand()%4) engine Random() settings eps=1000"},
+                  {"client":"python", "query_type": "stream", "terminate" : "auto", "query_end_timer" : 7, "query_id":"2227", "wait":2, "query":"select count(1) from table(test22_create_random) settings max_events=5000"}
+                ]
+              }
+            ],
+            "expected_results": [
+              {
+                "query_id":"2227", "expected_results":[
+                    ["5000"]
+                ]
+              }
+            ]
           }
     ]
   }

--- a/tests/stream/test_stream_smoke/0021_random_stream.json
+++ b/tests/stream/test_stream_smoke/0021_random_stream.json
@@ -418,6 +418,28 @@
                 ]
               }
             ]
+          },
+          {
+            "id": 19,
+            "tags": ["create random", "unstable"],
+            "name": "set generate_eps, test eps",
+            "description": "set generate_eps, test eps",
+            "steps":[
+              {
+                "statements": [
+                  {"client":"python", "query_type": "table", "wait":2, "query": "drop stream if exists test22_create_random"},
+                  {"client":"python", "query_type": "table", "wait":2, "query": "create random stream test22_create_random(id int default rand()%4) engine Random() settings eps=1000"},
+                  {"client":"python", "query_type": "table", "query_id":"2228", "wait":2, "query":"select count(1) from tumble(test22_create_random, 1s) group by window_start limit 5 settings generate_eps=10000"}
+                ]
+              }
+            ],
+            "expected_results": [
+              {
+                "query_id":"2228", "expected_results":[
+                    ["10000"], ["10000"], ["10000"], ["10000"], ["10000"]
+                ]
+              }
+            ]
           }
     ]
   }


### PR DESCRIPTION
this close #260 
```sql
create random stream test22_create_random(id int default rand()%4) engine Random() settings eps=1000;
select count(1) from test22_create_random settings generate_eps=100;
```
If you set `generate_eps` in query time, it will use `generate_eps` as eps to generate data.
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
