### PR TITLE
expose read metrics of external streams to the current prometheus endpoint

### DIFF
--- a/programs/server/config.yaml
+++ b/programs/server/config.yaml
@@ -645,6 +645,7 @@ prometheus:
     events: true
     asynchronous_metrics: true
     status_info: true
+    external_stream: true
 
 # Query log. Used only for queries with setting log_queries = 1.
 query_log:

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -153,7 +153,7 @@ HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, Asynchronous
     {
         auto factory = std::make_shared<HTTPRequestHandlerFactoryMain>(name);
         auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics));
+            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics, server.context()));
         handler->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"));
         handler->allowGetAndHeadRequest();
         factory->addHandler(handler);
@@ -218,7 +218,7 @@ void addDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IServer 
     if (server.config().has("prometheus") && server.config().getInt("prometheus.port", 0) == 0)
     {
         auto prometheus_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics));
+            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics, server.context()));
         prometheus_handler->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"));
         prometheus_handler->allowGetAndHeadRequest();
         factory.addHandler(prometheus_handler);

--- a/src/Server/PrometheusMetricsWriter.cpp
+++ b/src/Server/PrometheusMetricsWriter.cpp
@@ -1,9 +1,9 @@
 #include "PrometheusMetricsWriter.h"
-
 #include <algorithm>
 
 #include <IO/WriteHelpers.h>
 #include <Common/StatusInfo.h>
+#include <Storages/ExternalStream/StorageExternalStream.h>
 #include <regex>
 
 namespace
@@ -41,12 +41,14 @@ namespace DB
 
 PrometheusMetricsWriter::PrometheusMetricsWriter(
     const Poco::Util::AbstractConfiguration & config, const std::string & config_name,
-    const AsynchronousMetrics & async_metrics_)
+    const AsynchronousMetrics & async_metrics_, ContextPtr context)
     : async_metrics(async_metrics_)
+    , context(context)
     , send_events(config.getBool(config_name + ".events", true))
     , send_metrics(config.getBool(config_name + ".metrics", true))
     , send_asynchronous_metrics(config.getBool(config_name + ".asynchronous_metrics", true))
     , send_status_info(config.getBool(config_name + ".status_info", true))
+    , send_external_stream(config.getBool(config_name+".external_stream", true))
 {
 }
 
@@ -121,7 +123,6 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
 
             writeOutLine(wb, "# HELP", key, metric_doc);
             writeOutLine(wb, "# TYPE", key, "gauge");
-
             for (const auto & value: CurrentStatusInfo::values[i])
             {
                 for (const auto & enum_value: CurrentStatusInfo::getAllPossibleValues(static_cast<CurrentStatusInfo::Status>(i)))
@@ -136,6 +137,35 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
                     DB::writeText("} ", wb);
                     DB::writeText(value.second == enum_value.second, wb);
                     DB::writeChar('\n', wb);
+                }
+            }
+        }
+    }
+    if (send_external_stream) {
+        auto databases = DatabaseCatalog::instance().getDatabases();
+        for (const auto & database_name : databases | boost::adaptors::map_keys){
+            DatabasePtr database = DatabaseCatalog::instance().tryGetDatabase(database_name);
+            if (!database)
+                continue;
+            for (auto table_it = database->getTablesIterator(context); table_it->isValid(); table_it->next()) {
+                StoragePtr tableptr = table_it->table();
+                if(auto * external_stream = tableptr->as<StorageExternalStream>()){
+                    auto tablestorageid = external_stream->getStorageID();
+                    std::string tablename = tablestorageid.getFullTableName();
+                    auto excounter = external_stream->getExternalStreamCounter();
+                    std::vector<ExternalStreamCounter::CounterInfo> counters = excounter->getCounters();
+                    for (const auto& cntinfo : counters) {
+                        std::string key{external_stream_prefix + cntinfo.name};
+                        writeOutLine(wb, "# TYPE", key, "counter");
+                        DB::writeText(key, wb);
+                        DB::writeText("{name=", wb);
+                        DB::writeText(tablename, wb);
+                        DB::writeText("}=", wb);
+                        DB::writeText(key, wb);
+                        DB::writeChar(' ', wb);
+                        DB::writeIntText(cntinfo.value, wb);
+                        DB::writeChar('\n', wb);
+                    }
                 }
             }
         }

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -9,7 +9,6 @@
 
 #include <Poco/Util/AbstractConfiguration.h>
 
-
 namespace DB
 {
 
@@ -19,10 +18,9 @@ class PrometheusMetricsWriter
 public:
     PrometheusMetricsWriter(
         const Poco::Util::AbstractConfiguration & config, const std::string & config_name,
-        const AsynchronousMetrics & async_metrics_, ContextPtr context);
+        const AsynchronousMetrics & async_metrics_, ContextPtr context_);
 
     void write(WriteBuffer & wb) const;
-
 
 private:
     const AsynchronousMetrics & async_metrics;
@@ -38,7 +36,7 @@ private:
     static inline constexpr auto current_metrics_prefix = "ProtonMetrics_";
     static inline constexpr auto asynchronous_metrics_prefix = "ProtonAsyncMetrics_";
     static inline constexpr auto current_status_prefix = "ProtonStatusInfo_";
-    static inline constexpr auto external_stream_prefix = "ExternalStream_";
+    static inline constexpr auto external_stream_prefix = "ProtonExternalStream_";
 };
 
 }

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -3,10 +3,12 @@
 #include <string>
 
 #include <Interpreters/AsynchronousMetrics.h>
