### PR TITLE
Feature/support streaming shuffle by

### DIFF
--- a/src/Functions/UserDefined/UDFHelper.cpp
+++ b/src/Functions/UserDefined/UDFHelper.cpp
@@ -146,9 +146,9 @@ createUserDefinedExecutableFunction(ContextPtr context, const std::string & name
                     arguments.emplace_back(std::move(argument));
                 }
             }
-            catch (const std::exception &)
+            catch (const std::exception & e)
             {
-                throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid UDF config");
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid UDF config: {}", e.what());
             }
         }
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3262,7 +3262,10 @@ void InterpreterSelectQuery::executeStreamingAggregation(
         ? static_cast<size_t>(settings.aggregation_memory_efficient_merge_threads)
         : static_cast<size_t>(settings.max_threads);
 
-    if (query_info.hasPartitionByKeys())
+    /// There are two substream categories:
+    /// 1) `parition by`: calculating substream with substream ID (The data have been shuffled by `ShufflingTransform`)
+    /// 2) `shuffle by`: calculating light substream without substream ID (The data have been shuffled by `LightShufflingTransform`)
+    if (query_info.hasPartitionByKeys() || light_shuffled)
         query_plan.addStep(std::make_unique<Streaming::AggregatingStepWithSubstream>(
             query_plan.getCurrentDataStream(), std::move(params), final, emit_version, data_stream_semantic_pair.isChangelogOutput()));
     else

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -50,14 +50,9 @@ Chunk Chunk::clone() const
     return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx);
 }
 
-ChunkContextPtr Chunk::cloneChunkContext() const
-{
-    return chunk_ctx ? std::make_shared<ChunkContext>(*chunk_ctx) : nullptr;
-}
-
 Chunk Chunk::cloneWithChunkContext(const ChunkContextPtr & chunk_ctx_) const
 {
-    return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx_ ? std::make_shared<ChunkContext>(*chunk_ctx_) : nullptr);
+    return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx_ ? chunk_ctx_->clone() : nullptr);
 }
 
 void Chunk::setColumns(Columns columns_, UInt64 num_rows_)

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -50,11 +50,6 @@ Chunk Chunk::clone() const
     return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx);
 }
 
-Chunk Chunk::cloneWithChunkContext(const ChunkContextPtr & chunk_ctx_) const
-{
-    return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx_ ? chunk_ctx_->clone() : nullptr);
-}
-
 void Chunk::setColumns(Columns columns_, UInt64 num_rows_)
 {
     columns = std::move(columns_);

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -50,6 +50,16 @@ Chunk Chunk::clone() const
     return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx);
 }
 
+ChunkContextPtr Chunk::cloneChunkContext() const
+{
+    return chunk_ctx ? std::make_shared<ChunkContext>(*chunk_ctx) : nullptr;
+}
+
+Chunk Chunk::cloneWithChunkContext(const ChunkContextPtr & chunk_ctx_) const
+{
+    return Chunk(getColumns(), getNumRows(), chunk_info, chunk_ctx_ ? std::make_shared<ChunkContext>(*chunk_ctx_) : nullptr);
+}
+
 void Chunk::setColumns(Columns columns_, UInt64 num_rows_)
 {
     columns = std::move(columns_);

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -14,8 +14,17 @@ namespace DB
 {
 
 /// proton : starts
-struct ChunkContext
+struct ChunkContext : public COW<ChunkContext>
 {
+private:
+    friend class COW<ChunkContext>;
+
+    /// This is internal method to use from COW.
+    /// It performs shallow copy with copy-ctor and not useful from outside.
+    /// If you want to copy column for modification, look at 'mutate' method.
+    [[nodiscard]] MutablePtr clone() const { return ChunkContext::create(*this); }
+
+public:
     static constexpr UInt64 WATERMARK_FLAG = 0x1;
     static constexpr UInt64 APPEND_TIME_FLAG = 0x2;
     static constexpr UInt64 HISTORICAL_DATA_START_FLAG = 0x4;
@@ -94,10 +103,9 @@ struct ChunkContext
     CheckpointContextPtr getCheckpointContext() const { return ckpt_ctx; }
 
     const Streaming::SubstreamID & getSubstreamID() const { return id; }
-
-    std::shared_ptr<ChunkContext> clone() const { return std::make_shared<ChunkContext>(*this); }
 };
-using ChunkContextPtr = std::shared_ptr<ChunkContext>;
+using ChunkContextPtr = ChunkContext::Ptr;
+using MutableChunkContextPtr = ChunkContext::MutablePtr;
 /// proton : ends
 
 class ChunkInfo
@@ -204,9 +212,6 @@ public:
     void append(Chunk && chunk);
 
     /// proton : starts
-    /// Clone chunk with copyed chunk context, used for shuffling to prevent access to the same chunk context
-    Chunk cloneWithChunkContext(const ChunkContextPtr & chunk_ctx_) const;
-
     bool hasWatermark() const { return chunk_ctx && chunk_ctx->hasWatermark(); }
 
     bool hasTimeoutWatermark() const { return chunk_ctx && chunk_ctx->hasTimeoutWatermark(); }
@@ -224,7 +229,7 @@ public:
         if (chunk_ctx)
             return chunk_ctx;
 
-        setChunkContext(std::make_shared<ChunkContext>());
+        setChunkContext(ChunkContext::create());
 
         return chunk_ctx;
     }
@@ -248,13 +253,24 @@ public:
     void trySetSubstreamID(Streaming::SubstreamID id)
     {
         if (chunk_ctx)
-            chunk_ctx->setSubstreamID(std::move(id));
+        {
+            auto mutate_chunk_ctx = ChunkContext::mutate(chunk_ctx);
+            mutate_chunk_ctx->setSubstreamID(std::move(id));
+            chunk_ctx = std::move(mutate_chunk_ctx);
+        }
     }
 
     Int64 getWatermark() const
     {
         assert(chunk_ctx);
         return chunk_ctx->getWatermark();
+    }
+
+    void setWatermark(Int64 watermark)
+    {
+        auto mutate_chunk_ctx = chunk_ctx ? ChunkContext::mutate(chunk_ctx) : ChunkContext::create();
+        mutate_chunk_ctx->setWatermark(watermark);
+        chunk_ctx = std::move(mutate_chunk_ctx);
     }
 
     void reserve(size_t num_columns)
@@ -272,16 +288,38 @@ public:
         return chunk_ctx && chunk_ctx->avoidWatermark();
     }
 
-    void clearWatermark() const
+    void clearWatermark()
     {
-        if (chunk_ctx)
-            chunk_ctx->clearWatermark();
+        if (chunk_ctx && chunk_ctx->hasWatermark())
+        {
+            auto mutate_chunk_ctx = ChunkContext::mutate(chunk_ctx);
+            mutate_chunk_ctx->clearWatermark();
+            chunk_ctx = std::move(mutate_chunk_ctx);
+        }
     }
 
