### PR TITLE
Update TelemetryCollector.h, 1hour to 2min

### DIFF
--- a/programs/server/TelemetryCollector.h
+++ b/programs/server/TelemetryCollector.h
@@ -19,7 +19,7 @@ private:
     bool new_session = true;
     Int64 started_on_in_minutes;
 
-    static constexpr auto INTERVAL_MS = 60 * 60 * 1000; /// 1 hour
+    static constexpr auto INTERVAL_MS = 2 * 60 * 1000; /// sending anonymous telemetry data every 2 minutes
 
 public:
     static TelemetryCollector & instance(ContextPtr context_)


### PR DESCRIPTION
sending telemetry data every 2min to get more query stats during server session.

Please write user-readable short description of the changes:
Currently the telemetry data is sent every 1 hour, but if the user stops proton within 1 hour, we cannot get such stats, such as how long they run the server. Changing this to every 2 min and we will check whether it's too much