### PR TITLE
Allow full range for var-int encoded integers

### DIFF
--- a/src/IO/VarInt.cpp
+++ b/src/IO/VarInt.cpp
@@ -1,0 +1,16 @@
+#include <IO/VarInt.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
+}
+
+void throwReadAfterEOF()
+{
+    throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+}
+
+}

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <base/types.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
@@ -8,34 +7,68 @@
 
 namespace DB
 {
-namespace ErrorCodes
+
+/// Variable-Length Quantity (VLQ) Base-128 compression, also known as Variable Byte (VB) or Varint encoding.
+
+[[noreturn]] void throwReadAfterEOF();
+
+
+inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
 {
-    extern const int ATTEMPT_TO_READ_AFTER_EOF;
+    while (x > 0x7F)
+    {
+        uint8_t byte = 0x80 | (x & 0x7F);
+
+        ostr.nextIfAtEnd();
+        *ostr.position() = byte;
+        ++ostr.position();
+
+        x >>= 7;
+    }
+
+    uint8_t final_byte = static_cast<uint8_t>(x);
+
+    ostr.nextIfAtEnd();
+    *ostr.position() = final_byte;
+    ++ostr.position();
 }
 
+inline void writeVarUInt(UInt64 x, std::ostream & ostr)
+{
+    while (x > 0x7F)
+    {
+        uint8_t byte = 0x80 | (x & 0x7F);
+        ostr.put(byte);
 
-/** Write UInt64 in variable length format (base128) NOTE Only up to 2^63 - 1 are supported. */
-void writeVarUInt(UInt64 x, std::ostream & ostr);
-void writeVarUInt(UInt64 x, WriteBuffer & ostr);
-char * writeVarUInt(UInt64 x, char * ostr);
+        x >>= 7;
+    }
 
+    uint8_t final_byte = static_cast<uint8_t>(x);
+    ostr.put(final_byte);
+}
 
-/** Read UInt64, written in variable length format (base128) */
-void readVarUInt(UInt64 & x, std::istream & istr);
-void readVarUInt(UInt64 & x, ReadBuffer & istr);
-const char * readVarUInt(UInt64 & x, const char * istr, size_t size);
+inline char * writeVarUInt(UInt64 x, char * ostr)
+{
+    while (x > 0x7F)
+    {
+        uint8_t byte = 0x80 | (x & 0x7F);
 
+        *ostr = byte;
+        ++ostr;
 
-/** Get the length of UInt64 in VarUInt format */
-size_t getLengthOfVarUInt(UInt64 x);
+        x >>= 7;
+    }
 
-/** Get the Int64 length in VarInt format */
-size_t getLengthOfVarInt(Int64 x);
+    uint8_t final_byte = static_cast<uint8_t>(x);
 
+    *ostr = final_byte;
+    ++ostr;
 
-/** Write Int64 in variable length format (base128) */
-template <typename OUT>
-inline void writeVarInt(Int64 x, OUT & ostr)
+    return ostr;
+}
+
+template <typename Out>
+inline void writeVarInt(Int64 x, Out & ostr)
 {
     writeVarUInt(static_cast<UInt64>((x << 1) ^ (x >> 63)), ostr);
 }
@@ -45,10 +78,73 @@ inline char * writeVarInt(Int64 x, char * ostr)
     return writeVarUInt(static_cast<UInt64>((x << 1) ^ (x >> 63)), ostr);
 }
 
+namespace impl
+{
 
-/** Read Int64, written in variable length format (base128) */
-template <typename IN>
-inline void readVarInt(Int64 & x, IN & istr)
+template <bool check_eof>
+inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
+{
+    x = 0;
+    for (size_t i = 0; i < 10; ++i)
+    {
+        if constexpr (check_eof)
+            if (istr.eof()) [[unlikely]]
+                throwReadAfterEOF();
+
+        UInt64 byte = *istr.position();
+        ++istr.position();
+        x |= (byte & 0x7F) << (7 * i);
+
+        if (!(byte & 0x80))
+            return;
+    }
+}
+
+}
+
+inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
+{
+    if (istr.buffer().end() - istr.position() >= 10)
+        return impl::readVarUInt<false>(x, istr);
+    return impl::readVarUInt<true>(x, istr);
+}
+
+inline void readVarUInt(UInt64 & x, std::istream & istr)
+{
+    x = 0;
+    for (size_t i = 0; i < 10; ++i)
+    {
+        UInt64 byte = istr.get();
+        x |= (byte & 0x7F) << (7 * i);
+
+        if (!(byte & 0x80))
+            return;
+    }
+}
+
+inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
+{
+    const char * end = istr + size;
+
+    x = 0;
+    for (size_t i = 0; i < 10; ++i)
+    {
+        if (istr == end) [[unlikely]]
+            throwReadAfterEOF();
+
+        UInt64 byte = *istr;
+        ++istr;
+        x |= (byte & 0x7F) << (7 * i);
+
+        if (!(byte & 0x80))
+            return istr;
+    }
+
+    return istr;
+}
+
+template <typename In>
+inline void readVarInt(Int64 & x, In & istr)
 {
     readVarUInt(*reinterpret_cast<UInt64*>(&x), istr);
     x = (static_cast<UInt64>(x) >> 1) ^ -(x & 1);
@@ -60,24 +156,6 @@ inline const char * readVarInt(Int64 & x, const char * istr, size_t size)
     x = (static_cast<UInt64>(x) >> 1) ^ -(x & 1);
     return res;
 }