-    void clearRequestCheckpoint() const
+    void clearRequestCheckpoint()
     {
-        if (chunk_ctx)
-            chunk_ctx->setCheckpointContext(nullptr);
+        if (chunk_ctx && chunk_ctx->getCheckpointContext())
+        {
+            auto mutate_chunk_ctx = ChunkContext::mutate(chunk_ctx);
+            mutate_chunk_ctx->setCheckpointContext(nullptr);
+            chunk_ctx = std::move(mutate_chunk_ctx);
+        }
+    }
+
+    void setCheckpointContext(CheckpointContextPtr ckpt_ctx)
+    {
+        auto mutate_chunk_ctx = chunk_ctx ? ChunkContext::mutate(chunk_ctx) : ChunkContext::create();
+        mutate_chunk_ctx->setCheckpointContext(ckpt_ctx);
+        chunk_ctx = std::move(mutate_chunk_ctx);
+    }
+
+    void setRetractedDataFlag()
+    {
+        auto mutate_chunk_ctx = chunk_ctx ? ChunkContext::mutate(chunk_ctx) : ChunkContext::create();
+        mutate_chunk_ctx->setRetractedDataFlag();
+        chunk_ctx = std::move(mutate_chunk_ctx);
     }
 
     bool isHistoricalDataStart() const { return chunk_ctx && chunk_ctx->isHistoricalDataStart(); }
@@ -296,6 +334,7 @@ private:
     Columns columns;
     UInt64 num_rows = 0;
     ChunkInfoPtr chunk_info;
+    /// COW<ChunkContext>::Ptr, it can be shared by multiple processors (only copy on write)
     ChunkContextPtr chunk_ctx;
 
     void checkNumRowsIsConsistent();

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -94,6 +94,8 @@ struct ChunkContext
     CheckpointContextPtr getCheckpointContext() const { return ckpt_ctx; }
 
     const Streaming::SubstreamID & getSubstreamID() const { return id; }
+
+    std::shared_ptr<ChunkContext> clone() const { return std::make_shared<ChunkContext>(*this); }
 };
 using ChunkContextPtr = std::shared_ptr<ChunkContext>;
 /// proton : ends
@@ -202,7 +204,6 @@ public:
     void append(Chunk && chunk);
 
     /// proton : starts
-    ChunkContextPtr cloneChunkContext() const;
     /// Clone chunk with copyed chunk context, used for shuffling to prevent access to the same chunk context
     Chunk cloneWithChunkContext(const ChunkContextPtr & chunk_ctx_) const;
 

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -202,6 +202,10 @@ public:
     void append(Chunk && chunk);
 
     /// proton : starts
+    ChunkContextPtr cloneChunkContext() const;
+    /// Clone chunk with copyed chunk context, used for shuffling to prevent access to the same chunk context
+    Chunk cloneWithChunkContext(const ChunkContextPtr & chunk_ctx_) const;
+
     bool hasWatermark() const { return chunk_ctx && chunk_ctx->hasWatermark(); }
 
     bool hasTimeoutWatermark() const { return chunk_ctx && chunk_ctx->hasTimeoutWatermark(); }
@@ -243,7 +247,7 @@ public:
     void trySetSubstreamID(Streaming::SubstreamID id)
     {
         if (chunk_ctx)
-            chunk_ctx->setSubstreamID(id);
+            chunk_ctx->setSubstreamID(std::move(id));
     }
 
     Int64 getWatermark() const

