### PR TITLE
prometheus metrics for external stream sink

### DIFF
--- a/src/Storages/ExternalStream/ExternalStreamCounter.h
+++ b/src/Storages/ExternalStream/ExternalStreamCounter.h
@@ -11,10 +11,16 @@ public:
     inline uint64_t getReadBytes() const { return read_bytes.load(); }
     inline uint64_t getReadCounts() const { return read_counts.load(); }
     inline uint64_t getReadFailed() const { return read_failed.load(); }
+    inline uint64_t getWriteBytes() const { return write_bytes.load(); }
+    inline uint64_t getWriteCounts() const { return write_counts.load(); }
+    inline uint64_t getWriteFailed() const { return write_failed.load(); }
 
     inline void addToReadBytes(uint64_t bytes) { read_bytes.fetch_add(bytes); }
     inline void addToReadCounts(uint64_t counts) { read_counts.fetch_add(counts); }
     inline void addToReadFailed(uint64_t amount) { read_failed.fetch_add(amount); }
+    inline void addToWriteBytes(uint64_t bytes) { write_bytes.fetch_add(bytes); }
+    inline void addToWriteCounts(uint64_t counts) { write_counts.fetch_add(counts); }
+    inline void addToWriteFailed(uint64_t amount) { write_failed.fetch_add(amount); }
 
     std::map<String, uint64_t> getCounters() const
     {
@@ -22,6 +28,9 @@ public:
             {"ReadBytes", read_bytes.load()},
             {"ReadCounts", read_counts.load()},
             {"ReadFailed", read_failed.load()},
+            {"WriteBytes", write_bytes.load()},
+            {"WriteCounts", write_counts.load()},
+            {"WriteFailed", write_failed.load()},
         };
     }
 
@@ -29,6 +38,9 @@ private:
     std::atomic<uint64_t> read_bytes;
     std::atomic<uint64_t> read_counts;
     std::atomic<uint64_t> read_failed;
+    std::atomic<uint64_t> write_bytes;
+    std::atomic<uint64_t> write_counts;
+    std::atomic<uint64_t> write_failed;
 };
 
 using ExternalStreamCounterPtr = std::shared_ptr<ExternalStreamCounter>;

--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -314,6 +314,7 @@ SinkToStoragePtr Kafka::write(const ASTPtr & /*query*/, const StorageMetadataPtr
 {
     /// always validate before actual use
     validate();
-    return std::make_shared<KafkaSink>(this, metadata_snapshot->getSampleBlock(), shards, message_key_ast, context, logger);
+    return std::make_shared<KafkaSink>(
+        this, metadata_snapshot->getSampleBlock(), shards, message_key_ast, context, logger, external_stream_counter);
 }
 }

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.h
@@ -3,6 +3,7 @@
 #include <Core/BlockWithShard.h>
 #include <Formats/FormatFactory.h>
 #include <Processors/Sinks/SinkToStorage.h>
+#include <Storages/ExternalStream/ExternalStreamCounter.h>
 #include <Storages/ExternalStream/Kafka/Kafka.h>
 #include <Storages/ExternalStream/Kafka/WriteBufferFromKafkaSink.h>
 #include <Common/ThreadPool.h>
@@ -46,7 +47,14 @@ private:
 class KafkaSink final : public SinkToStorage
 {
 public:
-    KafkaSink(const Kafka * kafka, const Block & header, Int32 initial_partition_cnt, const ASTPtr & message_key, ContextPtr context, Poco::Logger * logger_);
+    KafkaSink(
+        const Kafka * kafka,
+        const Block & header,
+        Int32 initial_partition_cnt,
+        const ASTPtr & message_key,
+        ContextPtr context,
+        Poco::Logger * logger_,
+        ExternalStreamCounterPtr external_stream_counter_);
     ~KafkaSink() override;
 
     String getName() const override { return "KafkaSink"; }
@@ -113,5 +121,6 @@ private:
     State state;
 
     Poco::Logger * logger;
+    ExternalStreamCounterPtr external_stream_counter;
 };
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

how to check:
1. create a topic `test` on redpanda/kafka

2. proton client
```sql
create external stream test(i int, j int) settings type='kafka', brokers='redpanda:9092', topic='test', data_format='JSONEachRow';
insert into test(i, j) values(1, 2)(3, 4)(5, 6);
select * from test settings seek_to='earliest'
```

3. query prometheus metrics
```shell
curl http://localhost:9363/metrics
```

response:
```
...
# TYPE ProtonExternalStream_ReadBytes counter
ProtonExternalStream_ReadBytes{database="default", name="test"} 42
# TYPE ProtonExternalStream_ReadCounts counter
ProtonExternalStream_ReadCounts{database="default", name="test"} 3
# TYPE ProtonExternalStream_ReadFailed counter
ProtonExternalStream_ReadFailed{database="default", name="test"} 0
# TYPE ProtonExternalStream_WriteBytes counter
ProtonExternalStream_WriteBytes{database="default", name="test"} 42
# TYPE ProtonExternalStream_WriteCounts counter
ProtonExternalStream_WriteCounts{database="default", name="test"} 3
# TYPE ProtonExternalStream_WriteFailed counter
ProtonExternalStream_WriteFailed{database="default", name="test"} 0
```