-
-
-inline void writeVarT(UInt64 x, std::ostream & ostr) { writeVarUInt(x, ostr); }
-inline void writeVarT(Int64 x, std::ostream & ostr) { writeVarInt(x, ostr); }
-inline void writeVarT(UInt64 x, WriteBuffer & ostr) { writeVarUInt(x, ostr); }
-inline void writeVarT(Int64 x, WriteBuffer & ostr) { writeVarInt(x, ostr); }
-inline char * writeVarT(UInt64 x, char * & ostr) { return writeVarUInt(x, ostr); }
-inline char * writeVarT(Int64 x, char * & ostr) { return writeVarInt(x, ostr); }
-
-inline void readVarT(UInt64 & x, std::istream & istr) { readVarUInt(x, istr); }
-inline void readVarT(Int64 & x, std::istream & istr) { readVarInt(x, istr); }
-inline void readVarT(UInt64 & x, ReadBuffer & istr) { readVarUInt(x, istr); }
-inline void readVarT(Int64 & x, ReadBuffer & istr) { readVarInt(x, istr); }
-inline const char * readVarT(UInt64 & x, const char * istr, size_t size) { return readVarUInt(x, istr, size); }
-inline const char * readVarT(Int64 & x, const char * istr, size_t size) { return readVarInt(x, istr, size); }
-
-
-/// For [U]Int32, [U]Int16, size_t.
 
 inline void readVarUInt(UInt32 & x, ReadBuffer & istr)
 {
@@ -116,130 +194,6 @@ inline void readVarUInt(T & x, ReadBuffer & istr)
     x = tmp;
 }
 
-
-[[noreturn]] inline void throwReadAfterEOF()
-{
-    throw Exception("Attempt to read after eof", ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF);
-}
-
-template <bool fast>
-inline void readVarUIntImpl(UInt64 & x, ReadBuffer & istr)
-{
-    x = 0;
-    for (size_t i = 0; i < 9; ++i)
-    {
-        if constexpr (!fast)
-            if (istr.eof())
-                throwReadAfterEOF();
-
-        UInt64 byte = *istr.position(); /// NOLINT
-        ++istr.position();
-        x |= (byte & 0x7F) << (7 * i);
-
-        if (!(byte & 0x80))
-            return;
-    }
-}
-
-inline void readVarUInt(UInt64 & x, ReadBuffer & istr)
-{
-    if (istr.buffer().end() - istr.position() >= 9)
-        return readVarUIntImpl<true>(x, istr);
-    return readVarUIntImpl<false>(x, istr);
-}
-
-
-inline void readVarUInt(UInt64 & x, std::istream & istr)
-{
-    x = 0;
-    for (size_t i = 0; i < 9; ++i)
-    {
-        UInt64 byte = istr.get();
-        x |= (byte & 0x7F) << (7 * i);
-
-        if (!(byte & 0x80))
-            return;
-    }
-}
-
-inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
-{
-    const char * end = istr + size;
-
-    x = 0;
-    for (size_t i = 0; i < 9; ++i)
-    {
-        if (istr == end)
-            throwReadAfterEOF();
-
-        UInt64 byte = *istr; /// NOLINT
-        ++istr;
-        x |= (byte & 0x7F) << (7 * i);
-
-        if (!(byte & 0x80))
-            return istr;
-    }
-
-    return istr;
-}
-
-
-inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
-{
-    for (size_t i = 0; i < 9; ++i)
-    {
-        uint8_t byte = x & 0x7F;
-        if (x > 0x7F)
-            byte |= 0x80;
-
-        ostr.nextIfAtEnd();
-        *ostr.position() = byte;
-        ++ostr.position();
-
-        x >>= 7;
-        if (!x)
-            return;
-    }
-}
-
-
-inline void writeVarUInt(UInt64 x, std::ostream & ostr)
-{
-    for (size_t i = 0; i < 9; ++i)
-    {
-        uint8_t byte = x & 0x7F;
-        if (x > 0x7F)
-            byte |= 0x80;
-
-        ostr.put(byte);
-
-        x >>= 7;
-        if (!x)
-            return;
-    }
-}
-
-
-inline char * writeVarUInt(UInt64 x, char * ostr)
-{
-    for (size_t i = 0; i < 9; ++i)
-    {
-        uint8_t byte = x & 0x7F;
-        if (x > 0x7F)
-            byte |= 0x80;
-
-        *ostr = byte;
-        ++ostr;
-
-        x >>= 7;
-        if (!x)
-            return ostr;
-    }
-
-    return ostr;
-}
-
-
 inline size_t getLengthOfVarUInt(UInt64 x)
 {
     return x < (1ULL << 7) ? 1
@@ -250,7 +204,8 @@ inline size_t getLengthOfVarUInt(UInt64 x)
         : (x < (1ULL << 42) ? 6
         : (x < (1ULL << 49) ? 7
         : (x < (1ULL << 56) ? 8
-        : 9)))))));
+        : (x < (1ULL << 63) ? 9
+        : 10))))))));
 }
 
 

