### PR TITLE
enhancement: input_format_skip_unknown_fields default to true for external streams

### DIFF
--- a/src/Storages/ExternalStream/StorageExternalStreamImpl.h
+++ b/src/Storages/ExternalStream/StorageExternalStreamImpl.h
@@ -12,7 +12,12 @@ namespace DB
 class StorageExternalStreamImpl : public std::enable_shared_from_this<StorageExternalStreamImpl>
 {
 public:
-    explicit StorageExternalStreamImpl(std::unique_ptr<ExternalStreamSettings> settings_): settings(std::move(settings_)) {}
+    explicit StorageExternalStreamImpl(std::unique_ptr<ExternalStreamSettings> settings_): settings(std::move(settings_)) {
+        /// Make it easier for people to ingest data from external streams. A lot of times people didn't see data coming
+        /// only because the external stream does not have all the fields.
+        if (!settings->input_format_skip_unknown_fields.changed)
+            settings->input_format_skip_unknown_fields = true;
+    }
     virtual ~StorageExternalStreamImpl() = default;
 
     virtual void startup() = 0;


### PR DESCRIPTION

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Closes #549 .