--- a/src/Processors/QueryPlan/Streaming/AggregatingStepWithSubstream.cpp
+++ b/src/Processors/QueryPlan/Streaming/AggregatingStepWithSubstream.cpp
@@ -57,9 +57,13 @@ void AggregatingStepWithSubstream::transformPipeline(QueryPipelineBuilder & pipe
     /// Forget about current totals and extremes. They will be calculated again after aggregation if needed.
     pipeline.dropTotalsAndExtremes();
 
-    /// Disable convert to two level group by, since the input stream already is shuffled substream data.
-    params.group_by_two_level_threshold = 0;
-    params.group_by_two_level_threshold_bytes = 0;
+    /// By default, disable convert to two level group by, since the input stream already is shuffled substream data.
+    bool allow_to_use_two_level_group_by = params.max_bytes_before_external_group_by != 0;
+    if (!allow_to_use_two_level_group_by)
+    {
+        params.group_by_two_level_threshold = 0;
+        params.group_by_two_level_threshold_bytes = 0;
+    }
 
     auto transform_params = std::make_shared<AggregatingTransformParams>(std::move(params), final, emit_version, emit_changelog);
 

--- a/src/Processors/QueryPlan/Streaming/AggregatingStepWithSubstream.cpp
+++ b/src/Processors/QueryPlan/Streaming/AggregatingStepWithSubstream.cpp
@@ -57,7 +57,6 @@ void AggregatingStepWithSubstream::transformPipeline(QueryPipelineBuilder & pipe
     /// Forget about current totals and extremes. They will be calculated again after aggregation if needed.
     pipeline.dropTotalsAndExtremes();
 
-    /// By default, disable convert to two level group by, since the input stream already is shuffled substream data.
     bool allow_to_use_two_level_group_by = params.max_bytes_before_external_group_by != 0;
     if (!allow_to_use_two_level_group_by)
     {

--- a/src/Processors/Sources/MarkSource.h
+++ b/src/Processors/Sources/MarkSource.h
@@ -10,7 +10,7 @@ class MarkSource final : public ISource
 public:
     explicit MarkSource(Block header, UInt64 mark) : ISource(std::move(header), true, ProcessorID::MarkSourceID), chunk(output.getHeader().getColumns(), 0)
     {
-        auto chunk_ctx = std::make_shared<ChunkContext>();
+        auto chunk_ctx = ChunkContext::create();
         chunk_ctx->setMark(mark);
 
         chunk.setChunkContext(std::move(chunk_ctx));

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -121,11 +121,7 @@ std::optional<Chunk> RemoteSource::tryGenerate()
 
     /// proton: starts
     if (block.hasWatermark())
-    {
-        auto chunk_ctx = std::make_shared<ChunkContext>();
-        chunk_ctx->setWatermark(block.watermark());
-        chunk.setChunkContext(std::move(chunk_ctx));
-    }
+        chunk.setWatermark(block.watermark());
     /// proton: ends
 
     return chunk;

--- a/src/Processors/Streaming/ResizeProcessor.cpp
+++ b/src/Processors/Streaming/ResizeProcessor.cpp
@@ -133,7 +133,7 @@ bool ShrinkResizeProcessor::updateAndAlignWatermark(InputPortWithStatus & input_
     input_with_data.status = InputStatus::NeedData;
 
     if (updated)
-        chunk.getChunkContext()->setWatermark(aligned_watermark);
+        chunk.setWatermark(aligned_watermark);
     else
         chunk.clearWatermark();
 
@@ -296,12 +296,12 @@ IProcessor::Status ExpandResizeProcessor::prepare(const PortNumbers & /*updated_
             /// Checkpoint barrier is always standalone, it can't coexist with watermark, we must propagate watermark first
             if (waiting_output.propagate_flag & OutputPortWithStatus::PROPAGATE_WATERMARK)
             {
-                chunk.getOrCreateChunkContext()->setWatermark(watermark);
+                chunk.setWatermark(watermark);
                 waiting_output.propagate_flag &= ~(OutputPortWithStatus::PROPAGATE_WATERMARK | OutputPortWithStatus::PROPAGATE_HEARTBEAT);
             }
             else if (waiting_output.propagate_flag & OutputPortWithStatus::PROPAGATE_CHECKPOINT_REQUEST)
             {
-                chunk.getOrCreateChunkContext()->setCheckpointContext(ckpt_ctx);
+                chunk.setCheckpointContext(ckpt_ctx);
                 waiting_output.propagate_flag
                     &= ~(OutputPortWithStatus::PROPAGATE_CHECKPOINT_REQUEST | OutputPortWithStatus::PROPAGATE_HEARTBEAT);
                 assert(num_checkpoint_requests > 0);

--- a/src/Processors/Transforms/LightShufflingTransform.cpp
+++ b/src/Processors/Transforms/LightShufflingTransform.cpp
@@ -138,11 +138,12 @@ void LightShufflingTransform::consume(Chunk chunk)
 {
     if (chunk.hasRows())
     {
+        auto chunk_ctx = chunk.getChunkContext(); /// save chunk context before split
         auto split_chunks{chunk_splitter.split(chunk)};
         for (auto & chunk_with_shard : split_chunks)
         {
             assert(chunk_with_shard.chunk);
-            chunk_with_shard.chunk.setChunkContext(chunk.cloneChunkContext());
+            chunk_with_shard.chunk.setChunkContext(chunk_ctx ? chunk_ctx->clone() : nullptr);
             shuffled_output_chunks[chunk_with_shard.shard].push(std::move(chunk_with_shard.chunk));
         }
     }

--- a/src/Processors/Transforms/LightShufflingTransform.cpp
+++ b/src/Processors/Transforms/LightShufflingTransform.cpp
@@ -142,6 +142,7 @@ void LightShufflingTransform::consume(Chunk chunk)
         for (auto & chunk_with_shard : split_chunks)
         {
             assert(chunk_with_shard.chunk);
+            chunk_with_shard.chunk.setChunkContext(chunk.cloneChunkContext());
             shuffled_output_chunks[chunk_with_shard.shard].push(std::move(chunk_with_shard.chunk));
         }
     }
@@ -151,8 +152,9 @@ void LightShufflingTransform::consume(Chunk chunk)
         /// depends on this empty timer chunk to calculate watermark for global aggregation
         /// When we fix the timer issue systematically, the pipeline system shall have minimum
         /// empty block flowing around and we don't need this anymore
+        auto chunk_ctx = chunk.getChunkContext();
         for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx)
-            shuffled_output_chunks[output_idx].push(chunk.clone());
+            shuffled_output_chunks[output_idx].push(chunk.cloneWithChunkContext(chunk_ctx));
     }
 }
 

--- a/src/Processors/Transforms/LightShufflingTransform.cpp
+++ b/src/Processors/Transforms/LightShufflingTransform.cpp
@@ -143,7 +143,7 @@ void LightShufflingTransform::consume(Chunk chunk)
         for (auto & chunk_with_shard : split_chunks)
         {
             assert(chunk_with_shard.chunk);
-            chunk_with_shard.chunk.setChunkContext(chunk_ctx ? chunk_ctx->clone() : nullptr);
+            chunk_with_shard.chunk.setChunkContext(chunk_ctx);
             shuffled_output_chunks[chunk_with_shard.shard].push(std::move(chunk_with_shard.chunk));
         }
     }
@@ -153,9 +153,8 @@ void LightShufflingTransform::consume(Chunk chunk)
         /// depends on this empty timer chunk to calculate watermark for global aggregation
         /// When we fix the timer issue systematically, the pipeline system shall have minimum
         /// empty block flowing around and we don't need this anymore
-        auto chunk_ctx = chunk.getChunkContext();
         for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx)
-            shuffled_output_chunks[output_idx].push(chunk.cloneWithChunkContext(chunk_ctx));
+            shuffled_output_chunks[output_idx].push(chunk.clone());
     }
 }
 

--- a/src/Processors/Transforms/Streaming/AggregatingHelper.cpp
+++ b/src/Processors/Transforms/Streaming/AggregatingHelper.cpp
@@ -88,7 +88,7 @@ convertToChangelogChunk(AggregatedDataVariants & data, RetractedDataVariants & r
     {
         auto retracted_delta_col = ColumnInt8::create(retracted_chunk.rows(), Int8(-1));
         retracted_chunk.addColumn(std::move(retracted_delta_col));
-        retracted_chunk.getOrCreateChunkContext()->setRetractedDataFlag();
+        retracted_chunk.setRetractedDataFlag();
     }
 
     auto chunk = convertToChunkImpl(data, params, ConvertAction::StreamingEmit);

--- a/src/Processors/Transforms/Streaming/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/AggregatingTransform.cpp
@@ -380,7 +380,7 @@ bool AggregatingTransform::propagateWatermarkAndClear()
         else
             assert(finalized_watermark == current_chunk_aggregated.getWatermark());
 
-        removeBuckets(finalized_watermark);
+        clearFinalized(finalized_watermark);
         propagated_watermark = finalized_watermark;
         return true;
     }

--- a/src/Processors/Transforms/Streaming/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/AggregatingTransform.cpp
@@ -169,10 +169,10 @@ void AggregatingTransform::consume(Chunk chunk)
     /// If the last attempt to finalize failed (because other threads were finalizing), then we will continue to try in this processing.
     /// But there is already output, we will try in the next `work()`
     if (try_finalizing_watermark.has_value() && !has_input)
-        finalizeAlignment(std::make_shared<ChunkContext>());
+        finalizeAlignment(ChunkContext::create());
 
     /// Try propagate and garbage collect time bucketed memory by finalized watermark
-    propagateWatermarkAndClear();
+    propagateWatermarkAndClearExpiredStates();
 
     /// Try propagate checkpoint to downstream
     propagateCheckpointAndReset();
@@ -223,7 +223,7 @@ void AggregatingTransform::emitVersion(Chunk & chunk)
     }
 }
 
-void AggregatingTransform::setCurrentChunk(Chunk chunk, const ChunkContextPtr & chunk_ctx, Chunk retracted_chunk)
+void AggregatingTransform::setCurrentChunk(Chunk chunk, Chunk retracted_chunk)
 {
     if (has_input)
         throw Exception("Current chunk was already set.", ErrorCodes::LOGICAL_ERROR);
@@ -234,21 +234,10 @@ void AggregatingTransform::setCurrentChunk(Chunk chunk, const ChunkContextPtr & 
     has_input = true;
     current_chunk_aggregated = std::move(chunk);
 
-    if (chunk_ctx)
-    {
-        /// NOTE: For StremaingShrinkResize of downstream, it's need all inputs propagate watermark then do watermark alignment,
-        /// So the watermark cannot be cleared. On the other hand, if the downstream needs to establish its own watermark,
-        /// the watermark will be cleared and reassigned in another `WatermarkStamper` of downstream.
-        // if (params->final && params->params.group_by != Aggregator::Params::GroupBy::OTHER)
-        //     chunk_ctx->clearWatermark();
-
-        current_chunk_aggregated.setChunkContext(std::move(chunk_ctx));
-    }
-
     if (retracted_chunk.rows())
     {
         current_chunk_retracted = std::move(retracted_chunk);
-        current_chunk_retracted.getOrCreateChunkContext()->setRetractedDataFlag();
+        current_chunk_retracted.setRetractedDataFlag();
     }
 }
 
@@ -274,7 +263,7 @@ bool AggregatingTransform::propagateHeartbeatChunk()
     if (has_input)
         return false;
 
-    setCurrentChunk(Chunk{getOutputs().front().getHeader().getColumns(), 0}, nullptr);
+    setCurrentChunk(Chunk{getOutputs().front().getHeader().getColumns(), 0});
     return true;
 }
 
@@ -353,8 +342,9 @@ void AggregatingTransform::finalizeAlignment(const ChunkContextPtr & chunk_ctx)
         }
     } while (!all_locks_acquired);
 
-    chunk_ctx->setWatermark(*try_finalizing_watermark);
-    finalize(chunk_ctx);
+    auto mutate_chunk_ctx = ChunkContext::mutate(chunk_ctx);
+    mutate_chunk_ctx->setWatermark(*try_finalizing_watermark);
+    finalize(std::move(mutate_chunk_ctx));
     try_finalizing_watermark.reset();
 
     auto end = MonotonicMilliseconds::now();
@@ -366,21 +356,21 @@ void AggregatingTransform::finalizeAlignment(const ChunkContextPtr & chunk_ctx)
         many_data->finalized_watermark.load(std::memory_order_relaxed));
 }
 
-bool AggregatingTransform::propagateWatermarkAndClear()
+bool AggregatingTransform::propagateWatermarkAndClearExpiredStates()
 {
     auto finalized_watermark = many_data->finalized_watermark.load(std::memory_order_relaxed);
     if (finalized_watermark > propagated_watermark)
     {
         if (!has_input)
         {
-            auto chunk_ctx = std::make_shared<ChunkContext>();
+            auto chunk_ctx = ChunkContext::create();
             chunk_ctx->setWatermark(finalized_watermark);
-            setCurrentChunk(Chunk{getOutputs().front().getHeader().getColumns(), 0}, chunk_ctx);
+            setCurrentChunk(Chunk{getOutputs().front().getHeader().getColumns(), 0, nullptr, std::move(chunk_ctx)});
         }
         else
             assert(finalized_watermark == current_chunk_aggregated.getWatermark());
 
-        clearFinalized(finalized_watermark);
+        clearExpiredState(finalized_watermark);
         propagated_watermark = finalized_watermark;
         return true;
     }
@@ -419,9 +409,9 @@ bool AggregatingTransform::propagateCheckpointAndReset()
     /// Only all checkpoints request done, then can reset and propagate current ckpt request
     if (many_data->ckpt_requested.load() == 0)
     {
-        auto chunk_ctx = std::make_shared<ChunkContext>();
+        auto chunk_ctx = ChunkContext::create();
         chunk_ctx->setCheckpointContext(std::move(ckpt_request));
-        setCurrentChunk(Chunk{getOutputs().front().getHeader().getColumns(), 0}, std::move(chunk_ctx));
+        setCurrentChunk(Chunk{getOutputs().front().getHeader().getColumns(), 0, nullptr, std::move(chunk_ctx)});
         assert(!ckpt_request);
         return true;
     }

--- a/src/Processors/Transforms/Streaming/AggregatingTransform.h
+++ b/src/Processors/Transforms/Streaming/AggregatingTransform.h
@@ -178,7 +178,7 @@ private:
     Int64 updateAndAlignWatermark(Int64 new_watermark);
 
     /// Try propagate and garbage collect time bucketed memory by finalized watermark
-    bool propagateWatermarkAndClear();
+    bool propagateWatermarkAndClearExpiredStates();
 
     /// Try propagate checkpoint to downstream
     bool propagateCheckpointAndReset();
@@ -190,7 +190,7 @@ protected:
     void emitVersion(Chunk & chunk);
     /// return {should_abort, need_finalization} pair
     virtual std::pair<bool, bool> executeOrMergeColumns(Chunk & chunk, size_t num_rows);
-    void setCurrentChunk(Chunk chunk, const ChunkContextPtr & chunk_ctx, Chunk retracted_chunk = {});
+    void setCurrentChunk(Chunk chunk, Chunk retracted_chunk = {});
 
     /// Quickly check if need finalization
     virtual bool needFinalization(Int64 /*min_watermark*/) const { return true; }
@@ -198,7 +198,7 @@ protected:
     /// Prepare and check whether can finalization many_data (called after acquired finalizing lock)
     virtual bool prepareFinalization(Int64 /*min_watermark*/) { return true; }
 
-    virtual void clearFinalized(Int64 /*finalized_watermark*/) { }
+    virtual void clearExpiredState(Int64 /*finalized_watermark*/) { }
 
 protected:
     /// To read the data that was flushed into the temporary data file.

--- a/src/Processors/Transforms/Streaming/AggregatingTransform.h
+++ b/src/Processors/Transforms/Streaming/AggregatingTransform.h
@@ -198,7 +198,7 @@ protected:
     /// Prepare and check whether can finalization many_data (called after acquired finalizing lock)
     virtual bool prepareFinalization(Int64 /*min_watermark*/) { return true; }
 
-    virtual void removeBuckets(Int64 /*finalized_watermark*/) { }
+    virtual void clearFinalized(Int64 /*finalized_watermark*/) { }
 
 protected:
     /// To read the data that was flushed into the temporary data file.

--- a/src/Processors/Transforms/Streaming/AggregatingTransformWithSubstream.h
+++ b/src/Processors/Transforms/Streaming/AggregatingTransformWithSubstream.h
@@ -85,6 +85,9 @@ private:
 
     virtual void finalize(const SubstreamContextPtr &, const ChunkContextPtr &) { }
 
+    /// Try propagate and garbage collect time bucketed memory by finalized watermark
+    void propagateWatermarkAndClear(const SubstreamContextPtr & substream_ctx);
+
 protected:
     void emitVersion(Chunk & chunk, const SubstreamContextPtr & substream_ctx);
     /// return {should_abort, need_finalization} pair
@@ -93,6 +96,8 @@ protected:
 
     virtual SubstreamContextPtr getOrCreateSubstreamContext(const SubstreamID & id);
     bool removeSubstreamContext(const SubstreamID & id);
+
+    virtual void clearFinalized(Int64 /*finalized_watermark*/, const SubstreamContextPtr &) { }
 
     inline IProcessor::Status preparePushToOutput();
 

--- a/src/Processors/Transforms/Streaming/AggregatingTransformWithSubstream.h
+++ b/src/Processors/Transforms/Streaming/AggregatingTransformWithSubstream.h
@@ -86,18 +86,18 @@ private:
     virtual void finalize(const SubstreamContextPtr &, const ChunkContextPtr &) { }
 
     /// Try propagate and garbage collect time bucketed memory by finalized watermark
-    void propagateWatermarkAndClear(const SubstreamContextPtr & substream_ctx);
+    void propagateWatermarkAndClearExpiredStates(const SubstreamContextPtr & substream_ctx);
 
 protected:
     void emitVersion(Chunk & chunk, const SubstreamContextPtr & substream_ctx);
     /// return {should_abort, need_finalization} pair
     virtual std::pair<bool, bool> executeOrMergeColumns(Chunk & chunk, const SubstreamContextPtr & substream_ctx);
-    void setCurrentChunk(Chunk chunk, const ChunkContextPtr & chunk_ctx, Chunk retracted_chunk = {});
+    void setCurrentChunk(Chunk chunk, Chunk retracted_chunk = {});
 
     virtual SubstreamContextPtr getOrCreateSubstreamContext(const SubstreamID & id);
     bool removeSubstreamContext(const SubstreamID & id);
 
-    virtual void clearFinalized(Int64 /*finalized_watermark*/, const SubstreamContextPtr &) { }
+    virtual void clearExpiredState(Int64 /*finalized_watermark*/, const SubstreamContextPtr &) { }
 
     inline IProcessor::Status preparePushToOutput();
 

--- a/src/Processors/Transforms/Streaming/ChangelogConvertTransform.cpp
+++ b/src/Processors/Transforms/Streaming/ChangelogConvertTransform.cpp
@@ -310,7 +310,7 @@ void ChangelogConvertTransform::retractAndIndex(size_t rows, const ColumnRawPtrs
         /// We also can't concat -1 / +1 chunks since downstream join depends on this separation
         /// behavior meaning depends on a chunk is either all retraction or all append which
         /// largely simplify its logic and usually more performant
-        output_chunks.back().getOrCreateChunkContext()->setRetractedDataFlag();
+        output_chunks.back().setRetractedDataFlag();
     }
 
     /// Composing resulting chunk

--- a/src/Processors/Transforms/Streaming/ChangelogTransform.cpp
+++ b/src/Processors/Transforms/Streaming/ChangelogTransform.cpp
@@ -140,7 +140,7 @@ void ChangelogTransform::work()
     }
     else if (std::all_of(delta_flags.begin(), delta_flags.end(), [](auto delta) { return delta < 0; }))
     {
-        input_data.chunk.getOrCreateChunkContext()->setRetractedDataFlag();
+        input_data.chunk.setRetractedDataFlag();
         transformChunk(input_data.chunk);
         return;
     }
@@ -163,7 +163,7 @@ void ChangelogTransform::work()
 
     if (chunks[0].getNumRows())
     {
-        chunks[0].getOrCreateChunkContext()->setRetractedDataFlag();
+        chunks[0].setRetractedDataFlag();
         transformChunk(chunks[0]);
     }
 

--- a/src/Processors/Transforms/Streaming/GlobalAggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/GlobalAggregatingTransform.cpp
@@ -130,7 +130,8 @@ void GlobalAggregatingTransform::finalize(const ChunkContextPtr & chunk_ctx)
         auto [retracted_chunk, chunk] = AggregatingHelper::mergeAndConvertToChangelogChunk(
             many_data->variants, many_data->getField<ManyRetractedDataVariants>(), *params);
 
-        setCurrentChunk(std::move(chunk), chunk_ctx, std::move(retracted_chunk));
+        chunk.setChunkContext(chunk_ctx);
+        setCurrentChunk(std::move(chunk), std::move(retracted_chunk));
     }
     else
     {
@@ -138,7 +139,8 @@ void GlobalAggregatingTransform::finalize(const ChunkContextPtr & chunk_ctx)
         if (params->emit_version && params->final)
             emitVersion(chunk);
 
-        setCurrentChunk(std::move(chunk), chunk_ctx);
+        chunk.setChunkContext(chunk_ctx);
+        setCurrentChunk(std::move(chunk));
     }
 }
 

--- a/src/Processors/Transforms/Streaming/GlobalAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/GlobalAggregatingTransformWithSubstream.cpp
@@ -89,7 +89,8 @@ void GlobalAggregatingTransformWithSubstream::finalize(const SubstreamContextPtr
     {
         auto [retracted_chunk, chunk]
             = AggregatingHelper::convertToChangelogChunk(variants, *substream_ctx->getField<RetractedDataVariantsPtr>(), *params);
-        setCurrentChunk(std::move(chunk), chunk_ctx, std::move(retracted_chunk));
+        chunk.setChunkContext(chunk_ctx);
+        setCurrentChunk(std::move(chunk), std::move(retracted_chunk));
     }
     else
     {
@@ -97,7 +98,8 @@ void GlobalAggregatingTransformWithSubstream::finalize(const SubstreamContextPtr
         if (params->final && params->emit_version)
             emitVersion(chunk, substream_ctx);
 
-        setCurrentChunk(std::move(chunk), chunk_ctx);
+        chunk.setChunkContext(chunk_ctx);
+        setCurrentChunk(std::move(chunk));
     }
     auto end = MonotonicMilliseconds::now();
 

--- a/src/Processors/Transforms/Streaming/JoinTransform.cpp
+++ b/src/Processors/Transforms/Streaming/JoinTransform.cpp
@@ -201,7 +201,7 @@ void JoinTransform::work()
         /// Propagate request checkpoint
         std::scoped_lock lock(mutex);
         assert(!output_chunks.empty());
-        output_chunks.back().getOrCreateChunkContext()->setCheckpointContext(std::move(requested_ckpt));
+        output_chunks.back().setCheckpointContext(std::move(requested_ckpt));
     }
 }
 
@@ -220,7 +220,7 @@ inline bool JoinTransform::setupWatermark(Chunk & chunk, int64_t local_watermark
         watermark = local_watermark;
 
         /// Propagate it
-        chunk.getOrCreateChunkContext()->setWatermark(local_watermark);
+        chunk.setWatermark(local_watermark);
         return true;
     }
     return false;
@@ -278,7 +278,7 @@ inline void JoinTransform::joinBidirectionally(Chunks chunks)
             if (retracted_block_rows)
             {
                 /// Don't watermark this block. We can concat retracted / result blocks or use avoid watermarking
-                auto chunk_ctx = std::make_shared<ChunkContext>();
+                auto chunk_ctx = ChunkContext::create();
                 chunk_ctx->setRetractedDataFlag();
                 output_chunks.emplace_back(retracted_block.getColumns(), retracted_block_rows, nullptr, std::move(chunk_ctx));
             }

--- a/src/Processors/Transforms/Streaming/SessionAggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/SessionAggregatingTransform.cpp
@@ -58,7 +58,7 @@ std::pair<bool, bool> SessionAggregatingTransform::executeOrMergeColumns(Chunk &
         {
             if (!(*riter)->active)
             {
-                chunk.getOrCreateChunkContext()->setWatermark((*riter)->id);
+                chunk.setWatermark((*riter)->id);
                 return result;
             }
         }

--- a/src/Processors/Transforms/Streaming/SessionAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/SessionAggregatingTransformWithSubstream.cpp
@@ -61,7 +61,7 @@ SessionAggregatingTransformWithSubstream::executeOrMergeColumns(Chunk & chunk, c
         {
             if (!(*riter)->active)
             {
-                chunk.getOrCreateChunkContext()->setWatermark((*riter)->id);
+                chunk.setWatermark((*riter)->id);
                 return result;
             }
         }

--- a/src/Processors/Transforms/Streaming/ShufflingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/ShufflingTransform.cpp
@@ -124,13 +124,14 @@ void ShufflingTransform::consume(Chunk chunk)
 {
     if (chunk.hasRows())
     {
+        auto chunk_ctx = chunk.getChunkContext(); /// save chunk context before split
         auto split_chunks{chunk_splitter.split(chunk)};
         for (auto & chunk_with_id : split_chunks)
         {
             assert(chunk_with_id.chunk);
             auto output_idx = chunk_with_id.id.items[0] % outputs.size();
             /// Keep substream id for each sub-chunk, used for downstream processors
-            chunk_with_id.chunk.setChunkContext(chunk.cloneChunkContext());
+            chunk_with_id.chunk.setChunkContext(chunk_ctx ? chunk_ctx->clone() : nullptr);
             chunk_with_id.chunk.getOrCreateChunkContext()->setSubstreamID(std::move(chunk_with_id.id));  
             shuffled_output_chunks[output_idx].push(std::move(chunk_with_id.chunk));
         }

--- a/src/Processors/Transforms/Streaming/ShufflingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/ShufflingTransform.cpp
@@ -124,16 +124,14 @@ void ShufflingTransform::consume(Chunk chunk)
 {
     if (chunk.hasRows())
     {
-        auto chunk_ctx = chunk.getOrCreateChunkContext();
         auto split_chunks{chunk_splitter.split(chunk)};
         for (auto & chunk_with_id : split_chunks)
         {
             assert(chunk_with_id.chunk);
             auto output_idx = chunk_with_id.id.items[0] % outputs.size();
             /// Keep substream id for each sub-chunk, used for downstream processors
-            auto new_chunk_ctx = std::make_shared<ChunkContext>(*chunk_ctx);
-            new_chunk_ctx->setSubstreamID(std::move(chunk_with_id.id));
-            chunk_with_id.chunk.setChunkContext(std::move(new_chunk_ctx));
+            chunk_with_id.chunk.setChunkContext(chunk.cloneChunkContext());
+            chunk_with_id.chunk.getOrCreateChunkContext()->setSubstreamID(std::move(chunk_with_id.id));  
             shuffled_output_chunks[output_idx].push(std::move(chunk_with_id.chunk));
         }
     }
@@ -141,12 +139,13 @@ void ShufflingTransform::consume(Chunk chunk)
     {
         chunk.trySetSubstreamID(INVALID_SUBSTREAM_ID);
 
-        /// Shuffling is very upstream, downstream substream watermark transform still
+        /// Shuffling is upstream, downstream substream watermark transform still
         /// depends on this empty timer chunk to calculate watermark for global aggregation
         /// When we fix the timer issue systematically, the pipeline system shall have minimum
         /// empty block flowing around and we don't need this anymore
+        auto chunk_ctx = chunk.getChunkContext();
         for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx)
-            shuffled_output_chunks[output_idx].push(chunk.clone());
+            shuffled_output_chunks[output_idx].push(chunk.cloneWithChunkContext(chunk_ctx));
     }
 }
 

--- a/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransform.cpp
@@ -46,7 +46,8 @@ void UserDefinedEmitStrategyAggregatingTransform::finalize(const ChunkContextPtr
     if (params->emit_version && params->final)
         emitVersion(chunk);
 
-    setCurrentChunk(std::move(chunk), chunk_ctx);
+    chunk.setChunkContext(chunk_ctx);
+    setCurrentChunk(std::move(chunk));
 }
 }
 }

--- a/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/UserDefinedEmitStrategyAggregatingTransformWithSubstream.cpp
@@ -35,7 +35,8 @@ void UserDefinedEmitStrategyAggregatingTransformWithSubstream::finalize(const Su
     if (params->emit_version && params->final)
         emitVersion(chunk, substream_ctx);
 
-    setCurrentChunk(std::move(chunk), chunk_ctx);
+    chunk.setChunkContext(chunk_ctx);
+    setCurrentChunk(std::move(chunk));
 }
 }
 }

--- a/src/Processors/Transforms/Streaming/WatermarkStamper.cpp
+++ b/src/Processors/Transforms/Streaming/WatermarkStamper.cpp
@@ -189,7 +189,7 @@ void WatermarkStamper::processPeriodic(Chunk & chunk)
 
     next_periodic_emit_ts = now + periodic_interval;
 
-    chunk.getOrCreateChunkContext()->setWatermark(now);
+    chunk.setWatermark(now);
 }
 
 void WatermarkStamper::processTimeout(Chunk & chunk)
