### PR TITLE
enhance UDF name validation

### DIFF
--- a/src/Functions/UserDefined/UDFHelper.cpp
+++ b/src/Functions/UserDefined/UDFHelper.cpp
@@ -54,7 +54,7 @@ void validateUDFName(const String & func_name)
         throw Exception(ErrorCodes::UDF_INVALID_NAME, "UDF name's first char shall be an alphabetic or underscore");
 
     if (AggregateFunctionCombinatorPtr combinator = AggregateFunctionCombinatorFactory::instance().tryFindSuffix(func_name))
-        throw Exception(ErrorCodes::UDF_INVALID_NAME, "UDF name can not end up with " + combinator->getName() + ", because it is key word suffix");
+        throw Exception(fmt::format("UDF name can not end up with {}, because it is key word suffix", combinator->getName()), ErrorCodes::UDF_INVALID_NAME);
 }
 
 namespace

--- a/src/Functions/UserDefined/UDFHelper.cpp
+++ b/src/Functions/UserDefined/UDFHelper.cpp
@@ -1,5 +1,6 @@
 #include <Functions/UserDefined/UDFHelper.h>
 
+#include <AggregateFunctions/AggregateFunctionCombinatorFactory.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <Functions/UserDefined/IUserDefinedSQLObjectsLoader.h>
 #include <Functions/UserDefined/UserDefinedExecutableFunction.h>
@@ -51,6 +52,9 @@ void validateUDFName(const String & func_name)
 
     if (!std::isalpha(func_name[0]) && func_name[0] != '_')
         throw Exception(ErrorCodes::UDF_INVALID_NAME, "UDF name's first char shall be an alphabetic or underscore");
+
+    if (AggregateFunctionCombinatorPtr combinator = AggregateFunctionCombinatorFactory::instance().tryFindSuffix(func_name))
+        throw Exception(ErrorCodes::UDF_INVALID_NAME, "UDF name can not end up with " + combinator->getName() + ", because it is key word suffix");
 }
 
 namespace


### PR DESCRIPTION
When you create a UDA funtion like below:
```sql
CREATE OR REPLACE AGGREGATE FUNCTION group_distinct(value string)
RETURNS array(string)
LANGUAGE JAVASCRIPT AS $$
....
$$;
```
Proton won't recognize is as aggregation function, the reason is in this [code ](https://github.com/timeplus-io/proton/blob/develop/src/AggregateFunctions/AggregateFunctionFactory.cpp#L290C13-L290C13).Because the `_distinct` is key word suffix.
The other key word suffixes are below:
- `_distinct_streaming`
- `_distinct_retract`
- `_sample_state`
- `_or_default`
- `_distinct`
- `_resample`
- `_for_each`
- `_or_null`
- `_merge`
- `_state`
- `_array`
- `_null`
- `_map`
- `_if`
this closes #479 