### PR TITLE
feature: select message key from kafka external stream

### DIFF
--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -1,5 +1,6 @@
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeString.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
@@ -192,6 +193,8 @@ Kafka::ConfPtr createConfFromSettings(const KafkaExternalStreamSettings & settin
 
 }
 
+const String Kafka::VIRTUAL_COLUMN_MESSAGE_KEY = "_message_key";
+
 Kafka::Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, ExternalStreamCounterPtr external_stream_counter_, ContextPtr context)
     : StorageExternalStreamImpl(std::move(settings_))
     , storage_id(storage->getStorageID())
@@ -260,6 +263,7 @@ void Kafka::cacheVirtualColumnNamesAndTypes()
     virtual_column_names_and_types.push_back(NameAndTypePair(ProtonConsts::RESERVED_PROCESS_TIME, std::make_shared<DataTypeDateTime64>(3, "UTC")));
     virtual_column_names_and_types.push_back(NameAndTypePair(ProtonConsts::RESERVED_SHARD, std::make_shared<DataTypeInt32>()));
     virtual_column_names_and_types.push_back(NameAndTypePair(ProtonConsts::RESERVED_EVENT_SEQUENCE_ID, std::make_shared<DataTypeInt64>()));
+    virtual_column_names_and_types.push_back(NameAndTypePair(VIRTUAL_COLUMN_MESSAGE_KEY, std::make_shared<DataTypeString>()));
 }
 
 std::vector<Int64> Kafka::getOffsets(const SeekToInfoPtr & seek_to_info, const std::vector<int32_t> & shards_to_query) const

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -21,6 +21,8 @@ class Kafka final : public StorageExternalStreamImpl
 public:
     using ConfPtr = std::unique_ptr<rd_kafka_conf_t, decltype(rd_kafka_conf_destroy) *>;
 
+    static const String VIRTUAL_COLUMN_MESSAGE_KEY;
+
     static Poco::Logger * cbLogger() {
         static Poco::Logger * logger { &Poco::Logger::get("KafkaExternalStream") };
         return logger;

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -312,6 +312,11 @@ void KafkaSource::calculateColumnPositions()
             virtual_col_value_functions[pos] = [](const rd_kafka_message_t * kmessage) -> Int64 { return kmessage->offset; };
             virtual_col_types[pos] = column.type;
         }
+        else if (column.name == Kafka::VIRTUAL_COLUMN_MESSAGE_KEY)
+        {
+            virtual_col_value_functions[pos] = [](const rd_kafka_message_t * kmessage) -> String { return {static_cast<char *>(kmessage->key), kmessage->key_len}; };
+            virtual_col_types[pos] = column.type;
+        }
         else
         {
             physical_header.insert(column);


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Allow to select `_message_key` from kafka external streams. refs #400 