### PR TITLE
bugfix/fix changed aggregated states with StringRef key

### DIFF
--- a/src/Common/HashTable/FixedHashTable.h
+++ b/src/Common/HashTable/FixedHashTable.h
@@ -343,11 +343,14 @@ public:
 
 
 public:
-    /// proton: starts. This interface is invalid but exists for compatibility with HashTable interface.
+    /// proton: starts. This interface is used for compatibility with HashTable interface.
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplace(KeyHolder &&, LookupResult &, bool &, size_t /* hash */ = 0)
+    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it, bool & inserted, size_t hash = 0)
     {
-        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "This is a invalid default interface, which cannot be called");
+        if constexpr (std::is_same_v<std::decay_t<decltype(keyHolderGetKey(key_holder))>, StringRef>)
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "FixedHashTable doesn't support StringRef key, it's a bug");
+        else
+            emplace(keyHolderGetKey(key_holder), it, inserted, hash);
     }
     /// proton: ends.
 

--- a/src/Common/HashTable/FixedHashTable.h
+++ b/src/Common/HashTable/FixedHashTable.h
@@ -7,6 +7,9 @@ namespace DB
     namespace ErrorCodes
     {
         extern const int NO_AVAILABLE_DATA;
+        // proton: starts.
+        extern const int LOGICAL_ERROR;
+        /// proton: ends.
     }
 }
 
@@ -340,6 +343,14 @@ public:
 
 
 public:
+    /// proton: starts. This interface is invalid but exists for compatibility with HashTable interface.
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder &&, LookupResult &, bool &, size_t /* hash */ = 0)
+    {
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "This is a invalid default interface, which cannot be called");
+    }
+    /// proton: ends.
+
     /// The last parameter is unused but exists for compatibility with HashTable interface.
     void ALWAYS_INLINE emplace(const Key & x, LookupResult & it, bool & inserted, size_t /* hash */ = 0)
     {

--- a/src/Common/HashTable/FixedHashTable.h
+++ b/src/Common/HashTable/FixedHashTable.h
@@ -343,20 +343,17 @@ public:
 
 
 public:
-    /// proton: starts. This interface is used for compatibility with HashTable interface.
+    /// proton: starts. KeyHolder is used for compatibility with HashTable interface.
+    /// The last parameter is unused but exists for compatibility with HashTable interface.
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it, bool & inserted, size_t hash = 0)
+    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it, bool & inserted, size_t /* hash */ = 0)
     {
         if constexpr (std::is_same_v<std::decay_t<decltype(keyHolderGetKey(key_holder))>, StringRef>)
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "FixedHashTable doesn't support StringRef key, it's a bug");
-        else
-            emplace(keyHolderGetKey(key_holder), it, inserted, hash);
-    }
-    /// proton: ends.
 
-    /// The last parameter is unused but exists for compatibility with HashTable interface.
-    void ALWAYS_INLINE emplace(const Key & x, LookupResult & it, bool & inserted, size_t /* hash */ = 0)
-    {
+        Key x = keyHolderGetKey(key_holder);
+        /// proton: ends.
+
         it = &buf[x];
 
         if (!buf[x].isZero(*this))

--- a/tests/stream/test_stream_smoke/0029_emit_changelog.yaml
+++ b/tests/stream/test_stream_smoke/0029_emit_changelog.yaml
@@ -103,7 +103,7 @@ tests:
           depends_on: 3000
           wait: 1
           query: |
-            insert into test30_vk_stream(i, k) values (1, 'k1')(2, 'k1');
+            insert into test30_vk_stream(i, k) values (1, 'kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk1')(2, 'kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk1');
 
         - client: python
           query_type: table
@@ -111,15 +111,15 @@ tests:
           kill_wait: 3
           wait: 1
           query: |
-            insert into test30_vk_stream(i, k) values (1, 'k2');
+            insert into test30_vk_stream(i, k) values (1, 'kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk2');
 
     expected_results:
       - query_id: '3000'
         expected_results:
-          - ["k1", 2, 1]
-          - ["k1", 2, -1]
-          - ["k1", 1, 1]
-          - ["k2", 1, 1]
+          - ["kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk1", 2, 1]
+          - ["kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk1", 2, -1]
+          - ["kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk1", 1, 1]
+          - ["kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk2", 1, 1]
 
   - id: 2
     tags:

--- a/tests/stream/test_stream_smoke/0031_join_alignment.yaml
+++ b/tests/stream/test_stream_smoke/0031_join_alignment.yaml
@@ -12,6 +12,7 @@ test_suite_config:
         - change
         - bug
         - sample
+        - unstable
       cluster:
         - view
         - cluster_table_bug
@@ -23,6 +24,7 @@ tests:
       - "join processing time alignment"
       - "asof join"
       - "query state"
+      - "unstable"
     name: append-asof-join-versioned_kv-with-processing-time-alignment
     description: streaming append (left) asof join versioned_kv with processing time alignment
     steps:


### PR DESCRIPTION
This fix #415 

Please write user-readable short description of the changes:
- During merge aggregated data and retracted data, for `StringRef` key, we need copy memory into aggregated pool from retracted pool.