+#include <Interpreters/Context_fwd.h>
 
 #include <IO/WriteBuffer.h>
 
 #include <Poco/Util/AbstractConfiguration.h>
+
 
 namespace DB
 {
@@ -17,22 +19,26 @@ class PrometheusMetricsWriter
 public:
     PrometheusMetricsWriter(
         const Poco::Util::AbstractConfiguration & config, const std::string & config_name,
-        const AsynchronousMetrics & async_metrics_);
+        const AsynchronousMetrics & async_metrics_, ContextPtr context);
 
     void write(WriteBuffer & wb) const;
 
+
 private:
     const AsynchronousMetrics & async_metrics;
+    ContextPtr context;
 
     const bool send_events;
     const bool send_metrics;
     const bool send_asynchronous_metrics;
     const bool send_status_info;
+    const bool send_external_stream;
 
     static inline constexpr auto profile_events_prefix = "ProtonProfileEvents_";
     static inline constexpr auto current_metrics_prefix = "ProtonMetrics_";
     static inline constexpr auto asynchronous_metrics_prefix = "ProtonAsyncMetrics_";
     static inline constexpr auto current_status_prefix = "ProtonStatusInfo_";
+    static inline constexpr auto external_stream_prefix = "ExternalStream_";
 };
 
 }

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -45,7 +45,7 @@ HTTPRequestHandlerFactoryPtr
 createPrometheusHandlerFactory(IServer & server, AsynchronousMetrics & async_metrics, const std::string & config_prefix)
 {
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-        server, PrometheusMetricsWriter(server.config(), config_prefix + ".handler", async_metrics));
+        server, PrometheusMetricsWriter(server.config(), config_prefix + ".handler", async_metrics, server.context()));
     factory->addFiltersFromConfig(server.config(), config_prefix);
     return factory;
 }

--- a/src/Storages/ExternalStream/ExternalStreamCounter.h
+++ b/src/Storages/ExternalStream/ExternalStreamCounter.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomic>
+
+namespace DB
+{
+
+class ExternalStreamCounter
+{
+public:
+    inline uint64_t getReadBytes() const { return read_bytes.load(); }
+    inline uint64_t getReadCounts() const { return read_counts.load(); }
+    inline uint64_t getReadFailed() const { return read_failed.load(); }
+
+    inline void addToReadBytes(uint64_t bytes) { read_bytes.fetch_add(bytes); }
+    inline void addToReadCounts(uint64_t counts) { read_counts.fetch_add(counts); }
+    inline void addToReadFailed(uint64_t amount) { read_failed.fetch_add(amount); }
+
+    std::map<String, uint64_t> getCounters() const
+    {
+        return {
+            {"ReadBytes", read_bytes.load()},
+            {"ReadCounts", read_counts.load()},
+            {"ReadFailed", read_failed.load()},
+        };
+    }
+
+private:
+    std::atomic<uint64_t> read_bytes;
+    std::atomic<uint64_t> read_counts;
+    std::atomic<uint64_t> read_failed;
+};
+
+using ExternalStreamCounterPtr = std::shared_ptr<ExternalStreamCounter>;
+}