--- a/src/IO/tests/gtest_serialize_primitives.cpp
+++ b/src/IO/tests/gtest_serialize_primitives.cpp
@@ -1,0 +1,76 @@
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromVector.h>
+
+#include <gtest/gtest.h>
+
+TEST(Serde, VarUInt)
+{
+    struct Test
+    {
+        uint64_t i;
+        uint64_t e;
+    };
+
+    std::vector<Test> tests = {
+        {std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max()},
+        {std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::min()},
+        {std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max()},
+        {std::numeric_limits<int64_t>::max() - 1, std::numeric_limits<int64_t>::max() - 1},
+        {static_cast<uint64_t>(2ull | 0x80'00'00'00'00'00'00'00ull), static_cast<uint64_t>(2ull | 0x80'00'00'00'00'00'00'00ull)},
+        {static_cast<uint64_t>(2ull | 0x40'00'00'00'00'00'00'00ull), static_cast<uint64_t>(2ull | 0x40'00'00'00'00'00'00'00ull)},
+    };
+
+    for (const auto & t : tests)
+    {
+        std::vector<char> v;
+        v.reserve(sizeof(t.i));
+
+        {
+            DB::WriteBufferFromVector wb(v);
+            DB::writeVarUInt(t.i, wb);
+        }
+        {
+            DB::ReadBufferFromMemory rb(v.data(), v.size());
+
+            uint64_t r = 0;
+            DB::readVarUInt(r, rb);
+            ASSERT_EQ(r, t.e);
+        }
+    }
+}
+
+TEST(Serde, VarInt)
+{
+    struct Test
+    {
+        int64_t i;
+        int64_t e;
+    };
+
+    std::vector<Test> tests = {
+        {-1, -1},
+        {std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::min()},
+        {std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max()},
+    };
+
+    for (const auto & t : tests)
+    {
+        std::vector<char> v;
+        v.reserve(sizeof(t.i));
+
+        {
+            DB::WriteBufferFromVector wb(v);
+            DB::writeVarInt(t.i, wb);
+        }
+        {
+            DB::ReadBufferFromMemory rb(v.data(), v.size());
+
+            int64_t r = 0;
+            DB::readVarInt(r, rb);
+            ASSERT_EQ(r, t.e);
+        }
+    }
+}

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1683,17 +1683,18 @@ void TCPHandler::sendData(const Block & block)
 {
     initBlockOutput(block);
 
-    auto prev_bytes_written_out = out->count();
-    auto prev_bytes_written_compressed_out = state.maybe_compressed_out->count();
+    size_t prev_bytes_written_out = out->count();
+    size_t prev_bytes_written_compressed_out = state.maybe_compressed_out->count();
 
     try
     {
         /// For testing hedged requests
         if (unknown_packet_in_send_data)
         {
+            constexpr UInt64 marker = (1ULL<<63) - 1;
             --unknown_packet_in_send_data;
             if (unknown_packet_in_send_data == 0)
-                writeVarUInt(UInt64(-1), *out);
+                writeVarUInt(marker, *out);
         }
 
         writeVarUInt(Protocol::Server::Data, *out);

--- a/tests/queries_ported/0_stateless/02812_large_varints.sql
+++ b/tests/queries_ported/0_stateless/02812_large_varints.sql
@@ -1,0 +1,7 @@
+-- 64-bit integers with MSB set (i.e. values > (1ULL<<63) - 1) could for historical/compat reasons not be serialized as var-ints (issue #51486).
+-- These two queries internally produce such big values, run them to be sure no bad things happen.
+
+-- SELECT top_k(65535, now() -2) FORMAT Null; (topk need revisit? clickhouse works well)
+-- https://fiddle.clickhouse.com/760fc2b2-f1d3-42e2-8856-b2b835f97589
+
+SELECT number FROM numbers(to_uint64(-1)) limit 10 Format Null;


### PR DESCRIPTION
porting 
- [ ] https://github.com/ClickHouse/ClickHouse/pull/51905

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
