### PR TITLE
feat: support configuring message.max.bytes for kafka external streams

### DIFF
--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -141,6 +141,7 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
         "queue.buffering.max.messages",
         "queue.buffering.max.kbytes",
         "queue.buffering.max.ms",
+        "message.max.bytes",
         "message.send.max.retries",
         "retries",
         "retry.backoff.ms",


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Now this is possible:
```sql
CREATE EXTERNAL STREAM my_stream (
...
) SETTINGS properties='message.max.bytes=1234'
```

This allows limiting the size of messages which are sent to the topic, or makes it possible to send big messages ( by default the max bytes is 1000000 ). Valid sizes are 1000 .. 1000000000 (refs: https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md).

NOTE: the message size limit configured on the topic has higher priority, i.e. setting `message.max.bytes` to a value that is bigger than the topic limit is useless.

fixes #335 