--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -34,6 +34,7 @@ Kafka::Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> setting
     , external_stream_counter(external_stream_counter_)
 {
     assert(settings->type.value == StreamTypes::KAFKA || settings->type.value == StreamTypes::REDPANDA);
+    assert(external_stream_counter);
 
     if (settings->brokers.value.empty())
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Empty `brokers` setting for {} external stream", settings->type.value);

--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -25,14 +25,14 @@ extern const int INVALID_SETTING_VALUE;
 extern const int RESOURCE_NOT_FOUND;
 }
 
-Kafka::Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, std::shared_ptr<ExternalStreamCounter> thecounter)
+Kafka::Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, ExternalStreamCounterPtr external_stream_counter_)
     : storage_id(storage->getStorageID())
     , settings(std::move(settings_))
     , data_format(settings->data_format.value)
     , log(&Poco::Logger::get("External-" + settings->topic.value))
     , engine_args(engine_args_)
+    , external_stream_counter(external_stream_counter_)
 {
-    external_stream_counter = thecounter;
     assert(settings->type.value == StreamTypes::KAFKA || settings->type.value == StreamTypes::REDPANDA);
 
     if (settings->brokers.value.empty())

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -13,7 +13,7 @@ class IStorage;
 class Kafka final : public StorageExternalStreamImpl
 {
 public:
-    Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach);
+    Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, std::shared_ptr<ExternalStreamCounter> thecounter);
     ~Kafka() override = default;
 
     void startup() override { }

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -3,6 +3,7 @@
 #include <KafkaLog/KafkaWALCommon.h>
 #include <Storages/ExternalStream/ExternalStreamSettings.h>
 #include <Storages/ExternalStream/StorageExternalStreamImpl.h>
+#include <Storages/ExternalStream/ExternalStreamCounter.h>
 #include <Storages/Streaming/SeekToInfo.h>
 
 namespace DB
@@ -13,13 +14,14 @@ class IStorage;
 class Kafka final : public StorageExternalStreamImpl
 {
 public:
-    Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, std::shared_ptr<ExternalStreamCounter> thecounter);
+    Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, ExternalStreamCounterPtr external_stream_counter_);
     ~Kafka() override = default;
 
     void startup() override { }
     void shutdown() override { }
     bool supportsSubcolumns() const override { return true; }
     NamesAndTypesList getVirtuals() const override;
+    ExternalStreamCounterPtr getExternalStreamCounter() const override { return external_stream_counter; }
 
     Pipe read(
         const Names & column_names,
@@ -66,5 +68,7 @@ private:
 
     std::mutex shards_mutex;
     int32_t shards = 0;
+
+    ExternalStreamCounterPtr external_stream_counter;
 };
 }

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -52,6 +52,8 @@ KafkaSource::KafkaSource(
     , ckpt_data(consume_ctx)
     , external_stream_counter(external_stream_counter_)
 {
+    assert(external_stream_counter);
+
     is_streaming = true;
 
     calculateColumnPositions();

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.h
@@ -4,6 +4,7 @@
 #include <KafkaLog/KafkaWALSimpleConsumer.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <Processors/ISource.h>
+#include <Storages/IStorage.h>
 #include <Storages/StorageSnapshot.h>
 #include <Checkpoint/CheckpointRequest.h>
 
@@ -30,7 +31,8 @@ public:
         Int32 shard,
         Int64 offset,
         size_t max_block_size,
-        Poco::Logger * log_);
+        Poco::Logger * log_,
+        std::shared_ptr<ExternalStreamCounter> thecounter);
 
     ~KafkaSource() override;
 
@@ -103,6 +105,7 @@ private:
 
         State(const klog::KafkaWALContext & consume_ctx_) : topic(consume_ctx_.topic), partition(consume_ctx_.partition) { }
     } ckpt_data;
