### PR TITLE
feature: support more secure settings for HTTPS for schema registry

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -771,6 +771,10 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(String, rawstore_time_extraction_rule, "", "_tp_time extraction rule (string, json, regex)", 0) \
     M(URI, kafka_schema_registry_url, "", "For ProtobufSingle format: Kafka Schema Registry URL.", 0) \
     M(String, kafka_schema_registry_credentials, "", "Credetials to be used to fetch schema from the `kafka_schema_registry_url`, with format '<username>:<password>'.", 0) \
+    M(String, kafka_schema_registry_private_key_file, "", "Path to the private key file used for encryption. Can be empty if no private key file is used.", 0) \
+    M(String, kafka_schema_registry_cert_file, "", "Path to the certificate file (in PEM format). If the private key and the certificate are stored in the same file, this can be empty if kakfa_schema_registry_private_key_file is given.", 0) \
+    M(String, kafka_schema_registry_ca_location, "", "Path to the file or directory containing the CA/root certificates.", 0) \
+    M(Bool, kafka_schema_registry_skip_cert_check, false, "If set to true, ignore server certificate check result.", 0) \
     /** proton: ends. */
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -110,8 +110,12 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.schema.format_schema_path = context->getFormatSchemaPath();
     format_settings.schema.is_server = context->hasGlobalContext() && (context->getGlobalContext()->getApplicationType() == Context::ApplicationType::SERVER);
     /// proton: starts
-    format_settings.schema.kafka_schema_registry_url = settings.kafka_schema_registry_url.toString();
-    format_settings.schema.kafka_schema_registry_credentials = settings.kafka_schema_registry_credentials;
+    format_settings.kafka_schema_registry.url = settings.kafka_schema_registry_url.toString();
+    format_settings.kafka_schema_registry.credentials = settings.kafka_schema_registry_credentials;
+    format_settings.kafka_schema_registry.private_key_file = settings.kafka_schema_registry_private_key_file;
+    format_settings.kafka_schema_registry.certificate_file = settings.kafka_schema_registry_cert_file;
+    format_settings.kafka_schema_registry.ca_location = settings.kafka_schema_registry_ca_location;
+    format_settings.kafka_schema_registry.skip_cert_check = settings.kafka_schema_registry_skip_cert_check;
     /// proton: ends
     format_settings.skip_unknown_fields = settings.input_format_skip_unknown_fields;
     format_settings.template_settings.resultset_format = settings.format_template_resultset;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -217,7 +217,7 @@ struct FormatSettings
         std::string private_key_file;
         std::string certificate_file;
         std::string ca_location;
-        bool skip_cert_check;
+        bool skip_cert_check = false;
     } kafka_schema_registry;
     /// proton: ends
 

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -207,11 +207,19 @@ struct FormatSettings
         std::string format_schema;
         std::string format_schema_path;
         bool is_server = false;
-        /// proton: starts
-        std::string kafka_schema_registry_url;
-        std::string kafka_schema_registry_credentials;
-        /// proton: ends
     } schema;
