### PR TITLE
bugfix: properly quote CH table name for SELECT queries.

### DIFF
--- a/src/ClickHouse/Source.cpp
+++ b/src/ClickHouse/Source.cpp
@@ -17,7 +17,7 @@ String constructSelectQuery(const String & database, const String & table, const
     auto query = "SELECT " + backQuoteIfNeed(col_names[0]);
     for (const auto & name : std::vector<String>(std::next(col_names.begin()), col_names.end()))
         query.append(", " + backQuoteIfNeed(name));
-    query.append(" FROM " + (database.empty() ? "" : backQuoteIfNeed(database) + ".") + table);
+    query.append(" FROM " + (database.empty() ? "" : backQuoteIfNeed(database) + ".") + backQuoteIfNeed(table));
 
     return query;
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

closes #623 