### PR TITLE
make default interval_time to 5 ms to avoid generating huge

### DIFF
--- a/src/Storages/Streaming/StorageRandom.h
+++ b/src/Storages/Streaming/StorageRandom.h
@@ -14,7 +14,7 @@ class ASTStorage;
 
 #define STORAGE_RANDOM_RELATED_SETTINGS(M) \
     M(UInt64, eps, 1000, "Limit how many rows to be generated per second for each thread. Used by RANDOM STREAM. 0 means no limit", 0) \
-    M(UInt64, interval_time, 100, "the data generating interval, unit ms", 0) \
+    M(UInt64, interval_time, 5, "the data generating interval, unit ms", 0) \
     M(UInt64, shards, 1, "Shards number for random stream", 0)
 
 #define LIST_OF_STORAGE_RANDOM_SETTINGS(M) \

--- a/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
+++ b/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
@@ -13,7 +13,7 @@ test_suite_config:
         exist_wait: 2
         wait: 1
         query: |
-          create random stream if not exists test_31_rstream(i int default rand() % 100000 + 1, v string) settings eps=5000;
+          create random stream if not exists test_31_rstream(i int default rand() % 100000 + 1, v string) settings eps=5000, interval_time=100;
 
   tests_2_run:
     ids_2_run:


### PR DESCRIPTION
this closes #367 
Set default `interval_time` to 5 ms to avoid generating huge chunks for random stream.This is a temp workround,we should come up with a dynamic `interval_time` computing algorithm according to the `eps`.I will do it later.