@@ -213,7 +213,7 @@ void WatermarkStamper::processTimeout(Chunk & chunk)
     watermark_ts = max_event_ts + 1;
     next_timeout_emit_ts = now + timeout_interval;
 
-    chunk.getOrCreateChunkContext()->setWatermark(TIMEOUT_WATERMARK);
+    chunk.setWatermark(TIMEOUT_WATERMARK);
     LOG_DEBUG(log, "Timeout emit time={}, rows={}", now, chunk.getNumRows());
 }
 
@@ -310,8 +310,7 @@ void WatermarkStamper::processWatermark(Chunk & chunk)
     /// Use max event time as new watermark
     if (event_ts_watermark > watermark_ts)
     {
-        auto chunk_ctx = chunk.getOrCreateChunkContext();
-        chunk_ctx->setWatermark(event_ts_watermark);
+        chunk.setWatermark(event_ts_watermark);
         watermark_ts = event_ts_watermark;
     }
 }

--- a/src/Processors/Transforms/Streaming/WatermarkStamper.h
+++ b/src/Processors/Transforms/Streaming/WatermarkStamper.h
@@ -60,7 +60,7 @@ public:
     void preProcess(const Block & header);
     void process(Chunk & chunk);
 
-    bool requiresPeriodicOrTimeout() const { return periodic_interval || timeout_interval; }
+    bool requiresPeriodicOrTimeoutEmit() const { return periodic_interval || timeout_interval; }
 
     VersionType getVersion() const;
 

