### PR TITLE
Send one message to Kafka per row

### DIFF
--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -223,8 +223,9 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
     if (data_format.empty())
         data_format = "JSONEachRow";
 
-    writer = FormatFactory::instance().getOutputFormat(data_format, *wb, header, context);
-    writer->setAutoFlush();
+    /// The callback lets it produce one Kafka message per row.
+    writer = FormatFactory::instance().getOutputFormat(
+        data_format, *wb, header, context, [this](auto & /*column*/, auto /*row*/) { wb->next(); });
 
     partitioner = std::make_unique<KafkaStream::ChunkPartitioner>(context, header, kafka->partitioning_expr_ast());
 

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -226,6 +226,7 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
     /// The callback lets it produce one Kafka message per row.
     writer = FormatFactory::instance().getOutputFormat(
         data_format, *wb, header, context, [this](auto & /*column*/, auto /*row*/) { wb->next(); });
+    writer->setAutoFlush();
 
     partitioner = std::make_unique<KafkaStream::ChunkPartitioner>(context, header, kafka->partitioning_expr_ast());
 

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -223,7 +223,7 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
     if (data_format.empty())
         data_format = "JSONEachRow";
 
-    /// The callback lets it produce one Kafka message per row.
+    /// The callback allows `IRowOutputFormat` based formats produce one Kafka message per row.
     writer = FormatFactory::instance().getOutputFormat(
         data_format, *wb, header, context, [this](auto & /*column*/, auto /*row*/) { wb->next(); });
     writer->setAutoFlush();

--- a/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/WriteBufferFromKafka.cpp
@@ -20,6 +20,7 @@ void WriteBufferFromKafka::nextImpl()
     if (!offset())
         return;
 
+    /// rd_kafka_produce only enqueue messages, it does not send messages out right away.
     auto err = rd_kafka_produce(
         topic,
         /// we want to trigger the partitioner function, check KafkaSink.cpp


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Instead of encoding multiple rows into one single message, now it sends one message per row, which is the expected behavior.

closes #274 
