### PR TITLE
random stream supports native ipv4 and ipv6 data type

### DIFF
--- a/src/Storages/Streaming/StorageRandom.cpp
+++ b/src/Storages/Streaming/StorageRandom.cpp
@@ -345,7 +345,18 @@ ColumnPtr fillColumnWithRandomData(const DataTypePtr type, UInt64 limit, pcg64 &
 
             return column;
         }
-
+        case TypeIndex::IPv4: {
+            auto column = ColumnVector<IPv4>::create();
+            column->getData().resize(limit);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(IPv4), rng);
+            return column;
+        }
+        case TypeIndex::IPv6: {
+            auto column = ColumnVector<IPv6>::create();
+            column->getData().resize(limit);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(IPv6), rng);
+            return column;
+        }
         default:
             throw Exception("The 'Generating' is not implemented for type " + type->getName(), ErrorCodes::NOT_IMPLEMENTED);
     }

--- a/tests/stream/test_stream_smoke/0021_random_stream.json
+++ b/tests/stream/test_stream_smoke/0021_random_stream.json
@@ -573,7 +573,29 @@
                 "query_id":"2234", "expected_results":"error_code:36"
               }
             ]
-          }
+          },
+          {
+            "id": 25,
+            "tags": ["ipv4 data type"],
+            "name": "random stream supports native ipv4 data type",
+            "description": "random stream supports native ipv4 and ipv6 data type",
+            "steps":[
+              {
+                "statements": [
+                  {"client":"python", "query_type": "table", "wait":2, "query": "drop stream if exists test22_create_random"},
+                  {"client":"python", "query_type": "table", "wait":2, "query": "create random stream test22_create_random(id int, ipv4 ipv4, ipv6 ipv6)"},
+                  {"client":"python", "query_type": "table", "query_id":"2235", "wait":2, "query":"select ipv4, ipv6 from test22_create_random settings max_events=1"}
 
+                ]
+              }
+            ],
+            "expected_results": [
+              {
+                "query_id":"2235", "expected_results":[
+                    ["any_value", "any_value"]
+                ]
+              }
+            ]
+          }
     ]
   }


### PR DESCRIPTION
this closes #404 
```sql
create random stream rand_ip(id int, ipv4 ipv4);
select * from rand_ip settings max_events=10;
┌──────────id─┬─ipv4────────────┬────────────────_tp_time─┐
│  2078218314 │ 219.126.36.236  │ 2023-12-12 06:19:49.318 │
│ -2100051516 │ 172.55.79.96    │ 2023-12-12 06:19:49.318 │
│   891957574 │ 55.117.217.249  │ 2023-12-12 06:19:49.318 │
│  1882135599 │ 19.24.168.77    │ 2023-12-12 06:19:49.318 │
│   842037215 │ 0.238.88.15     │ 2023-12-12 06:19:49.318 │
│  1664291058 │ 194.4.144.103   │ 2023-12-12 06:19:49.318 │
│   898659259 │ 126.231.169.253 │ 2023-12-12 06:19:49.318 │
│  -394660525 │ 15.111.9.137    │ 2023-12-12 06:19:49.318 │
│ -1734591513 │ 62.196.67.202   │ 2023-12-12 06:19:49.318 │
│ -2087265617 │ 122.184.184.88  │ 2023-12-12 06:19:49.318 │
└─────────────┴─────────────────┴─────────────────────────┘
```