--- a/src/Processors/Transforms/Streaming/WatermarkStamper.h
+++ b/src/Processors/Transforms/Streaming/WatermarkStamper.h
@@ -60,6 +60,8 @@ public:
     void preProcess(const Block & header);
     void process(Chunk & chunk);
 
+    bool requiresPeriodicOrTimeout() const { return periodic_interval || timeout_interval; }
+
     VersionType getVersion() const;
 
     virtual void serialize(WriteBuffer & wb) const;

--- a/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.cpp
@@ -144,9 +144,9 @@ void WatermarkTransformWithSubstream::work()
         /// FIXME, we shall establish timer only when necessary instead of blindly generating empty heartbeat chunk
         bool propagated_heartbeat = false;
 
-        /// It's possible to generate periodic or timeout watermark for each substream by empty chunk
+        /// It's possible to generate periodic or timeout watermark for each substream via an empty chunk
         /// FIXME: This is a very ugly and inefficient implementation and needs to revisit.
-        if (!avoid_watermark && watermark_template->requiresPeriodicOrTimeout())
+        if (!avoid_watermark && watermark_template->requiresPeriodicOrTimeoutEmit())
         {
             output_chunks.reserve(substream_watermarks.size());
             for (auto & [id, watermark] : substream_watermarks)
@@ -156,7 +156,7 @@ void WatermarkTransformWithSubstream::work()
 
                 if (process_chunk.hasChunkContext())
                 {
-                    process_chunk.getChunkContext()->setSubstreamID(id);
+                    process_chunk.trySetSubstreamID(id);
                     output_chunks.emplace_back(process_chunk.clone());
                     propagated_heartbeat = true;
                 }

--- a/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/WatermarkTransformWithSubstream.cpp
@@ -127,36 +127,39 @@ void WatermarkTransformWithSubstream::work()
         checkpoint(process_chunk.getCheckpointContext());
         output_chunks.emplace_back(std::move(process_chunk));
     }
