### PR TITLE
enhance telemetry metrics

### DIFF
--- a/programs/server/TelemetryCollector.cpp
+++ b/programs/server/TelemetryCollector.cpp
@@ -114,7 +114,7 @@ void TelemetryCollector::collect()
             "    \"new_session\": \"{}\","
             "    \"started_on\": \"{}\","
             "    \"duration_in_minute\": \"{}\","
-            "    \"session_id\": \"{}\","
+            "    \"server_id\": \"{}\","
             "    \"docker\": \"{}\","
             "    \"total_select_query\": \"{}\","
             "    \"historical_select_query\": \"{}\","

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -5,6 +5,8 @@
 #define APPLY_FOR_EVENTS(M) \
     M(Query, "Number of queries to be interpreted and potentially executed. Does not include queries that failed to parse or were rejected due to AST size limits, quota limits or limits on the number of simultaneously running queries. May include internal queries initiated by proton itself. Does not count subqueries.") \
     M(SelectQuery, "Same as Query, but only for SELECT queries.") \
+    M(StreamingSelectQuery, "Same as Query, but only for streaming SELECT queries.") \
+    M(HistoricalSelectQuery, "Same as Query, but only for historical SELECT queries.") \
     M(InsertQuery, "Same as Query, but only for INSERT queries.") \
     M(FailedQuery, "Number of failed queries.") \
     M(FailedSelectQuery, "Same as FailedQuery, but only for SELECT queries.") \

--- a/src/Interpreters/InterpreterFactory.cpp
+++ b/src/Interpreters/InterpreterFactory.cpp
@@ -127,10 +127,7 @@ std::unique_ptr<IInterpreter> InterpreterFactory::get(ASTPtr & query, ContextMut
     {
         auto interpreter = std::make_unique<InterpreterSelectWithUnionQuery>(query, context, options);
         ProfileEvents::increment(ProfileEvents::SelectQuery);
-        if (interpreter->isStreamingQuery())
-            ProfileEvents::increment(ProfileEvents::StreamingSelectQuery);
-        else
-            ProfileEvents::increment(ProfileEvents::HistoricalSelectQuery);
+        ProfileEvents::increment(interpreter->isStreamingQuery() ? ProfileEvents::StreamingSelectQuery : ProfileEvents::HistoricalSelectQuery);
         return std::move(interpreter);
     }
     else if (query->as<ASTSelectIntersectExceptQuery>())

--- a/src/Interpreters/InterpreterFactory.cpp
+++ b/src/Interpreters/InterpreterFactory.cpp
@@ -97,6 +97,8 @@ namespace ProfileEvents
 {
     extern const Event Query;
     extern const Event SelectQuery;
+    extern const Event StreamingSelectQuery;
+    extern const Event HistoricalSelectQuery;
     extern const Event InsertQuery;
 }
 
@@ -123,8 +125,13 @@ std::unique_ptr<IInterpreter> InterpreterFactory::get(ASTPtr & query, ContextMut
     }
     else if (query->as<ASTSelectWithUnionQuery>())
     {
+        auto interpreter = std::make_unique<InterpreterSelectWithUnionQuery>(query, context, options);
         ProfileEvents::increment(ProfileEvents::SelectQuery);
-        return std::make_unique<InterpreterSelectWithUnionQuery>(query, context, options);
+        if (interpreter->isStreamingQuery())
+            ProfileEvents::increment(ProfileEvents::StreamingSelectQuery);
+        else
+            ProfileEvents::increment(ProfileEvents::HistoricalSelectQuery);
+        return std::move(interpreter);
     }
     else if (query->as<ASTSelectIntersectExceptQuery>())
     {

--- a/tests/proton_ci/functional_tests_check.py
+++ b/tests/proton_ci/functional_tests_check.py
@@ -47,6 +47,7 @@ def get_run_command(check_name, output_path):
     env.append("-e MAX_CONCURRENT_QUERIES=200")
     env.append("-e MAX_CONCURRENT_INSERT_QUERIES=200")
     env.append("-e MAX_CONCURRENT_SELECT_QUERIES=200")
+    env.append("-e TELEMETRY_ENABLED=false")
 
     env_str = " ".join(env)
 

--- a/tests/stream/test_stream_smoke/configs/docker-compose-native.yaml
+++ b/tests/stream/test_stream_smoke/configs/docker-compose-native.yaml
@@ -27,6 +27,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -58,6 +59,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -89,6 +91,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"       

--- a/tests/stream/test_stream_smoke/configs/docker-compose-redp.yaml
+++ b/tests/stream/test_stream_smoke/configs/docker-compose-redp.yaml
@@ -28,6 +28,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -62,6 +63,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -97,6 +99,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -131,6 +134,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -165,6 +169,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"

--- a/tests/stream/test_stream_smoke/configs/docker-compose.yaml
+++ b/tests/stream/test_stream_smoke/configs/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -58,6 +59,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"      
@@ -90,6 +92,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"  
@@ -122,6 +125,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -156,6 +160,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -191,6 +196,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -225,6 +231,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -259,6 +266,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"

--- a/tests/stream/test_stream_smoke/configs/docker-compose_11_containers.yaml
+++ b/tests/stream/test_stream_smoke/configs/docker-compose_11_containers.yaml
@@ -27,6 +27,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -58,6 +59,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"      
@@ -90,6 +92,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"  
@@ -121,6 +124,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -152,6 +156,7 @@ services:
       - MAX_CONCURRENT_STREAMING_QUERIES=100   # Default: 100
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"    
@@ -185,6 +190,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -223,6 +229,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -262,6 +269,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -300,6 +308,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -338,6 +347,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -376,6 +386,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"
@@ -414,6 +425,7 @@ services:
       - MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO=0.9 # Default: 0.9
       - MAX_SERVER_MEMORY_CACHE_TO_RAM_RATIO=0.5 # Default: 0.5
       - STREAM_STORAGE_TYPE=kafka
+      - TELEMETRY_ENABLED=false # Turn off telemetry on smoke test
 
     command: >
       /bin/bash -c "echo sleeping; sleep 2; /entrypoint.sh"


### PR DESCRIPTION
* add some telemetry property:
  * session uuid
  * in docker or not
  * query counter
* disable telemetry on CI

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

raw event looks like this:

```
{
	"event": "proton_ping",
	"messageId": "G6Gj95OHIkpcwZRqNs9nxrb2",
	"properties": {
		"cpu": "20",
		"duration_in_minute": "0",
		"edition": "oss",
		"historical_select_query": "0",
		"docker": "false",
		"memory_in_gb": "31",
		"new_session": "true",
		"server_id": "df052db6-b68a-49f1-ae6e-7f3d27c5ca0a",
		"started_on": "2023-11-20T06:48:08.507Z",
		"streaming_select_query": "0",
		"total_select_query": "0",
		"version": "1.3.22"
	},
	"receivedAt": "2023-11-20T06:48:43.050Z",
	"request_ip": "222.70.244.211",
	"timestamp": "2023-11-20T06:48:43.050Z",
	"type": "track"
}
```
