### PR TITLE
change the data processing order in changelog

### DIFF
--- a/tests/stream/test_stream_smoke/0013_changelog_stream13.yaml
+++ b/tests/stream/test_stream_smoke/0013_changelog_stream13.yaml
@@ -343,3 +343,40 @@ tests:
           - [120, 210, 3, 5]
           - [120, 120, 3, 3]
           - [30, 30, 1, 1]
+  - id: 108
+    tags:
+      - global aggr distinct
+      - changelog_kv
+      - single shard
+    name: "global aggr on changelog_kv stream with single shard"
+    description: sum_distinct and count_distinct for changelog_kv stream with single shard.
+    steps:
+    - statements:
+      - client: python
+        query_type: table
+        query: drop stream if exists changelog_kv_13
+
+      - client: python
+        query_type: table
+        wait: 2
+        query: create stream changelog_kv_13(id int, val int) primary key id settings mode='changelog_kv';
+
+      - client: python
+        query_type: stream
+        wait: 2
+        depends_on_stream: changelog_kv_13
+        query_id: '13108'
+        query: select count_distinct(val), sum_distinct(val) from changelog_kv_13;
+
+      - client: python
+        query_type: table
+        depends_on: '13108'
+        wait: 3
+        kill: '13108'
+        kill_wait: 2
+        query: insert into changelog_kv_13(id, val, _tp_delta) values(2, 1, 1)(2, 1, -1)(3, 2, 1)(3, 2, -1);
+
+    expected_results:
+      - query_id: '13108'
+        expected_results:
+          - [0, 0]


### PR DESCRIPTION
change the data processing order in changelog.
For example: 
```sql
drop stream if exists test_kv;
create stream if not exists test_kv(id int, value int) primary key id settings mode='changelog_kv';
select count_distinct(value) from test_kv;
insert into test_kv(id, value, _tp_delta) values(2, 1, 1)(2, 1, -1)(3, 2, 1)(3, 2, -1);
```
The output  will be `2`, it should be `0`.Because a piece of data is inserted and then deleted, there should be no data.The `sum_distinct` will encountered the same problem
 
The previous processing strategy was to divide two chunks according to the delta value. The data with a delta value of -1 is placed in the first chunk, and the data with a delta value of 1 is placed in the second chunk(take the example above, it will be `[(2, 1, -1), (3, 2, -1),(2, 1, 1), (3, 2, 1)]`). Therefore, the data with a delta value of -1 will be placed in the first chunk. will be processed first, which is inconsistent with the order of data input.

The current strategy is putting consecutive data with the same _tp_delta value in a chunk.
If the input chunk delta flags are `[1, 1, 1, -1, -1, 1, 1, 1]`.We will split into 3 chunks:`[[1, 1, 1], [-1, -1], [1, 1, 1]]`.
This not only ensures that the order of data processing is consistent with the input, but also ensures that the _tp_delta values in the same chunk are the same. 

this closes #448 