-    else if (avoid_watermark)
-    {
-        output_chunks.emplace_back(std::move(process_chunk));
-    }
     else if (process_chunk.hasRows())
     {
         assert(process_chunk.hasChunkContext());
 
         auto & watermark = getOrCreateSubstreamWatermark(process_chunk.getSubstreamID());
 
-        watermark.process(process_chunk);
-        assert(process_chunk);
+        if (!avoid_watermark)
+            watermark.process(process_chunk);
 
+        assert(process_chunk);
         output_chunks.emplace_back(std::move(process_chunk));
     }
     else
     {
         /// FIXME, we shall establish timer only when necessary instead of blindly generating empty heartbeat chunk
         bool propagated_heartbeat = false;
-        output_chunks.reserve(substream_watermarks.size());
-        for (auto & [id, watermark] : substream_watermarks)
-        {
-            auto chunk = process_chunk.clone();
-            watermark->process(chunk);
 
-            if (chunk.hasChunkContext())
+        /// It's possible to generate periodic or timeout watermark for each substream by empty chunk
+        /// FIXME: This is a very ugly and inefficient implementation and needs to revisit.
+        if (!avoid_watermark && watermark_template->requiresPeriodicOrTimeout())
+        {
+            output_chunks.reserve(substream_watermarks.size());
+            for (auto & [id, watermark] : substream_watermarks)
             {
-                chunk.getChunkContext()->setSubstreamID(id);
-                output_chunks.emplace_back(std::move(chunk));
-                propagated_heartbeat = true;
+                process_chunk.setChunkContext(nullptr); /// clear context, act as a heart beat
+                watermark->process(process_chunk);
+
+                if (process_chunk.hasChunkContext())
+                {
+                    process_chunk.getChunkContext()->setSubstreamID(id);
+                    output_chunks.emplace_back(process_chunk.clone());
+                    propagated_heartbeat = true;
+                }
             }
         }
 

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransform.cpp
@@ -160,7 +160,7 @@ void WindowAggregatingTransform::finalize(const ChunkContextPtr & chunk_ctx)
         setCurrentChunk(std::move(merged_chunk), chunk_ctx);
 }
 
-void WindowAggregatingTransform::removeBuckets(Int64 finalized_watermark)
+void WindowAggregatingTransform::clearFinalized(Int64 finalized_watermark)
 {
     /// Blocking finalization during remove buckets from current variant
     std::lock_guard lock(variants_mutex);

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransform.h
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransform.h
@@ -27,7 +27,7 @@ protected:
 
     void finalize(const ChunkContextPtr & chunk_ctx) override;
 
-    void clearFinalized(Int64 finalized_watermark) override;
+    void clearExpiredState(Int64 finalized_watermark) override;
 
     std::vector<Int64> getBucketsBefore(Int64 max_buckets) const;
 

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransform.h
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransform.h
@@ -27,7 +27,7 @@ protected:
 
     void finalize(const ChunkContextPtr & chunk_ctx) override;
 
-    void removeBuckets(Int64 finalized_watermark) override;
+    void clearFinalized(Int64 finalized_watermark) override;
 
     std::vector<Int64> getBucketsBefore(Int64 max_buckets) const;
 

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransformWithSubstream.cpp
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransformWithSubstream.cpp
@@ -96,5 +96,10 @@ void WindowAggregatingTransformWithSubstream::doFinalize(
     }
 }
 
+void WindowAggregatingTransformWithSubstream::clearFinalized(Int64 finalized_watermark, const SubstreamContextPtr & substream_ctx)
+{
+    removeBucketsImpl(finalized_watermark, substream_ctx);
+}
+
 }
 }

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransformWithSubstream.h
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransformWithSubstream.h
@@ -16,7 +16,7 @@ public:
 protected:
     void finalize(const SubstreamContextPtr & substream_ctx, const ChunkContextPtr & chunk_ctx) override;
 
