### PR TITLE
feat: Kafka external streams support SCRAM-SHA-256/512

### DIFF
--- a/src/KafkaLog/KafkaWALPool.h
+++ b/src/KafkaLog/KafkaWALPool.h
@@ -31,7 +31,7 @@ public:
 
     KafkaWALSimpleConsumerPtr getOrCreateStreaming(const String & cluster_id);
 
-    KafkaWALSimpleConsumerPtr getOrCreateStreamingExternal(const String & brokers, const KafkaWALAuth & auth, int32_t fetch_max_wait_ms = 200);
+    KafkaWALSimpleConsumerPtr getOrCreateStreamingExternal(const String & brokers, const KafkaWALAuth & auth, int32_t fetch_wait_max_ms = 200);
 
     std::vector<KafkaWALClusterPtr> clusters(const KafkaWALContext & ctx) const;
 

--- a/src/KafkaLog/KafkaWALSettings.h
+++ b/src/KafkaLog/KafkaWALSettings.h
@@ -2,9 +2,7 @@
 
 #include <boost/algorithm/string/join.hpp>
 
-#include <string>
-#include <vector>
-
+#include <boost/algorithm/string/predicate.hpp>
 #include <fmt/format.h>
 
 namespace klog
@@ -14,6 +12,7 @@ struct KafkaWALAuth
     std::string security_protocol;
     std::string username;
     std::string password;
+    std::string sasl_mechanism;
     std::string ssl_ca_cert_file;
 
     bool operator==(const KafkaWALAuth & o) const
@@ -23,6 +22,31 @@ struct KafkaWALAuth
             && password == o.password
             && ssl_ca_cert_file == o.ssl_ca_cert_file;
     }
+
+    bool usesSASL() const
+    {
+        return boost::istarts_with(security_protocol, "SASL_");
+    }
+
+    bool usesSecureConnection() const
+    {
+        return boost::iends_with(security_protocol, "SSL");
+    }
+
+    void populateConfigs(std::vector<std::pair<std::string, std::string>> & params) const
+    {
+        params.emplace_back("security.protocol", security_protocol.c_str());
+        if (usesSASL())
+        {
+            params.emplace_back("sasl.mechanism", sasl_mechanism.c_str());
+            params.emplace_back("sasl.username", username.c_str());
+            params.emplace_back("sasl.password", password.c_str());
+        }
+
+        /// "SASL_SSL" or "SSL"
+        if (usesSecureConnection() && !ssl_ca_cert_file.empty())
+            params.emplace_back("ssl.ca.location", ssl_ca_cert_file.c_str());
+        }
 };
 
 struct KafkaWALSettings
@@ -38,6 +62,7 @@ struct KafkaWALSettings
         .security_protocol = "plaintext",
         .username = "",
         .password = "",
+        .sasl_mechanism = "",
         .ssl_ca_cert_file = ""
     };
     /// FIXME, SASL, SSL etc support
@@ -45,7 +70,7 @@ struct KafkaWALSettings
     int32_t message_max_bytes = 1000000;
     int32_t topic_metadata_refresh_interval_ms = 300000;
     int32_t statistic_internal_ms = 30000;
-    std::string debug = "";
+    std::string debug;
 
     /////////////////////////////////////////////////////
 

--- a/src/KafkaLog/KafkaWALSettings.h
+++ b/src/KafkaLog/KafkaWALSettings.h
@@ -28,6 +28,7 @@ struct KafkaWALAuth
         return boost::istarts_with(security_protocol, "SASL_");
     }
 
+    /// "SASL_SSL" or "SSL"
     bool usesSecureConnection() const
     {
         return boost::iends_with(security_protocol, "SSL");
@@ -35,17 +36,16 @@ struct KafkaWALAuth
 
     void populateConfigs(std::vector<std::pair<std::string, std::string>> & params) const
     {
-        params.emplace_back("security.protocol", security_protocol.c_str());
+        params.emplace_back("security.protocol", security_protocol);
         if (usesSASL())
         {
-            params.emplace_back("sasl.mechanism", sasl_mechanism.c_str());
-            params.emplace_back("sasl.username", username.c_str());
-            params.emplace_back("sasl.password", password.c_str());
+            params.emplace_back("sasl.mechanism", sasl_mechanism);
+            params.emplace_back("sasl.username", username);
+            params.emplace_back("sasl.password", password);
         }
 
-        /// "SASL_SSL" or "SSL"
         if (usesSecureConnection() && !ssl_ca_cert_file.empty())
-            params.emplace_back("ssl.ca.location", ssl_ca_cert_file.c_str());
+            params.emplace_back("ssl.ca.location", ssl_ca_cert_file);
         }
 };
 
@@ -58,14 +58,7 @@ struct KafkaWALSettings
     /// Global settings for both producer and consumer /// global metrics
     /// comma separated host/port: host1:port,host2:port,...
     std::string brokers;
-    KafkaWALAuth auth = {
-        .security_protocol = "plaintext",
-        .username = "",
-        .password = "",
-        .sasl_mechanism = "",
-        .ssl_ca_cert_file = ""
-    };
-    /// FIXME, SASL, SSL etc support
+    KafkaWALAuth auth = { .security_protocol = "plaintext" };
 
     int32_t message_max_bytes = 1000000;
     int32_t topic_metadata_refresh_interval_ms = 300000;