+    std::shared_ptr<ExternalStreamCounter> external_stream_counter;
 };
 
 }

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.h
@@ -6,6 +6,7 @@
 #include <Processors/ISource.h>
 #include <Storages/IStorage.h>
 #include <Storages/StorageSnapshot.h>
+#include <Storages/ExternalStream/ExternalStreamCounter.h>
 #include <Checkpoint/CheckpointRequest.h>
 
 namespace Poco
@@ -32,7 +33,7 @@ public:
         Int64 offset,
         size_t max_block_size,
         Poco::Logger * log_,
-        std::shared_ptr<ExternalStreamCounter> thecounter);
+        ExternalStreamCounterPtr external_stream_counter_);
 
     ~KafkaSource() override;
 
@@ -105,7 +106,8 @@ private:
 
         State(const klog::KafkaWALContext & consume_ctx_) : topic(consume_ctx_.topic), partition(consume_ctx_.partition) { }
     } ckpt_data;
-    std::shared_ptr<ExternalStreamCounter> external_stream_counter;
+
+    ExternalStreamCounterPtr external_stream_counter;
 };
 
 }

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -3,6 +3,7 @@
 #include <Storages/IStorage.h>
 #include <base/shared_ptr_helper.h>
 #include <Common/SettingsChanges.h>
+#include <Storages/ExternalStream/ExternalStreamCounter.h>
 
 namespace DB
 {
@@ -13,10 +14,6 @@ class StorageExternalStreamImpl;
 /// external streaming storage like Kafka, Redpanda etc.
 class StorageExternalStream final : public shared_ptr_helper<StorageExternalStream>, public IStorage, public WithContext
 {
-    // StorageExternalStream(const StorageExternalStream &) = delete;
-    // StorageExternalStream(StorageExternalStream &&) = delete;
-    // StorageExternalStream & operator=(const StorageExternalStream &) = delete;
-    // StorageExternalStream & operator=(StorageExternalStream &&) = delete;
     friend struct shared_ptr_helper<StorageExternalStream>;
 
 public:
@@ -53,8 +50,8 @@ public:
     bool supportsStreamingQuery() const override { return true; }
 
     friend class KafkaSource;
-    //friend std::string getExternalStreamCounter(ContextPtr context);
-    std::shared_ptr<ExternalStreamCounter> getExternalStreamCounter();
+
+    ExternalStreamCounterPtr getExternalStreamCounter();
 
 protected:
     StorageExternalStream(
@@ -67,7 +64,6 @@ protected:
 
 private:
     std::unique_ptr<StorageExternalStreamImpl> external_stream;
-    std::shared_ptr<ExternalStreamCounter> external_stream_counter;
 };
-}
 
+}

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -13,6 +13,10 @@ class StorageExternalStreamImpl;
 /// external streaming storage like Kafka, Redpanda etc.
 class StorageExternalStream final : public shared_ptr_helper<StorageExternalStream>, public IStorage, public WithContext
 {
+    // StorageExternalStream(const StorageExternalStream &) = delete;
+    // StorageExternalStream(StorageExternalStream &&) = delete;
+    // StorageExternalStream & operator=(const StorageExternalStream &) = delete;
+    // StorageExternalStream & operator=(StorageExternalStream &&) = delete;
     friend struct shared_ptr_helper<StorageExternalStream>;
 
 public:
@@ -49,6 +53,8 @@ public:
     bool supportsStreamingQuery() const override { return true; }
 
     friend class KafkaSource;
+    //friend std::string getExternalStreamCounter(ContextPtr context);
+    std::shared_ptr<ExternalStreamCounter> getExternalStreamCounter();
 
 protected:
     StorageExternalStream(
@@ -61,6 +67,7 @@ protected:
 
 private:
     std::unique_ptr<StorageExternalStreamImpl> external_stream;
+    std::shared_ptr<ExternalStreamCounter> external_stream_counter;
 };
-
 }
+

--- a/src/Storages/ExternalStream/StorageExternalStreamImpl.h
+++ b/src/Storages/ExternalStream/StorageExternalStreamImpl.h
@@ -2,7 +2,6 @@
 
 #include <QueryPipeline/Pipe.h>
 #include <Storages/IStorage.h>