-    void clearFinalized(Int64 finalized_watermark, const SubstreamContextPtr & substream_ctx) override;
+    void clearExpiredState(Int64 finalized_watermark, const SubstreamContextPtr & substream_ctx) override;
 
 private:
     inline void doFinalize(Int64 watermark, const SubstreamContextPtr & substream_ctx, const ChunkContextPtr & chunk_ctx);

--- a/src/Processors/Transforms/Streaming/WindowAggregatingTransformWithSubstream.h
+++ b/src/Processors/Transforms/Streaming/WindowAggregatingTransformWithSubstream.h
@@ -16,6 +16,8 @@ public:
 protected:
     void finalize(const SubstreamContextPtr & substream_ctx, const ChunkContextPtr & chunk_ctx) override;
 
+    void clearFinalized(Int64 finalized_watermark, const SubstreamContextPtr & substream_ctx) override;
+
 private:
     inline void doFinalize(Int64 watermark, const SubstreamContextPtr & substream_ctx, const ChunkContextPtr & chunk_ctx);
 

--- a/src/Processors/Transforms/convertToChunk.cpp
+++ b/src/Processors/Transforms/convertToChunk.cpp
@@ -19,11 +19,7 @@ Chunk convertToChunk(const Block & block)
 
     /// proton: starts
     if (block.hasWatermark())
