### PR TITLE
fix teardown for log stream

### DIFF
--- a/src/Storages/ExternalStream/Log/FileLogSource.h
+++ b/src/Storages/ExternalStream/Log/FileLogSource.h
@@ -39,8 +39,7 @@ public:
 private:
     bool handleCurrentFile();
 
-    static size_t
-    calculateFileHash(int fd, std::vector<char> & read_buf, size_t bytes_to_read, const String & filename, Poco::Logger * log_);
+    size_t calculateFileHash(int fd, std::vector<char> & read_buf, size_t bytes_to_read, const String & filename);
 
     Chunk readAndProcess();
     Chunk process();


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
