### PR TITLE
make file storage unsupport streaming query

### DIFF
--- a/src/Storages/FileLog/StorageFileLog.h
+++ b/src/Storages/FileLog/StorageFileLog.h
@@ -208,6 +208,8 @@ private:
 
     void deserialize();
     static void checkOffsetIsValid(const String & full_name, UInt64 offset);
+
+    bool supportsStreamingQuery() const override { return true; }
 };
 
 }

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -94,8 +94,6 @@ public:
 
     static SchemaCache & getSchemaCache(const ContextPtr & context);
 
-    bool supportsStreamingQuery() const override { return true; }
-
 protected:
     friend class StorageFileSource;
     friend class StorageFileSink;


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
this closed #469 
Originnal file storage supports streaming query, but the global aggregation is triggered with an interval.
```sql
SELECT
  count()
FROM
  file('/home/timeplus/lijianan/ssd/protondata/server_data/user_files/data', 'CSV', 'Time string, Exchange string, Symbol string, Sale_Condition string, Trade_Volume uint32, Trade_Price decimal(20,6), Trade_Stop_Stock_Indicator string, Trade_Correction_Indicator string, Sequence_Number uint32, Trade_Id uint64, Source_of_Trade string, Trade_Reporting_Facility string, Participant_Timestamp string, Trade_Reporting_Facility_TRF_Timestamp string, Trade_Through_Exempt_Indicator uint8')
SETTINGS
  format_csv_delimiter = '|', input_format_parallel_parsing = 0

Query id: cc2652fd-6025-4772-8bc5-e75597d4e087

Connecting to localhost:8463 as user default.
Connected to proton server version 1.3.31 revision 54459.

┌─explain─────────────────────────┐
│ (Expression)                    │
│ ExpressionTransform             │
│   (StreamingAggregating)        │
│   GlobalAggregatingTransform    │
│     (Expression)                │
│     ExpressionTransform         │
│       (WatermarkStep)           │
│       WatermarkStamperTransform │
│         (ReadFromStorage)       │
│         File 0 → 1              │
└─────────────────────────────────┘
```