### PR TITLE
std::memcpy has overlapped memory region. Switched to std::memmove

### DIFF
--- a/src/Storages/ExternalStream/Log/FileLogSource.cpp
+++ b/src/Storages/ExternalStream/Log/FileLogSource.cpp
@@ -147,7 +147,7 @@ Chunk FileLogSource::process()
             col->insertData(line.data(), line.size());
 
         /// Move the remaining bytes to the start of buffer
-        memcpy(buffer.data(), buffer.data() + (buffer_offset - left), left);
+        std::memmove(buffer.data(), buffer.data() + (buffer_offset - left), left);
         remaining = left;
         buffer_offset = left;
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Closed #295 
