### PR TITLE
Feature/enable fan out for the same source

### DIFF
--- a/src/Storages/Streaming/SourceColumnsDescription.h
+++ b/src/Storages/Streaming/SourceColumnsDescription.h
@@ -21,8 +21,12 @@ using StorageSnapshotPtr = std::shared_ptr<StorageSnapshot>;
 struct SourceColumnsDescription
 {
     SourceColumnsDescription() = default;
-    SourceColumnsDescription(const Names & required_column_names, StorageSnapshotPtr storage_snapshot);
-    SourceColumnsDescription(const NamesAndTypesList & columns_to_read, const Block & schema, const NamesAndTypesList & all_extended_columns);
+    SourceColumnsDescription(const Names & required_column_names, StorageSnapshotPtr storage_snapshot, bool enable_partial_read = true);
+    SourceColumnsDescription(
+        const NamesAndTypesList & columns_to_read,
+        const Block & schema,
+        const NamesAndTypesList & all_extended_columns,
+        bool enable_partial_read = true);
 
     enum class ReadColumnType : uint8_t
     {

--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -486,15 +486,19 @@ void StorageStream::readConcat(
     for (auto & stream_shard : shards_to_read)
     {
         auto create_streaming_source = [this, header, storage_snapshot, stream_shard, seek_to_info = query_info.seek_to_info, context_](
-                                           Int64 & max_sn_in_parts) {
+                                           Int64 & max_sn_in_parts) -> SourcePtr {
             if (max_sn_in_parts < 0)
             {
                 /// Fallback to seek streaming store
                 auto offsets = stream_shard->getOffsets(seek_to_info);
                 LOG_INFO(log, "Fused read fallbacks to seek stream for shard={} since there are no historical data", stream_shard->shard);
 
-                return std::make_shared<StreamingStoreSource>(
-                    stream_shard, header, storage_snapshot, context_, offsets[stream_shard->shard], log);
+                if (context_->getSettingsRef().query_resource_group.value == "shared")
+                    return source_multiplexers->createChannel(
+                        stream_shard, header.getNames(), storage_snapshot, context_, offsets[stream_shard->shard]);
+                else
+                    return std::make_shared<StreamingStoreSource>(
+                        stream_shard, header, storage_snapshot, context_, offsets[stream_shard->shard], log);
             }
 
             auto committed = stream_shard->storage->inMemoryCommittedSN();
@@ -526,7 +530,12 @@ void StorageStream::readConcat(
                     max_sn_in_parts,
                     committed);
 
-                return std::make_shared<StreamingStoreSource>(stream_shard, header, storage_snapshot, context_, max_sn_in_parts + 1, log);
+                if (context_->getSettingsRef().query_resource_group.value == "shared")
+                    return source_multiplexers->createChannel(
+                        stream_shard, header.getNames(), storage_snapshot, context_, max_sn_in_parts + 1);
+                else
+                    return std::make_shared<StreamingStoreSource>(
+                        stream_shard, header, storage_snapshot, context_, max_sn_in_parts + 1, log);
             }
             else
             {
@@ -542,8 +551,12 @@ void StorageStream::readConcat(
 
                 /// We need reset max_sn_in_parts to tell caller that we are seeking streaming store directly
                 max_sn_in_parts = -1;
-                return std::make_shared<StreamingStoreSource>(
-                    stream_shard, header, storage_snapshot, context_, offsets[stream_shard->shard], log);
+                if (context_->getSettingsRef().query_resource_group.value == "shared")
+                    return source_multiplexers->createChannel(
+                        stream_shard, header.getNames(), storage_snapshot, context_, offsets[stream_shard->shard]);
+                else
+                    return std::make_shared<StreamingStoreSource>(
+                        stream_shard, header, storage_snapshot, context_, offsets[stream_shard->shard], log);
             }
         };
 

--- a/src/Storages/Streaming/StorageStream.h
+++ b/src/Storages/Streaming/StorageStream.h
@@ -10,6 +10,7 @@
 
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
+#include <Storages/Streaming/StreamingStoreSourceMultiplexer.h>
 
 namespace nlog
 {
@@ -298,8 +299,7 @@ private:
         UInt64 base_block_id,
         UInt64 sub_block_id);
 
-    void
-    appendToNativeLog(nlog::RecordPtr & record, IngestMode /*ingest_mode*/, klog::AppendCallback callback, klog::CallbackData data);
+    void appendToNativeLog(nlog::RecordPtr & record, IngestMode /*ingest_mode*/, klog::AppendCallback callback, klog::CallbackData data);
 
     void appendToKafka(
         nlog::RecordPtr & record,
@@ -354,5 +354,8 @@ private:
 
     std::atomic_flag inited;
     std::atomic_flag stopped;
+
+    /// Multiplex latest records of each shard.
+    std::unique_ptr<StreamingStoreSourceMultiplexers> source_multiplexers;
 };
 }

--- a/src/Storages/Streaming/StreamShard.cpp
+++ b/src/Storages/Streaming/StreamShard.cpp
@@ -124,8 +124,6 @@ StreamShard::~StreamShard()
 
 void StreamShard::startup()
 {
-    source_multiplexers.reset(new StreamingStoreSourceMultiplexers(shared_from_this(), storage_stream->getContext(), log));
-
     initLog();
 
     /// for virtual tables or in-memory storage type, there is no storage object

--- a/src/Storages/Streaming/StreamShard.h
+++ b/src/Storages/Streaming/StreamShard.h
@@ -148,8 +148,6 @@ private:
 
     std::unique_ptr<StreamCallbackData> callback_data;
 
-    std::unique_ptr<StreamingStoreSourceMultiplexers> source_multiplexers;
-
     // For random shard index generation
     mutable std::mutex rng_mutex;
     pcg64 rng;

--- a/src/Storages/Streaming/StreamingBlockReaderNativeLog.cpp
+++ b/src/Storages/Streaming/StreamingBlockReaderNativeLog.cpp
@@ -148,9 +148,8 @@ nlog::RecordPtrs StreamingBlockReaderNativeLog::processCached(nlog::RecordPtrs r
             {
                 /// In general, an object has a large number of subcolumns,
                 /// so when a few subcolumns required for the object, we only copy partials to improve performance
-                if (isObject(col_with_type->type) && !schema_ctx.column_positions.positions.empty())
+                if (isObject(col_with_type->type) && !schema_ctx.column_positions.subcolumns.empty())
                 {
-                    assert(column_names.size() == schema_ctx.column_positions.positions.size());
                     auto iter = schema_ctx.column_positions.subcolumns.find(i);
                     if (iter != schema_ctx.column_positions.subcolumns.end())
                     {

--- a/src/Storages/Streaming/StreamingStoreSource.h
+++ b/src/Storages/Streaming/StreamingStoreSource.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "StreamingStoreSourceBase.h"
+#include <Storages/Streaming/StreamingStoreSourceBase.h>
 
 namespace DB
 {

--- a/src/Storages/Streaming/StreamingStoreSourceBase.h
+++ b/src/Storages/Streaming/StreamingStoreSourceBase.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "SourceColumnsDescription.h"
+#include <Storages/Streaming/SourceColumnsDescription.h>
 
 #include <Interpreters/Context_fwd.h>
 #include <NativeLog/Record/Record.h>
@@ -16,7 +16,12 @@ class StreamingStoreSourceBase : public ISource
 {
 public:
     StreamingStoreSourceBase(
-        const Block & header, const StorageSnapshotPtr & storage_snapshot_, ContextPtr context_, Poco::Logger * log_, ProcessorID pid_);
+        const Block & header,
+        const StorageSnapshotPtr & storage_snapshot_,
+        bool enable_partial_read,
+        ContextPtr context_,
+        Poco::Logger * log_,
+        ProcessorID pid_);
 
     Chunk generate() override;
 

--- a/src/Storages/Streaming/StreamingStoreSourceMultiplexer.h
+++ b/src/Storages/Streaming/StreamingStoreSourceMultiplexer.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "StreamingBlockReaderKafka.h"
-#include "StreamingStoreSourceChannel.h"
-
-#include <Storages/StorageSnapshot.h>
+#include <Storages/Streaming/StreamingBlockReaderKafka.h>
+#include <Storages/Streaming/StreamingBlockReaderNativeLog.h>
+#include <Storages/Streaming/StreamingStoreSourceChannel.h>
 
 namespace DB
 {
 class StreamShard;
+struct StorageSnapshot;
+using StorageSnapshotPtr = std::shared_ptr<StorageSnapshot>;
 
 /// The multiplexer fans out one streaming store reader to different streaming queries. This has
 /// efficiency of disk read / TFF deserialization, memory allocation etc. But we may introduce
@@ -23,12 +24,19 @@ class StreamShard;
 class StreamingStoreSourceMultiplexer final : public std::enable_shared_from_this<StreamingStoreSourceMultiplexer>
 {
 public:
+    using AttachToSharedGroupFunc = std::function<void(std::shared_ptr<StreamingStoreSourceMultiplexer>)>;
     StreamingStoreSourceMultiplexer(
-        UInt32 id_, std::shared_ptr<StreamShard> storage_, ContextPtr global_context, Poco::Logger * log_);
+        UInt32 id_,
+        std::shared_ptr<StreamShard> storage_,
+        ContextPtr global_context,
+        Poco::Logger * log_,
+        AttachToSharedGroupFunc attach_to_shared_group_func = {});
     ~StreamingStoreSourceMultiplexer();
 
     StreamingStoreSourceChannelPtr
     createChannel(const Names & column_names, const StorageSnapshotPtr & storage_snapshot, ContextPtr query_context);
+
+    bool tryDetachChannelsInto(std::shared_ptr<StreamingStoreSourceMultiplexer> new_multiplexer);
 
     void removeChannel(UInt32 channel_id);
 
@@ -38,15 +46,31 @@ public:
 
     std::pair<String, Int32> getStreamShard() const;
 
+    /// NOTE: Reset sequence number only before startup()
+    void resetSequenceNumber(Int64 start_sn);
+    void startup();
+
 private:
+    inline nlog::RecordPtrs read();
     void backgroundPoll();
     void fanOut(nlog::RecordPtrs records);
     void doShutdown();
 
+    friend class StreamingStoreSourceMultiplexers;
+
 private:
     UInt32 id;
     std::shared_ptr<StreamShard> stream_shard;
-    std::shared_ptr<StreamingBlockReaderKafka> reader;
+    std::unique_ptr<StreamingBlockReaderKafka> kafka_reader;
+    std::unique_ptr<StreamingBlockReaderNativeLog> nativelog_reader;
+
+    std::atomic_flag started;
+
+    AttachToSharedGroupFunc attach_to_shared_group_func;
+    Int64 fanout_sn = -1;
+
+    UInt32 record_consume_batch_count = 1000;
+    Int32 record_consume_timeout_ms = 100;
 
     std::unique_ptr<ThreadPool> poller;
     std::atomic<bool> shutdown = false;
@@ -73,17 +97,37 @@ using StreamingStoreSourceMultiplexerPtrs = std::list<StreamingStoreSourceMultip
 class StreamingStoreSourceMultiplexers final
 {
 public:
-    StreamingStoreSourceMultiplexers(std::shared_ptr<StreamShard> stream_shard_, ContextPtr global_context_, Poco::Logger * log_);
+    StreamingStoreSourceMultiplexers(ContextPtr global_context_, Poco::Logger * log_);
 
-    StreamingStoreSourceChannelPtr
-    createChannel(Int32 shard, const Names & column_names, const StorageSnapshotPtr & storage_snapshot, ContextPtr query_context);
+    StreamingStoreSourceChannelPtr createChannel(
+        std::shared_ptr<StreamShard> stream_shard,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        ContextPtr query_context,
+        Int64 start_sn);
 
 private:
-    std::shared_ptr<StreamShard> stream_shard;
+    StreamingStoreSourceChannelPtr createIndependentChannelForRecover(
+        std::shared_ptr<StreamShard> stream_shard,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        ContextPtr query_context);
+
+    StreamingStoreSourceChannelPtr createIndependentChannelWithSeekTo(
+        std::shared_ptr<StreamShard> stream_shard,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        ContextPtr query_context,
+        Int64 start_sn);
+
+    void attachToSharedGroup(StreamingStoreSourceMultiplexerPtr multiplexer);
+
+private:
     ContextPtr global_context;
     Poco::Logger * log;
 
     std::mutex multiplexers_mutex;
     std::unordered_map<Int32, StreamingStoreSourceMultiplexerPtrs> multiplexers;
+    StreamingStoreSourceMultiplexerPtrs detached_multiplexers;
 };
 }

--- a/src/Storages/Streaming/StreamingStoreSourceMultiplexer.h
+++ b/src/Storages/Streaming/StreamingStoreSourceMultiplexer.h
@@ -122,9 +122,13 @@ private:
 
     void attachToSharedGroup(StreamingStoreSourceMultiplexerPtr multiplexer);
 
+    uint32_t getMultiplexerID() { return multiplexer_id.fetch_add(1); }
+
 private:
     ContextPtr global_context;
     Poco::Logger * log;
+
+    static std::atomic<uint32_t> multiplexer_id;
 
     std::mutex multiplexers_mutex;
     std::unordered_map<Int32, StreamingStoreSourceMultiplexerPtrs> multiplexers;

--- a/tests/stream/test_stream_smoke/0013_changelog_stream4.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream4.yaml
@@ -46,12 +46,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -118,12 +116,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -190,17 +186,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -255,17 +248,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -289,7 +279,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4
 
           - client: python
@@ -332,7 +321,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -356,17 +344,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -421,17 +406,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -474,12 +456,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -527,12 +507,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -575,12 +553,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -628,12 +604,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -676,7 +650,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -722,7 +695,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -765,17 +737,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -830,17 +799,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -924,12 +890,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -987,7 +951,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -1073,12 +1036,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -1136,7 +1097,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:
@@ -1223,17 +1183,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
           - client: python
@@ -1298,12 +1255,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_4;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_4;
 
     expected_results:

--- a/tests/stream/test_stream_smoke/0013_changelog_stream5.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream5.yaml
@@ -106,7 +106,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -230,17 +229,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -305,12 +301,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -336,12 +330,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -404,7 +396,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -428,12 +419,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -496,7 +485,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -527,17 +515,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -607,12 +592,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -643,7 +626,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -737,17 +719,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -807,12 +786,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -835,12 +812,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -898,7 +873,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -923,12 +897,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -986,7 +958,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -1011,17 +982,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -1083,12 +1051,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:
@@ -1113,7 +1079,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -1186,17 +1151,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
           - client: python
@@ -1261,12 +1223,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_5;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_5;
 
     expected_results:

--- a/tests/stream/test_stream_smoke/0013_changelog_stream6.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream6.yaml
@@ -47,12 +47,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_6;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_6;
 
           - client: python
@@ -110,7 +108,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_6;
 
   - id: 25
@@ -125,7 +122,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -237,7 +233,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -328,7 +323,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -420,7 +414,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -567,7 +560,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -641,7 +633,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -731,7 +722,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -823,7 +813,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -898,7 +887,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -974,7 +962,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python
@@ -1061,7 +1048,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_6;
 
           - client: python

--- a/tests/stream/test_stream_smoke/0013_changelog_stream7.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream7.yaml
@@ -107,7 +107,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_7;
 
           - client: python
@@ -181,7 +180,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_7;
 
           - client: python
@@ -332,7 +330,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_substream_7;
 
           - client: python
@@ -409,7 +406,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_stream;
 
           - client: python
@@ -495,7 +491,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_stream;
 
           - client: python
@@ -601,12 +596,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
@@ -675,7 +668,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
     expected_results:
@@ -720,12 +712,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
@@ -798,7 +788,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
     expected_results:
@@ -843,17 +832,14 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
@@ -929,12 +915,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
     expected_results:
@@ -979,7 +963,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
@@ -1085,22 +1068,18 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
@@ -1176,12 +1155,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
     expected_results:
@@ -1207,12 +1184,10 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
@@ -1256,7 +1231,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
     expected_results:
@@ -1283,17 +1257,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_target_changelog_kv_7;
 
           - client: python
@@ -1303,7 +1274,6 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: create stream if not exists test14_target_changelog_kv_7(i float, k1 int, k2 string) primary key k2 settings mode='changelog_kv';
 
           - client: python
@@ -1346,12 +1316,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_7;
   
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_target_changelog_kv_7;
 
     expected_results:

--- a/tests/stream/test_stream_smoke/0013_changelog_stream8.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream8.yaml
@@ -28,17 +28,14 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view2_8;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop view if exists test14_view1_8;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_8;
 
           - client: python
@@ -321,12 +318,10 @@ tests:
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_subquery_8;
 
           - client: python
             query_type: table
-            wait: 0
             query: drop stream if exists test14_target_changelog_kv_8;
 
     expected_results:
@@ -360,8 +355,8 @@ tests:
               type: javascript
               name: test_14_8_add_five
               arguments:
-                - name: value
-                - type: float32
+              - name: value
+                type: float32
               return_type: float32
               source: |
                 function test_14_8_add_five(value) {
@@ -524,7 +519,6 @@ tests:
       - statements:
           - client: python
             query_type: table
-            wait: 2
             query: drop stream if exists test14_substream_8;
 
           - client: python
@@ -535,6 +529,7 @@ tests:
           - client: python
             query_id: '1453'
             depends_on_stream: test14_substream_8
+            wait: 1
             query_type: stream
             query: select max(val), min(val), avg(val), id, name from test14_substream_8 partition by id group by name emit periodic 1s;
 
@@ -618,8 +613,8 @@ tests:
               type: javascript
               name: test_14_8_add_five
               arguments:
-                - name: value
-                - type: float32
+              - name: value
+                type: float32
               return_type: float32
               source: |
                 function test_14_8_add_five(value) {

--- a/tests/stream/test_stream_smoke/0015_single_stream_changelog_aggr.json
+++ b/tests/stream/test_stream_smoke/0015_single_stream_changelog_aggr.json
@@ -47,10 +47,10 @@
       "steps":[
         {
           "statements": [
-            {"client":"python","query_id":"1601", "depends_on_stream":"changelog_kv_stream_aggr","query_end_timer":6, "query_type": "stream", "query":"select count(), avg(i), sum(i), min(i), max(i), min(s), max(s) from changelog_kv_stream_aggr emit periodic 1s"},
+            {"client":"python","query_id":"1601", "depends_on_stream":"changelog_kv_stream_aggr", "query_type": "stream", "query":"select count(), avg(i), sum(i), min(i), max(i), min(s), max(s) from changelog_kv_stream_aggr emit periodic 1s"},
             {"client":"python", "query_type": "table","depends_on":1601,"depends_on_stream":"changelog_kv_stream_aggr", "query": "insert into changelog_kv_stream_aggr(i, s) values (1, 's1'), (2, 's2'), (3, 's3')"},
             {"client":"python", "query_type": "table","depends_on":1601,"depends_on_stream":"changelog_kv_stream_aggr", "wait":1, "query": "insert into changelog_kv_stream_aggr(i, s, _tp_delta) values (1, 's1', -1)"},
-            {"client":"python", "query_type": "table","depends_on":1601,"depends_on_stream":"changelog_kv_stream_aggr", "wait":1, "query": "insert into changelog_kv_stream_aggr(i, s, _tp_delta) values (3, 's3', -1)"}
+            {"client":"python", "query_type": "table","depends_on":1601,"depends_on_stream":"changelog_kv_stream_aggr", "wait":1, "kill":1601, "kill_wait":3, "query": "insert into changelog_kv_stream_aggr(i, s, _tp_delta) values (3, 's3', -1)"}
           ]
         }
       ],

--- a/tests/stream/test_stream_smoke/0099_fixed_issues.json
+++ b/tests/stream/test_stream_smoke/0099_fixed_issues.json
@@ -15,14 +15,14 @@
       "steps":[
         {
           "statements": [
-            {"client":"python", "query_type": "table", "wait":2, "query":"drop view if exists mv_2"},
-            {"client":"python", "query_type": "table", "wait":2, "query":"drop view if exists mv_1"},
+            {"client":"python", "query_type": "table", "query":"drop view if exists mv_2"},
+            {"client":"python", "query_type": "table", "query":"drop view if exists mv_1"},
             {"client":"python", "query_type": "table", "wait":2, "query":"drop view if exists mv_truck_track"},
             {"client":"python", "query_type": "table", "wait":2, "query":"drop stream if exists ttp_truck_track"},
             {"client":"python", "query_type": "table", "wait":2, "query_id":"9900", "query": "create stream ttp_truck_track(`lpn` string, `vno` string, `drc` string, `drcCode` int32, `wgs84Lat` float32, `wgs84Lon` float32, `gcj02Lat` float32, `gcj02Lon` float32, `province` nullable(string), `city` nullable(string), `country` nullable(string), `spd` float32, `mil` float32, `time` string, `adr` string)"},
-            {"client":"python", "query_type": "table", "wait":5, "query_id":"9901","depends_on_stream":"ttp_truck_track", "query": "create materialized view mv_truck_track as (select * from ttp_truck_track where date_diff('second', _tp_time, now()) < 30)"},
-            {"client":"python", "query_type": "table", "wait":5, "query_id":"9902", "depends_on_stream":"mv_truck_track", "query": "create materialized view if not exists mv_1 as (select now() as time, count_distinct(lpn) as cnt from mv_truck_track emit last 10m and periodic 10s)"},
-            {"client":"python", "query_type": "table", "wait":5, "query_id":"9903", "depends_on_stream":"mv_truck_track","drop_view":"mv_2,mv_1,mv_truck_track", "drop_view_wait":2, "query": "create materialized view if not exists mv_2 as (select now() as time, count_distinct(lpn) as cnt from mv_truck_track emit last 10m and periodic 10s)"}
+            {"client":"python", "query_type": "table", "wait":2, "query_id":"9901","depends_on_stream":"ttp_truck_track", "query": "create materialized view mv_truck_track as (select * from ttp_truck_track where date_diff('second', _tp_time, now()) < 30)"},
+            {"client":"python", "query_type": "table", "wait":2, "query_id":"9902", "depends_on_stream":"mv_truck_track", "query": "create materialized view if not exists mv_1 as (select now() as time, count_distinct(lpn) as cnt from mv_truck_track emit last 10m and periodic 10s)"},
+            {"client":"python", "query_type": "table", "wait":2, "query_id":"9903", "depends_on_stream":"mv_truck_track","drop_view":"mv_2,mv_1,mv_truck_track", "drop_view_wait":2, "query": "create materialized view if not exists mv_2 as (select now() as time, count_distinct(lpn) as cnt from mv_truck_track emit last 10m and periodic 10s)"}
           ]
         }
       ],
@@ -142,9 +142,9 @@
       "steps":[
         {
           "statements": [
-            {"client":"python", "query_type": "table", "wait":2, "query": "drop view if exists test_mv_1934"},
+            {"client":"python", "query_type": "table", "query": "drop view if exists test_mv_1934"},
             {"client":"python", "query_type": "table", "wait":2, "query": "drop stream if exists test_stream_1934"},
-            {"client":"python", "query_type": "table", "wait":2, "query": "create stream test_stream_1934(value int)"},
+            {"client":"python", "query_type": "table", "exist":"test_stream_1934", "exist_wait":2, "wait":1, "query": "create stream test_stream_1934(value int)"},
             {"client":"python", "query_type": "table", "depends_on_stream":"test_stream_1934", "query": "create materialized view test_mv_1934 as select count() from test_stream_1934"},
             {"client":"python", "query_type": "table", "depends_on_stream":"test_mv_1934", "wait":2, "query": "insert into test_stream_1934(value) values(1)"},
             {"client":"python", "query_type": "table", "wait":3, "query": "insert into test_stream_1934(value) values(2)"},


### PR DESCRIPTION
This resolves #288 

Please write user-readable short description of the changes:
- enable fan out for the same source (with setting `query_resource_group='shared'`)
- support attach back independent channel with seek to when reaches to latest records
- support attach back independent channel for recover mode when reaches to latest records
- move `StreamingStoreSourceMultiplexers` (a multiplexers is bound to a stream) to `StorageStream` from `StreamShard`
- fix minor for smoke test
- support fan out for backfill read and fix more