--- a/src/Storages/ExternalStream/ExternalStreamSettings.h
+++ b/src/Storages/ExternalStream/ExternalStreamSettings.h
@@ -15,6 +15,7 @@ class ASTStorage;
     M(String, security_protocol, "plaintext", "The protocol to connection external logstore", 0) \
     M(String, username, "", "The username of external logstore", 0) \
     M(String, password, "", "The password of external logstore", 0) \
+    M(String, sasl_mechanism, "PLAIN", "SASL mechanism to use for authentication. Supported: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. Default to PLAIN when SASL is enabled.", 0) \
     M(String, ssl_ca_cert_file, "", "The path of ssl ca cert file", 0) \
     M(String, properties, "", "A semi-colon-separated key-value pairs for configuring the kafka client used by the external stream. A key-value pair is separated by a equal sign. Example: 'client.id=my-client-id;group.id=my-group-id'. Note, not all properties are supported, please check the document for supported properties.", 0) \
     M(String, sharding_expr, "", "An expression which will be evaluated on each row of data returned by the query to calculate the an integer which will be used to determine the ID of the partition to which the row of data will be sent. If not set, data are sent to any partition randomly.", 0) \

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <KafkaLog/KafkaWALCommon.h>
+#include <KafkaLog/KafkaWALSimpleConsumer.h>
 #include <Storages/ExternalStream/ExternalStreamSettings.h>
 #include <Storages/ExternalStream/StorageExternalStreamImpl.h>
 #include <Storages/ExternalStream/ExternalStreamCounter.h>
@@ -38,13 +39,11 @@ public:
     const String & brokers() const { return settings->brokers.value; }
     const String & dataFormat() const override { return data_format; }
     const String & topic() const { return settings->topic.value; }
-    const String & securityProtocol() const { return settings->security_protocol.value; }
-    const String & username() const { return settings->username.value; }
-    const String & password() const { return settings->password.value; }
-    const String & sslCaCertFile() const { return settings->ssl_ca_cert_file.value; }
     const klog::KConfParams & properties() const { return kafka_properties; }
     bool hasCustomShardingExpr() const { return !engine_args.empty(); }
     const ASTPtr & shardingExprAst() const { assert(!engine_args.empty()); return engine_args[0]; }
+    klog::KafkaWALAuth auth() const;
+    klog::KafkaWALSimpleConsumerPtr getConsumer(int32_t fetch_wait_max_ms = 200) const;
 
 private:
     void calculateDataFormat(const IStorage * storage);

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -40,9 +40,9 @@ public:
     const String & dataFormat() const override { return data_format; }
     const String & topic() const { return settings->topic.value; }
     const klog::KConfParams & properties() const { return kafka_properties; }
+    const klog::KafkaWALAuth & auth() const noexcept { return *auth_info; }
     bool hasCustomShardingExpr() const { return !engine_args.empty(); }
     const ASTPtr & shardingExprAst() const { assert(!engine_args.empty()); return engine_args[0]; }
-    klog::KafkaWALAuth auth() const;
     klog::KafkaWALSimpleConsumerPtr getConsumer(int32_t fetch_wait_max_ms = 200) const;
 
 private:
@@ -62,6 +62,7 @@ private:
     NamesAndTypesList virtual_column_names_and_types;
     klog::KConfParams kafka_properties;
     const ASTs engine_args;
+    const std::unique_ptr<klog::KafkaWALAuth> auth_info;
 
     std::mutex shards_mutex;
     int32_t shards = 0;

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -174,17 +174,7 @@ KafkaSink::KafkaSink(const Kafka * kafka, const Block & header, ContextPtr conte
 
     /// properies from settings have higher priority
     producer_params.emplace_back("bootstrap.servers", kafka->brokers());
-    producer_params.emplace_back("security.protocol", kafka->securityProtocol());
-    if (boost::iequals(kafka->securityProtocol(), "SASL_PLAINTEXT")
-        || boost::iequals(kafka->securityProtocol(), "SASL_SSL"))
-    {
-        producer_params.emplace_back("sasl.mechanisms", "PLAIN");
-        producer_params.emplace_back("sasl.username", kafka->username());
-        producer_params.emplace_back("sasl.password", kafka->password());
-    }
-
-    if (boost::iequals(kafka->securityProtocol(), "SASL_SSL") && !kafka->sslCaCertFile().empty())
-        producer_params.emplace_back("ssl.ca.location", kafka->sslCaCertFile());
+    kafka->auth().populateConfigs(producer_params);
 
     auto * conf = rd_kafka_conf_new();
     char errstr[512]{'\0'};

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -278,13 +278,7 @@ void KafkaSource::initConsumer(const Kafka * kafka)
         consume_ctx.auto_offset_reset = "earliest";
 
     consume_ctx.enforce_offset = true;
-    klog::KafkaWALAuth auth = {
-        .security_protocol = kafka->securityProtocol(),
-        .username = kafka->username(),
-        .password = kafka->password(),
-        .ssl_ca_cert_file = kafka->sslCaCertFile()
-    };
-    consumer = klog::KafkaWALPool::instance(nullptr).getOrCreateStreamingExternal(kafka->brokers(), auth, record_consume_timeout_ms);
+    consumer = kafka->getConsumer(record_consume_timeout_ms);
     consumer->initTopicHandle(consume_ctx);
 }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

closes #453 

Added support for SASL mechanisms SCRAM-SHA-256 and SCRAM-SHA-512.