-
 namespace DB
 {
 /// Base class of StorageExternalStreamImpl
@@ -15,7 +14,6 @@ public:
     virtual void shutdown() = 0;
     virtual bool supportsSubcolumns() const { return false; }
     virtual NamesAndTypesList getVirtuals() const { return {}; }
-
     virtual Pipe read(
         const Names & column_names,
         const StorageSnapshotPtr & storage_snapshot,
@@ -30,6 +28,8 @@ public:
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Ingesting data to this type of external stream is not supported");
     }
+
+    std::shared_ptr<ExternalStreamCounter> external_stream_counter;
 };
 
 }

--- a/src/Storages/ExternalStream/StorageExternalStreamImpl.h
+++ b/src/Storages/ExternalStream/StorageExternalStreamImpl.h
@@ -2,6 +2,8 @@
 
 #include <QueryPipeline/Pipe.h>
 #include <Storages/IStorage.h>
+#include <Storages/ExternalStream/ExternalStreamCounter.h>
+
 namespace DB
 {
 /// Base class of StorageExternalStreamImpl
@@ -14,6 +16,8 @@ public:
     virtual void shutdown() = 0;
     virtual bool supportsSubcolumns() const { return false; }
     virtual NamesAndTypesList getVirtuals() const { return {}; }
+    virtual ExternalStreamCounterPtr getExternalStreamCounter() const { return nullptr; }
+
     virtual Pipe read(
         const Names & column_names,
         const StorageSnapshotPtr & storage_snapshot,
@@ -28,8 +32,6 @@ public:
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Ingesting data to this type of external stream is not supported");
     }
-
-    std::shared_ptr<ExternalStreamCounter> external_stream_counter;
 };
 
 }

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -91,6 +91,37 @@ struct ColumnSize
 
 using IndexSize = ColumnSize;
 
+struct ExternalStreamCounter {
+private:
+
+    std::atomic<int> readBytes;
+    std::atomic<int> readCounts;
+    std::atomic<int> readFailed;
+
+public:
+    int getReadBytes() { return readBytes.load();}
+    int getReadCounts() { return readCounts.load();}
+    int getReadFailed() { return readFailed.load();}
+
+    void addToReadBytes(int bytes) { readBytes.fetch_add(bytes);}
+    void addToReadCounts(int counts) { readCounts.fetch_add(counts);}
+    void addToReadFailed(int amount) { readFailed.fetch_add(amount);}
+    
+    struct CounterInfo {
+        std::string name;
+        int value;
+    };
+
+    std::vector<CounterInfo> getCounters() const {
+        return {
+            {"ReadBytes", readBytes.load()},
+            {"ReadCounts", readCounts.load()},
+            {"ReadFailed", readFailed.load()},
+        };
+    }
+
+};
+
 /** Storage. Describes the table. Responsible for
   * - storage of the table data;
   * - the definition in which files (or not in files) the data is stored;

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -91,37 +91,6 @@ struct ColumnSize
 
 using IndexSize = ColumnSize;
 
-struct ExternalStreamCounter {
-private:
-
-    std::atomic<int> readBytes;
-    std::atomic<int> readCounts;
-    std::atomic<int> readFailed;
-
-public:
-    int getReadBytes() { return readBytes.load();}
-    int getReadCounts() { return readCounts.load();}
-    int getReadFailed() { return readFailed.load();}
-
-    void addToReadBytes(int bytes) { readBytes.fetch_add(bytes);}
-    void addToReadCounts(int counts) { readCounts.fetch_add(counts);}
-    void addToReadFailed(int amount) { readFailed.fetch_add(amount);}
-    
-    struct CounterInfo {
-        std::string name;
-        int value;
-    };
-
-    std::vector<CounterInfo> getCounters() const {
-        return {
-            {"ReadBytes", readBytes.load()},
-            {"ReadCounts", readCounts.load()},
-            {"ReadFailed", readFailed.load()},
-        };
-    }
-
-};
-
 /** Storage. Describes the table. Responsible for
   * - storage of the table data;
   * - the definition in which files (or not in files) the data is stored;


### PR DESCRIPTION
- add the externalStreamCounter into the Istorage and the Kafkasource class
- add send_external_stream in PrometheusMetricsWriter
- format output and can get readBytes/readCounts/ReadFailed