-    {
-        auto chunk_ctx = std::make_shared<ChunkContext>();
-        chunk_ctx->setWatermark(block.watermark());
-        chunk.setChunkContext(std::move(chunk_ctx));
-    }
+        chunk.setWatermark(block.watermark());
     /// proton: ends
 
     return chunk;

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -370,9 +370,7 @@ Chunk KafkaSource::doCheckpoint(CheckpointContextPtr ckpt_ctx_)
 {
     /// Prepare checkpoint barrier chunk
     auto result = header_chunk.clone();
-    auto chunk_ctx = std::make_shared<ChunkContext>();
-    chunk_ctx->setCheckpointContext(ckpt_ctx_);
-    result.setChunkContext(std::move(chunk_ctx));
+    result.setCheckpointContext(ckpt_ctx_);
 
     ckpt_ctx_->coordinator->checkpoint(State::VERSION, getLogicID(), ckpt_ctx_, [&](WriteBuffer & wb) { ckpt_data.serialize(wb); });
 

--- a/src/Storages/Streaming/StreamingStoreSource.cpp
+++ b/src/Storages/Streaming/StreamingStoreSource.cpp
@@ -113,7 +113,7 @@ void StreamingStoreSource::readAndProcess()
         result_chunks.emplace_back(std::move(columns), rows);
         if (likely(block.info.appendTime() > 0))
         {
-            auto chunk_ctx = std::make_shared<ChunkContext>();
+            auto chunk_ctx = ChunkContext::create();
             chunk_ctx->setAppendTime(block.info.appendTime());
             result_chunks.back().setChunkContext(std::move(chunk_ctx));
         }

--- a/src/Storages/Streaming/StreamingStoreSourceBase.cpp
+++ b/src/Storages/Streaming/StreamingStoreSourceBase.cpp
@@ -178,9 +178,7 @@ Chunk StreamingStoreSourceBase::doCheckpoint(CheckpointContextPtr current_ckpt_c
 
     /// Prepare checkpoint barrier chunk
     auto result = header_chunk.clone();
-    auto chunk_ctx = std::make_shared<ChunkContext>();
-    chunk_ctx->setCheckpointContext(current_ckpt_ctx);
-    result.setChunkContext(std::move(chunk_ctx));
+    result.setCheckpointContext(current_ckpt_ctx);
 
     /// Commit the checkpoint : shard
     auto stream_shard = getStreamShard();

--- a/src/Storages/Streaming/StreamingStoreSourceChannel.cpp
+++ b/src/Storages/Streaming/StreamingStoreSourceChannel.cpp
@@ -93,7 +93,7 @@ void StreamingStoreSourceChannel::readAndProcess()
         result_chunks.emplace_back(std::move(columns), rows);
         if (likely(block.info.appendTime() > 0))
         {
-            auto chunk_ctx = std::make_shared<ChunkContext>();
+            auto chunk_ctx = ChunkContext::create();
             chunk_ctx->setAppendTime(block.info.appendTime());
             result_chunks.back().setChunkContext(std::move(chunk_ctx));
         }

--- a/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
+++ b/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
@@ -243,3 +243,55 @@ tests:
       - query_id: '3101-1'
         expected_results:
           - [101]
+
+  - id: 4
+    tags:
+      - "global aggr"
+      - "shuffle by"
+    name: global-aggr-with-shuffle-by
+    description: global aggregation query with shuffle by, convering stremaing and historical query, by default disable convert to two level
+    steps:
+      - statements:
+        - client: python
+          query_type: table
+          query: |
+            drop stream if exists test_31_multishards_stream;
+
+        - client: python
+          query_type: table
+          exist: test_31_multishards_stream
+          exist_wait: 2
+          wait: 1
+          query: |
+            create stream if not exists test_31_multishards_stream(i int, v string) settings shards=3;
+
+        - client: python
+          query_type: table
+          depends_on_stream: test_31_multishards_stream
+          wait: 1
+          query: |
+            insert into test_31_multishards_stream(i, v) select i % 100 + 1, v from test_31_rstream settings max_block_size=100, max_events=10000;
+
+        - client: python
+          query_type: stream
+          query_id: 3100
+          depends_on_stream: test_31_multishards_stream
+          wait: 1
+          query_end_timer: 5
+          query: |
+            with cte as (select i, count() from test_31_multishards_stream where _tp_time > earliest_ts() shuffle by i group by i settings group_by_two_level_threshold=10) select count() from cte settings emit_aggregated_during_backfill=false;
+
+        - client: python
+          query_type: table
+          query_id: 3101
+          depends_on_stream: test_31_multishards_stream
+          query: |
+            with cte as (select i, count() from table(test_31_multishards_stream) shuffle by i group by i settings group_by_two_level_threshold=10, max_block_size=100, max_events=10000) select count() from cte;
+
+    expected_results:
+      - query_id: '3100'
+        expected_results:
+          - [100]
+      - query_id: '3101'
+        expected_results:
+          - [100]


### PR DESCRIPTION
This resolves #268 

Please write user-readable short description of the changes:
- Build streaming shuffled aggregating pipe for shuffle by
- fix the ChunkContext was shared wrongly in multiple threads (AggregatingTransformWithSubstream) after shuffled 