### PR TITLE
Feature/issue 396 refine ci for compatibility test

### DIFF
--- a/.github/workflows/compatibility_test.yml
+++ b/.github/workflows/compatibility_test.yml
@@ -21,12 +21,28 @@ jobs:
       submodules: false
       timeout: 30
       command: |
-        # pull docker image
         export PROTON_VERSION=${{ github.event.inputs.target }}
-        docker pull ghcr.io/timeplus-io/proton:$PROTON_VERSION
 
         cd $GITHUB_WORKSPACE/tests/stream
-        env
+        
+        # make virtualenv
+        ln -s /usr/bin/python3 /usr/bin/python
+        apt-get update
+        systemctl stop unattended-upgrades
+        apt install python3-venv -y
+        python -m venv env
+        source env/bin/activate
+
+        pip install --upgrade pip
+
+        # FIXME: remove this line after pyyaml community fixed install bug
+        pip install pyyaml==5.3.1
+
+        # FIXME(yokofly): docker 7.0.0 introduce a breaking change
+        # https://github.com/docker/docker-py/issues/3194
+        pip install docker==6.1.3
+
+        pip install -r helpers/requirements.txt
 
         bash test_compatibility/prepare_data.sh
         bash test_compatibility/basic_tests.sh
@@ -59,17 +75,32 @@ jobs:
         export TARGET_VERSION=${{ github.event.inputs.target }}
         export SOURCE_VERSION=${{ github.event.inputs.source }}
         export PROTON_VERSION=$TARGET_VERSION
-        # pull docker image
-        docker pull ghcr.io/timeplus-io/proton:$PROTON_VERSION
 
         # prepare data
         cd $GITHUB_WORKSPACE
         aws s3 cp --no-progress s3://tp-internal/proton/compatibility/oss/$SOURCE_VERSION.tar.gz .
         tar -zxvf $SOURCE_VERSION.tar.gz
-        ls .
 
         cd $GITHUB_WORKSPACE/tests/stream
-        env
+        
+        # make virtualenv
+        ln -s /usr/bin/python3 /usr/bin/python
+        apt-get update
+        systemctl stop unattended-upgrades
+        apt install python3-venv -y
+        python -m venv env
+        source env/bin/activate
+
+        pip install --upgrade pip
+
+        # FIXME: remove this line after pyyaml community fixed install bug
+        pip install pyyaml==5.3.1
+
+        # FIXME(yokofly): docker 7.0.0 introduce a breaking change
+        # https://github.com/docker/docker-py/issues/3194
+        pip install docker==6.1.3
+
+        pip install -r helpers/requirements.txt
 
         bash test_compatibility/basic_tests.sh
         bash test_compatibility/extra_tests.sh

--- a/tests/stream/test_compatibility/basic_tests.sh
+++ b/tests/stream/test_compatibility/basic_tests.sh
@@ -1,4 +1,5 @@
 docker-compose -f test_compatibility/docker-compose.yaml up -d
-docker exec -it proton-server proton client -nm -q "select x from example where _tp_time > earliest_ts() limit 3;"
-docker exec -it proton-server proton client -nm -q "select x from example_external limit 3 settings seek_to='earliest';"
+sleep 5
+docker exec proton-server proton client -nm -q "select x from example where _tp_time > earliest_ts() limit 3;"
+docker exec proton-server proton client -nm -q "select x from example_external limit 3 settings seek_to='earliest';"
 docker-compose -f test_compatibility/docker-compose.yaml down

--- a/tests/stream/test_compatibility/docker-compose.yaml
+++ b/tests/stream/test_compatibility/docker-compose.yaml
@@ -62,5 +62,6 @@ services:
       - "redpanda.enable_idempotence=true"
       - --check=false
     container_name: redpanda
+    user: "0:0"
     volumes:
       - $GITHUB_WORKSPACE/data/redpanda:/var/lib/redpanda/data

--- a/tests/stream/test_compatibility/extra_tests.sh
+++ b/tests/stream/test_compatibility/extra_tests.sh
@@ -1,6 +1,7 @@
 docker-compose -f test_compatibility/docker-compose.yaml up -d
-docker exec -it proton-server proton client -nm -q "insert into example (x) values (4)(5)(6);"
-docker exec -it proton-server proton client -nm -q "select x from example where _tp_time > earliest_ts() limit 6;"
-docker exec -it proton-server proton client -nm -q "insert into example_external (x) values (8)(10)(12);"
-docker exec -it proton-server proton client -nm -q "select x from example_external limit 6 settings seek_to='earliest';"
+sleep 5
+docker exec proton-server proton client -nm -q "insert into example (x) values (4)(5)(6);"
+docker exec proton-server proton client -nm -q "select x from example where _tp_time > earliest_ts() limit 6;"
+docker exec proton-server proton client -nm -q "insert into example_external (x) values (8)(10)(12);"
+docker exec proton-server proton client -nm -q "select x from example_external limit 6 settings seek_to='earliest';"
 docker-compose -f test_compatibility/docker-compose.yaml down

--- a/tests/stream/test_compatibility/prepare_data.sh
+++ b/tests/stream/test_compatibility/prepare_data.sh
@@ -1,7 +1,8 @@
 docker-compose -f test_compatibility/docker-compose.yaml up -d
-docker exec -it proton-server proton client -nm -q "create stream example(x int);"
-docker exec -it proton-server proton client -nm -q "insert into example (x) values (1)(2)(3);"
-docker exec -it redpanda rpk topic create example_topic
-docker exec -it proton-server proton client -nm -q "create external stream example_external (x int) settings type='kafka', brokers='stream-store:9092',topic='example_topic',data_format = 'JSONEachRow';"
-docker exec -it proton-server proton client -nm -q "insert into example_external (x) values (2)(4)(6);"
+sleep 5
+docker exec proton-server proton client -nm -q "create stream example(x int);"
+docker exec proton-server proton client -nm -q "insert into example (x) values (1)(2)(3);"
+docker exec redpanda rpk topic create example_topic
+docker exec proton-server proton client -nm -q "create external stream example_external (x int) settings type='kafka', brokers='stream-store:9092',topic='example_topic',data_format = 'JSONEachRow';"
+docker exec proton-server proton client -nm -q "insert into example_external (x) values (2)(4)(6);"
 docker-compose -f test_compatibility/docker-compose.yaml down


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
* prepare python environment and install docker-compose before running tests
* sleep for 5 seconds after `docker-compose up`, waiting for proton start
* remove `-it` when running `docker exec` or it will output `the input device is not a TTY`
* remove debug log from commands in action yaml