### PR TITLE
feature: [External Stream] Format settings declared on creation time should be taken into account

### DIFF
--- a/src/Storages/ExternalStream/ExternalStreamSettings.h
+++ b/src/Storages/ExternalStream/ExternalStreamSettings.h
@@ -2,6 +2,8 @@
 
 #include <Core/BaseSettings.h>
 #include <Core/Settings.h>
+#include <Formats/FormatFactory.h>
+#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -43,6 +45,25 @@ DECLARE_SETTINGS_TRAITS(ExternalStreamSettingsTraits, LIST_OF_EXTERNAL_STREAM_SE
 struct ExternalStreamSettings : public BaseSettings<ExternalStreamSettingsTraits>
 {
     void loadFromQuery(ASTStorage & storage_def);
+
+    FormatSettings getFormatSettings(const ContextPtr & context)
+    {
+        FormatFactorySettings settings {};
+        const auto & settings_from_context = context->getSettingsRef();
+
+        /// settings from context have higher priority
+#define SET_CHANGED_SETTINGS(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) \
+        if ((NAME).changed) \
+            settings.NAME = (NAME); \
+        if (settings_from_context.NAME.changed) \
+            settings.NAME = settings_from_context.NAME;
+
+        FORMAT_FACTORY_SETTINGS(SET_CHANGED_SETTINGS)
+
+#undef SET_CHANGED_SETTINGS
+
+        return DB::getFormatSettings(context, settings);
+    }
 };
 
 }

--- a/src/Storages/ExternalStream/ExternalStreamSettings.h
+++ b/src/Storages/ExternalStream/ExternalStreamSettings.h
@@ -53,10 +53,10 @@ struct ExternalStreamSettings : public BaseSettings<ExternalStreamSettingsTraits
 
         /// settings from context have higher priority
 #define SET_CHANGED_SETTINGS(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) \
-        if ((NAME).changed) \
-            settings.NAME = (NAME); \
         if (settings_from_context.NAME.changed) \
-            settings.NAME = settings_from_context.NAME;
+            settings.NAME = settings_from_context.NAME; \
+        else if ((NAME).changed) \
+            settings.NAME = (NAME);
 
         FORMAT_FACTORY_SETTINGS(SET_CHANGED_SETTINGS)
 

--- a/src/Storages/ExternalStream/StorageExternalStreamImpl.h
+++ b/src/Storages/ExternalStream/StorageExternalStreamImpl.h
@@ -41,10 +41,7 @@ public:
 
     FormatSettings getFormatSettings(const ContextPtr & context) const
     {
-        auto format_settings = DB::getFormatSettings(context);
-        if (format_settings.schema.format_schema.empty())
-            format_settings.schema.format_schema = formatSchema();
-        return format_settings;
+        return settings->getFormatSettings(context);
     }
 
 protected:

--- a/src/Storages/ExternalStream/tests/gtest_settings.cpp
+++ b/src/Storages/ExternalStream/tests/gtest_settings.cpp
@@ -5,19 +5,15 @@
 
 TEST(ExternalStreamSettings, getFormatSettings)
 {
-    auto & context = getMutableContext();
-    auto original_value = context.context->getSettingsRef().format_csv_delimiter;
-    context.context->setSetting("format_csv_delimiter", '/');
+    auto context = DB::Context::createCopy(getContext().context);
+    context->setSetting("format_csv_delimiter", DB::Field("/"));
 
     DB::ExternalStreamSettings ex_stream_settings{};
     ex_stream_settings.format_csv_delimiter = ';';
     ex_stream_settings.bool_true_representation = "yes";
 
-    auto settings = ex_stream_settings.getFormatSettings(context.context);
+    auto settings = ex_stream_settings.getFormatSettings(context);
     EXPECT_EQ(settings.csv.delimiter, '/'); /// from settings_for_context
     EXPECT_EQ(settings.bool_true_representation, "yes"); /// from ex_stream_settings
     EXPECT_EQ(settings.bool_false_representation, "false"); /// default value
-
-    /// restore
-    context.context->setSetting("format_csv_delimiter", original_value.value);
 }

--- a/src/Storages/ExternalStream/tests/gtest_settings.cpp
+++ b/src/Storages/ExternalStream/tests/gtest_settings.cpp
@@ -1,0 +1,20 @@
+#include <Storages/ExternalStream/ExternalStreamSettings.h>
+
+#include <gtest/gtest.h>
+
+TEST(ExternalStreamSettings, getFormatSettings)
+{
+    DB::Settings settings_for_context{};
+    settings_for_context.format_csv_delimiter = '/';
+    auto context = std::make_shared<DB::Context>();
+    context->setSettings(settings_for_context);
+
+    DB::ExternalStreamSettings ex_stream_settings{};
+    ex_stream_settings.format_csv_delimiter = ';';
+    ex_stream_settings.bool_true_representation = "yes";
+
+    auto settings = ex_stream_settings.getFormatSettings(context);
+    EXPECT_EQ(settings.csv.delimiter, '/'); /// from settings_for_context
+    EXPECT_EQ(settings.bool_true_representation, "yes"); /// from ex_stream_settings
+    EXPECT_EQ(settings.bool_false_representation, "false"); /// default value
+}

--- a/src/Storages/ExternalStream/tests/gtest_settings.cpp
+++ b/src/Storages/ExternalStream/tests/gtest_settings.cpp
@@ -6,7 +6,8 @@ TEST(ExternalStreamSettings, getFormatSettings)
 {
     DB::Settings settings_for_context{};
     settings_for_context.format_csv_delimiter = '/';
-    auto context = std::make_shared<DB::Context>();
+    auto shared_context = DB::Context::createShared();
+    auto context = DB::Context::createGlobal(shared_context.get());
     context->setSettings(settings_for_context);
 
     DB::ExternalStreamSettings ex_stream_settings{};

--- a/src/Storages/ExternalStream/tests/gtest_settings.cpp
+++ b/src/Storages/ExternalStream/tests/gtest_settings.cpp
@@ -1,21 +1,23 @@
+#include <Common/tests/gtest_global_context.h>
 #include <Storages/ExternalStream/ExternalStreamSettings.h>
 
 #include <gtest/gtest.h>
 
 TEST(ExternalStreamSettings, getFormatSettings)
 {
-    DB::Settings settings_for_context{};
-    settings_for_context.format_csv_delimiter = '/';
-    auto shared_context = DB::Context::createShared();
-    auto context = DB::Context::createGlobal(shared_context.get());
-    context->setSettings(settings_for_context);
+    auto & context = getMutableContext();
+    auto original_value = context.context->getSettingsRef().format_csv_delimiter;
+    context.context->setSetting("format_csv_delimiter", '/');
 
     DB::ExternalStreamSettings ex_stream_settings{};
     ex_stream_settings.format_csv_delimiter = ';';
     ex_stream_settings.bool_true_representation = "yes";
 
-    auto settings = ex_stream_settings.getFormatSettings(context);
+    auto settings = ex_stream_settings.getFormatSettings(context.context);
     EXPECT_EQ(settings.csv.delimiter, '/'); /// from settings_for_context
     EXPECT_EQ(settings.bool_true_representation, "yes"); /// from ex_stream_settings
     EXPECT_EQ(settings.bool_false_representation, "false"); /// default value
+
+    /// restore
+    context.context->setSetting("format_csv_delimiter", original_value.value);
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Closes #533 . Please refer to the issue to see the problem this PR resolves.
