### PR TITLE
bugfix: kafka schema registry URI was not properly constructed

### DIFF
--- a/src/Formats/KafkaSchemaRegistry.cpp
+++ b/src/Formats/KafkaSchemaRegistry.cpp
@@ -22,7 +22,7 @@ KafkaSchemaRegistry::KafkaSchemaRegistry(
     const String & certificate_file_,
     const String & ca_location_,
     bool skip_cert_check)
-    : base_url(base_url_)
+    : base_url(base_url_.ends_with("/") ? base_url_ : base_url_ + "/")
     , private_key_file(private_key_file_)
     , certificate_file(certificate_file_)
     , ca_location(ca_location_)
@@ -46,7 +46,8 @@ String KafkaSchemaRegistry::fetchSchema(UInt32 id)
     {
         try
         {
-            Poco::URI url(base_url, std::format("/schemas/ids/{}", id));
+            /// Do not use "/schemas/ids/{}" here, otherwise the `path` in `base_url` will be removed.
+            Poco::URI url(base_url, std::format("schemas/ids/{}", id));
             LOG_TRACE(logger, "Fetching schema id = {}", id);
 
             /// One second for connect/send/receive. Just in case.


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

If the kafka schema registry base URL contains not just the host but also a path, for example "https://my.schema.registry/schema-registry", the path part ( 'schema-registry` in the example) will be removed, thus the schema won't be able to be fetched. This blocks the upstash case.