### PR TITLE
fix: time-based seek_to does not work with Kafka external streams

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3608,7 +3608,7 @@ void InterpreterSelectQuery::handleSeekToSetting()
         /// we rewrite WHERE predicates of SELECT query.
         /// Example : SELECT * FROM stream SETTINGS seek_to='2022-01-01 00:01:01' =>
         /// SELECT * FROM stream WHERE _tp_time >= '2022-01-01 00:01:01'
-        if (storage && !storage->builtinSeekToSupport())
+        if (storage && !storage->supportsNativeSeekTo())
             addEventTimePredicate(getSelectQuery(), seek_points[0]);
     }
     else

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3414,7 +3414,7 @@ void InterpreterSelectQuery::finalCheckAndOptimizeForStreamingQuery()
         /// For now, for the following scenarios, we disable backfill from historic data store
         /// 1) User select some virtual columns which is only available in streaming store, like `_tp_sn`, `_tp_index_time`
         /// 2) Seek by streaming store sequence number
-        /// 3) Replaying a stream. 
+        /// 3) Replaying a stream.
         /// TODO, ideally we shall check if historical data store has `_tp_sn` etc columns, if they have, we can backfill from
         /// the historical data store as well technically. This will be a future enhancement.
         const auto & settings = context->getSettingsRef();
@@ -3604,10 +3604,12 @@ void InterpreterSelectQuery::handleSeekToSetting()
         if (seek_points.size() != 1)
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "It doesn't support time based `seek_to` settings for multiple shards");
 
-        /// Here we rewrite WHERE predicates of SELECT query.
+        /// If the storage does not have built-in seek_to support (for example, external streams like Kafka support seek_to, via offset, natively)
+        /// we rewrite WHERE predicates of SELECT query.
         /// Example : SELECT * FROM stream SETTINGS seek_to='2022-01-01 00:01:01' =>
         /// SELECT * FROM stream WHERE _tp_time >= '2022-01-01 00:01:01'
-        addEventTimePredicate(getSelectQuery(), seek_points[0]);
+        if (storage && !storage->builtinSeekToSupport())
+            addEventTimePredicate(getSelectQuery(), seek_points[0]);
     }
     else
     {

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -22,6 +22,7 @@ public:
     void shutdown() override;
     bool supportsSubcolumns() const override;
     bool squashInsert() const noexcept override { return false; }
+    bool builtinSeekToSupport() const noexcept override { return true; }
     NamesAndTypesList getVirtuals() const override;
 
     Pipe read(

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -22,7 +22,7 @@ public:
     void shutdown() override;
     bool supportsSubcolumns() const override;
     bool squashInsert() const noexcept override { return false; }
-    bool supportsNativeSeekTo() const noexcept override { return true; }
+    bool supportsAccurateSeekTo() const noexcept override { return true; }
     NamesAndTypesList getVirtuals() const override;
 
     Pipe read(

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -22,7 +22,7 @@ public:
     void shutdown() override;
     bool supportsSubcolumns() const override;
     bool squashInsert() const noexcept override { return false; }
-    bool builtinSeekToSupport() const noexcept override { return true; }
+    bool supportsNativeSeekTo() const noexcept override { return true; }
     NamesAndTypesList getVirtuals() const override;
 
     Pipe read(

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -232,7 +232,7 @@ public:
     /// adding a prediction for filtering recrods by time (see InterpreterSelectQuery.cpp).
     /// However, some storages, like Kafka and alike, have built-in support for seek_to,
     /// for such storages, queries should not be rewritten.
-    virtual bool builtinSeekToSupport() const noexcept { return false; }
+    virtual bool supportsNativeSeekTo() const noexcept { return false; }
 
     virtual bool supportsStreamingQuery() const { return false; }
     /// proton: ends.

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -228,11 +228,10 @@ public:
     /// to skip using squashing.
     virtual bool squashInsert() const noexcept { return true; }
 
-    /// In order to support time-based seek_to, such queries will be rewritten by
-    /// adding a prediction for filtering recrods by time (see InterpreterSelectQuery.cpp).
-    /// However, some storages, like Kafka and alike, have built-in support for seek_to,
-    /// for such storages, queries should not be rewritten.
-    virtual bool supportsNativeSeekTo() const noexcept { return false; }
+    /// If a query uses time-based seek_to and the storage does not support accurate seek_to,
+    /// the query will be rewritten by adding a prediction for filtering records by time
+    /// (see InterpreterSelectQuery.cpp).
+    virtual bool supportsAccurateSeekTo() const noexcept { return false; }
 
     virtual bool supportsStreamingQuery() const { return false; }
     /// proton: ends.

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -228,6 +228,12 @@ public:
     /// to skip using squashing.
     virtual bool squashInsert() const noexcept { return true; }
 
+    /// In order to support time-based seek_to, such queries will be rewritten by
+    /// adding a prediction for filtering recrods by time (see InterpreterSelectQuery.cpp).
+    /// However, some storages, like Kafka and alike, have built-in support for seek_to,
+    /// for such storages, queries should not be rewritten.
+    virtual bool builtinSeekToSupport() const noexcept { return false; }
+
     virtual bool supportsStreamingQuery() const { return false; }
     /// proton: ends.
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Because data selected from Kafka external streams do not have `_tp_time`, the added predicate for time-based seek_to does not work. Even if we added `_tp_time` to Kafka external streams data, it would not make sense to add such predicate to the queries because Kafka already supports this feature natively, adding the predicate just wastes resources.

closes #287 
