### PR TITLE
bugfix: comment on ExternalStream was not showed in system.tables

### DIFF
--- a/src/Storages/ExternalStream/StorageExternalStream.cpp
+++ b/src/Storages/ExternalStream/StorageExternalStream.cpp
@@ -142,11 +142,13 @@ StorageExternalStream::StorageExternalStream(
     ContextPtr context_,
     const ColumnsDescription & columns_,
     std::unique_ptr<ExternalStreamSettings> external_stream_settings_,
+    const String & comment,
     bool attach)
     : IStorage(table_id_), WithContext(context_->getGlobalContext())
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
+    storage_metadata.setComment(comment);
     setInMemoryMetadata(storage_metadata);
 
     auto stream = createExternalStream(this, std::move(external_stream_settings_), context_, engine_args, attach, std::make_shared<ExternalStreamCounter>(), std::move(context_));
@@ -167,7 +169,7 @@ void registerStorageExternalStream(StorageFactory & factory)
             external_stream_settings->loadFromQuery(*args.storage_def);
 
             return StorageExternalStream::create(
-                args.engine_args, args.table_id, args.getContext(), args.columns, std::move(external_stream_settings), args.attach);
+                args.engine_args, args.table_id, args.getContext(), args.columns, std::move(external_stream_settings), args.comment, args.attach);
         }
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "External stream requires correct settings setup");

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -60,6 +60,7 @@ protected:
         ContextPtr context_,
         const ColumnsDescription & columns_,
         std::unique_ptr<ExternalStreamSettings> external_stream_settings_,
+        const String & comment,
         bool attach);
 
 private:


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

closes #563 