+
+    /// proton: starts
+    struct
+    {
+        std::string url;
+        std::string credentials;
+        std::string private_key_file;
+        std::string certificate_file;
+        std::string ca_location;
+        bool skip_cert_check;
+    } kafka_schema_registry;
+    /// proton: ends
 
     struct
     {

--- a/src/Formats/KafkaSchemaRegistry.cpp
+++ b/src/Formats/KafkaSchemaRegistry.cpp
@@ -22,12 +22,12 @@ KafkaSchemaRegistry::KafkaSchemaRegistry(
     const String & certificate_file_,
     const String & ca_location_,
     bool skip_cert_check)
-: base_url(base_url_)
-, private_key_file(private_key_file_)
-, certificate_file(certificate_file_)
-, ca_location(ca_location_)
-, Verification_mode(skip_cert_check ? Poco::Net::Context::VERIFY_NONE : Poco::Net::Context::VERIFY_RELAXED)
-, logger(&Poco::Logger::get("KafkaSchemaRegistry"))
+    : base_url(base_url_)
+    , private_key_file(private_key_file_)
+    , certificate_file(certificate_file_)
+    , ca_location(ca_location_)
+    , Verification_mode(skip_cert_check ? Poco::Net::Context::VERIFY_NONE : Poco::Net::Context::VERIFY_RELAXED)
+    , logger(&Poco::Logger::get("KafkaSchemaRegistry"))
 {
     assert(!base_url.empty());
 

--- a/src/Formats/KafkaSchemaRegistry.cpp
+++ b/src/Formats/KafkaSchemaRegistry.cpp
@@ -15,9 +15,19 @@ namespace ErrorCodes
 extern const int INCORRECT_DATA;
 }
 
-KafkaSchemaRegistry::KafkaSchemaRegistry(const String & base_url_, const String & credentials_)
-    : base_url(base_url_)
-    , logger(&Poco::Logger::get("KafkaSchemaRegistry"))
+KafkaSchemaRegistry::KafkaSchemaRegistry(
+    const String & base_url_,
+    const String & credentials_,
+    const String & private_key_file_,
+    const String & certificate_file_,
+    const String & ca_location_,
+    bool skip_cert_check)
+: base_url(base_url_)
+, private_key_file(private_key_file_)
+, certificate_file(certificate_file_)
+, ca_location(ca_location_)
+, Verification_mode(skip_cert_check ? Poco::Net::Context::VERIFY_NONE : Poco::Net::Context::VERIFY_RELAXED)
+, logger(&Poco::Logger::get("KafkaSchemaRegistry"))
 {
     assert(!base_url.empty());
 
@@ -48,7 +58,7 @@ String KafkaSchemaRegistry::fetchSchema(UInt32 id)
             if (!credentials.empty())
                 credentials.authenticate(request);
 
-            auto session = makePooledHTTPSession(url, timeouts, 1);
+            auto session = makePooledHTTPSession(url, private_key_file, certificate_file, ca_location, Verification_mode, timeouts, 1);
             std::istream * response_body{};
             try
             {

--- a/src/Formats/KafkaSchemaRegistry.h
+++ b/src/Formats/KafkaSchemaRegistry.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <Common/SipHash.h>
 #include <IO/ReadBuffer.h>
 
+#include <Poco/Net/Context.h>
 #include <Poco/Net/HTTPBasicCredentials.h>
 #include <Poco/URI.h>
 
@@ -14,14 +16,57 @@ class KafkaSchemaRegistry final
 public:
     static UInt32 readSchemaId(ReadBuffer & in);
 
+    /// The key type for caching KafkaSchemaRegistry
+    struct CacheKey
+    {
+        String base_url;
+        String credentials;
+        String private_key_file;
+        String certificate_file;
+        String ca_location;
+        bool skip_cert_check;
+
+        bool operator ==(const CacheKey & rhs) const
+        {
+            return std::tie(base_url, credentials, private_key_file, certificate_file, ca_location, skip_cert_check)
+                == std::tie(rhs.base_url, rhs.credentials, rhs.private_key_file, rhs.certificate_file, rhs.ca_location, rhs.skip_cert_check);
+        }
+    };
+
+    /// The hash function for caching KafkaSchemaRegistry
+    struct CacheHasher
+    {
+        size_t operator()(const CacheKey & k) const
+        {
+            SipHash s;
+            s.update(k.base_url);
+            s.update(k.credentials);
+            s.update(k.private_key_file);
+            s.update(k.certificate_file);
+            s.update(k.ca_location);
+            s.update(k.skip_cert_check);
+            return s.get64();
+        }
+    };
+
     /// \param credentials_ is expected to be formatted in "<username>:<password>".
-    KafkaSchemaRegistry(const String & base_url_, const String & credentials_);
+    KafkaSchemaRegistry(
+        const String & base_url_,
+        const String & credentials_,
+        const String & private_key_file_,
+        const String & certificate_file_,
+        const String & ca_location_,
+        bool skip_cert_check);
 
     String fetchSchema(UInt32 id);
 
 private:
     Poco::URI base_url;
     Poco::Net::HTTPBasicCredentials credentials;
+    String private_key_file;
+    String certificate_file;
+    String ca_location;
+    Poco::Net::Context::VerificationMode Verification_mode;
 
     Poco::Logger* logger;
 };

--- a/src/Formats/KafkaSchemaRegistry.h
+++ b/src/Formats/KafkaSchemaRegistry.h
@@ -26,7 +26,7 @@ public:
         String ca_location;
         bool skip_cert_check;
 
-        bool operator ==(const CacheKey & rhs) const
+        bool operator==(const CacheKey & rhs) const
         {
             return std::tie(base_url, credentials, private_key_file, certificate_file, ca_location, skip_cert_check)
                 == std::tie(rhs.base_url, rhs.credentials, rhs.private_key_file, rhs.certificate_file, rhs.ca_location, rhs.skip_cert_check);

--- a/src/IO/HTTPCommon.h
+++ b/src/IO/HTTPCommon.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <mutex>
 
+#include <Poco/Net/Context.h>
 #include <Poco/Net/HTTPClientSession.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
@@ -76,6 +77,29 @@ HTTPSessionPtr makeHTTPSession(const Poco::URI & uri, const ConnectionTimeouts &
 /// As previous method creates session, but tooks it from pool, without and with proxy uri.
 PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size, bool resolve_host = true);
 PooledHTTPSessionPtr makePooledHTTPSession(const Poco::URI & uri, const Poco::URI & proxy_uri, const ConnectionTimeouts & timeouts, size_t per_endpoint_pool_size, bool resolve_host = true);
+
+/// proton: starts
+PooledHTTPSessionPtr makePooledHTTPSession(
+    const Poco::URI & uri,
+    const String & private_key_file,
+    const String & certificate_file,
+    const String & ca_location,
+    Poco::Net::Context::VerificationMode verification_mode,
+    const ConnectionTimeouts & timeouts,
+    size_t per_endpoint_pool_size,
+    bool resolve_host = true);
+
+PooledHTTPSessionPtr makePooledHTTPSession(
+    const Poco::URI & uri,
+    const Poco::URI & proxy_uri,
+    const String & private_key_file,
+    const String & certificate_file,
+    const String & ca_location,
+    Poco::Net::Context::VerificationMode verification_mode,
+    const ConnectionTimeouts & timeouts,
+    size_t per_endpoint_pool_size,
+    bool resolve_host = true);
+/// proton: ends
 
 bool isRedirect(Poco::Net::HTTPResponse::HTTPStatus status);
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Four new settings are added:
* `kafka_schema_registry_private_key_file` - client private key file
* `kafka_schema_registry_certificate_file` - client certificate file
* `kafka_schema_registry_ca_location` - file or directory of CA file(s) to be used to verify the schema registry server certificate
* `kafka_schema_registry_skip_cert_check` - do not check server certificate, mostly useful for self-signed certificates

Check the changes in `Settings.h` for the details.