### PR TITLE
improve checkpoint compatibility

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -41,9 +41,9 @@ static ReturnType onError(const std::string & message [[maybe_unused]], int code
 
 template <typename ReturnType>
 static ReturnType checkColumnStructure(const ColumnWithTypeAndName & actual, const ColumnWithTypeAndName & expected,
-    std::string_view context_description, bool allow_materialize, int code)
+    std::string_view context_description, bool allow_materialize, bool ignore_name, int code)
 {
-    if (actual.name != expected.name)
+    if (!ignore_name && actual.name != expected.name)
         return onError<ReturnType>("Block structure mismatch in " + std::string(context_description) + " stream: different names of columns:\n"
             + actual.dumpStructure() + "\n" + expected.dumpStructure(), code);
 
@@ -107,7 +107,7 @@ static ReturnType checkColumnStructure(const ColumnWithTypeAndName & actual, con
 
 
 template <typename ReturnType>
-static ReturnType checkBlockStructure(const Block & lhs, const Block & rhs, std::string_view context_description, bool allow_materialize)
+static ReturnType checkBlockStructure(const Block & lhs, const Block & rhs, std::string_view context_description, bool allow_materialize, bool ignore_name)
 {
     size_t columns = rhs.columns();
     if (lhs.columns() != columns)
@@ -121,11 +121,11 @@ static ReturnType checkBlockStructure(const Block & lhs, const Block & rhs, std:
 
         if constexpr (std::is_same_v<ReturnType, bool>)
         {
-            if (!checkColumnStructure<ReturnType>(actual, expected, context_description, allow_materialize, ErrorCodes::LOGICAL_ERROR))
+            if (!checkColumnStructure<ReturnType>(actual, expected, context_description, allow_materialize, ignore_name, ErrorCodes::LOGICAL_ERROR))
                 return false;
         }
         else
-            checkColumnStructure<ReturnType>(actual, expected, context_description, allow_materialize, ErrorCodes::LOGICAL_ERROR);
+            checkColumnStructure<ReturnType>(actual, expected, context_description, allow_materialize, ignore_name, ErrorCodes::LOGICAL_ERROR);
     }
 
     return ReturnType(true);
@@ -166,7 +166,7 @@ void Block::insert(size_t position, ColumnWithTypeAndName elem)
     auto [new_it, inserted] = index_by_name.emplace(elem.name, position);
     if (!inserted)
         checkColumnStructure<void>(data[new_it->second], elem,
-            "(columns with identical name must have identical structure)", true, ErrorCodes::AMBIGUOUS_COLUMN_NAME);
+            "(columns with identical name must have identical structure)", true, false, ErrorCodes::AMBIGUOUS_COLUMN_NAME);
 
     for (auto it = index_by_name.begin(); it != index_by_name.end(); ++it)
     {
@@ -186,7 +186,7 @@ void Block::insert(ColumnWithTypeAndName elem)
     auto [it, inserted] = index_by_name.emplace(elem.name, data.size());
     if (!inserted)
         checkColumnStructure<void>(data[it->second], elem,
-            "(columns with identical name must have identical structure)", true, ErrorCodes::AMBIGUOUS_COLUMN_NAME);
+            "(columns with identical name must have identical structure)", true, false, ErrorCodes::AMBIGUOUS_COLUMN_NAME);
 
     data.emplace_back(std::move(elem));
 }
@@ -676,27 +676,31 @@ std::unordered_map<String, size_t> Block::getNamesToIndexesMap() const
 
 bool blocksHaveEqualStructure(const Block & lhs, const Block & rhs)
 {
-    return checkBlockStructure<bool>(lhs, rhs, "", false);
+    return checkBlockStructure<bool>(lhs, rhs, "", false, false);
 }
 
 
 void assertBlocksHaveEqualStructure(const Block & lhs, const Block & rhs, std::string_view context_description)
 {
-    checkBlockStructure<void>(lhs, rhs, context_description, false);
+    checkBlockStructure<void>(lhs, rhs, context_description, false, false);
 }
 
 
 bool isCompatibleHeader(const Block & actual, const Block & desired)
 {
-    return checkBlockStructure<bool>(actual, desired, "", true);
+    return checkBlockStructure<bool>(actual, desired, "", true, false);
 }
 
 
 void assertCompatibleHeader(const Block & actual, const Block & desired, std::string_view context_description)
 {
-    checkBlockStructure<void>(actual, desired, context_description, true);
+    checkBlockStructure<void>(actual, desired, context_description, true, false);
 }
 
+bool isCompatibleHeaderForRecovery(const Block & actual, const Block & desired)
+{
+    return checkBlockStructure<bool>(actual, desired, "", true, true);
+}
 
 void getBlocksDifference(const Block & lhs, const Block & rhs, std::string & out_lhs_diff, std::string & out_rhs_diff)
 {

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -676,30 +676,30 @@ std::unordered_map<String, size_t> Block::getNamesToIndexesMap() const
 
 bool blocksHaveEqualStructure(const Block & lhs, const Block & rhs)
 {
-    return checkBlockStructure<bool>(lhs, rhs, "", false, false);
+    return checkBlockStructure<bool>(lhs, rhs, "", false, /*ignore_name=*/false);
 }
 
 
 void assertBlocksHaveEqualStructure(const Block & lhs, const Block & rhs, std::string_view context_description)
 {
-    checkBlockStructure<void>(lhs, rhs, context_description, false, false);
+    checkBlockStructure<void>(lhs, rhs, context_description, false, /*ignore_name=*/false);
 }
 
 
 bool isCompatibleHeader(const Block & actual, const Block & desired)
 {
-    return checkBlockStructure<bool>(actual, desired, "", true, false);
+    return checkBlockStructure<bool>(actual, desired, "", true, /*ignore_name=*/false);
 }
 
 
 void assertCompatibleHeader(const Block & actual, const Block & desired, std::string_view context_description)
 {
-    checkBlockStructure<void>(actual, desired, context_description, true, false);
+    checkBlockStructure<void>(actual, desired, context_description, true, /*ignore_name=*/false);
 }
 
-bool isCompatibleHeaderForRecovery(const Block & actual, const Block & desired)
+bool isCompatibleHeaderWithoutComparingColumnNames(const Block & actual, const Block & desired)
 {
-    return checkBlockStructure<bool>(actual, desired, "", true, true);
+    return checkBlockStructure<bool>(actual, desired, "", true, /*ignore_name=*/true);
 }
 
 void getBlocksDifference(const Block & lhs, const Block & rhs, std::string & out_lhs_diff, std::string & out_rhs_diff)

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -234,6 +234,9 @@ void assertBlocksHaveEqualStructure(const Block & lhs, const Block & rhs, std::s
 bool isCompatibleHeader(const Block & actual, const Block & desired);
 void assertCompatibleHeader(const Block & actual, const Block & desired, std::string_view context_description);
 
+/// Actual header is compatible to desired if block have equal structure except constants and column names
+bool isCompatibleHeaderForRecovery(const Block & actual, const Block & desired);
+
 /// Calculate difference in structure of blocks and write description into output strings. NOTE It doesn't compare values of constant columns.
 void getBlocksDifference(const Block & lhs, const Block & rhs, std::string & out_lhs_diff, std::string & out_rhs_diff);
 

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -234,8 +234,10 @@ void assertBlocksHaveEqualStructure(const Block & lhs, const Block & rhs, std::s
 bool isCompatibleHeader(const Block & actual, const Block & desired);
 void assertCompatibleHeader(const Block & actual, const Block & desired, std::string_view context_description);
 
-/// Actual header is compatible to desired if block have equal structure except constants and column names
-bool isCompatibleHeaderForRecovery(const Block & actual, const Block & desired);
+/// proton : starts. Introduce head structure comparision without comparing the column names
+/// Actual header is compatible to desired if block have equal structure except column names
+bool isCompatibleHeaderWithoutComparingColumnNames(const Block & actual, const Block & desired);
+/// proton : ends
 
 /// Calculate difference in structure of blocks and write description into output strings. NOTE It doesn't compare values of constant columns.
 void getBlocksDifference(const Block & lhs, const Block & rhs, std::string & out_lhs_diff, std::string & out_rhs_diff);

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -463,11 +463,11 @@ void ExecutingGraph::deserialize(ReadBuffer & rb) const
 
             for (; recovered_ports_iter != recovered_ports.end();)
             {
-                /// Use `isCompatibleHeaderForRecovery` instead of `blocksHaveEqualStructure`,
-                /// 1) It's allowed when column from actual header is constant, but in desired is not,
-                ///    since the recovered columns are always non-const columns after serializing/deserializing for now
-                /// 2) It shall ignore column names, since the names are volatile.
-                if (!isCompatibleHeaderForRecovery(new_ports_iter->getHeader(), recovered_ports_iter->getHeader()))
+                /// Use `isCompatibleHeaderWithoutComparingColumnNames` instead of `blocksHaveEqualStructure`,
+                /// After deserialization from disk, the header name may be different than the current one in-memory
+                /// (for instance constant column names) for query state checkpoint. So skip column name comparision
+                /// when validting the head structure
+                if (!isCompatibleHeaderWithoutComparingColumnNames(new_ports_iter->getHeader(), recovered_ports_iter->getHeader()))
                     throw Exception(
                         ErrorCodes::RECOVER_CHECKPOINT_FAILED,
                         "Recovered streaming processor logic_id={} name={} doesn't have same input structure as the new planned processor. expected "

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -463,9 +463,11 @@ void ExecutingGraph::deserialize(ReadBuffer & rb) const
 
             for (; recovered_ports_iter != recovered_ports.end();)
             {
-                /// Use `isCompatibleHeader` instead of `blocksHaveEqualStructure`,
-                /// since the recovered columns are always non-const columns after serializing/deserializing for now
-                if (!isCompatibleHeader(new_ports_iter->getHeader(), recovered_ports_iter->getHeader()))
+                /// Use `isCompatibleHeaderForRecovery` instead of `blocksHaveEqualStructure`,
+                /// 1) It's allowed when column from actual header is constant, but in desired is not,
+                ///    since the recovered columns are always non-const columns after serializing/deserializing for now
+                /// 2) It shall ingore column names, since the names are volatile.
+                if (!isCompatibleHeaderForRecovery(new_ports_iter->getHeader(), recovered_ports_iter->getHeader()))
                     throw Exception(
                         ErrorCodes::RECOVER_CHECKPOINT_FAILED,
                         "Recovered streaming processor logic_id={} name={} doesn't have same input structure as the new planned processor. expected "

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -466,7 +466,7 @@ void ExecutingGraph::deserialize(ReadBuffer & rb) const
                 /// Use `isCompatibleHeaderForRecovery` instead of `blocksHaveEqualStructure`,
                 /// 1) It's allowed when column from actual header is constant, but in desired is not,
                 ///    since the recovered columns are always non-const columns after serializing/deserializing for now
-                /// 2) It shall ingore column names, since the names are volatile.
+                /// 2) It shall ignore column names, since the names are volatile.
                 if (!isCompatibleHeaderForRecovery(new_ports_iter->getHeader(), recovered_ports_iter->getHeader()))
                     throw Exception(
                         ErrorCodes::RECOVER_CHECKPOINT_FAILED,

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -363,7 +363,10 @@ void KafkaSource::doRecover(CheckpointContextPtr ckpt_ctx_)
 void KafkaSource::doResetStartSN(Int64 sn)
 {
     if (sn >= 0)
+    {
         offset = sn;
+        LOG_INFO(logger, "Reset start sn={}", offset);
+    }
 }
 
 void KafkaSource::State::serialize(WriteBuffer & wb) const

--- a/src/Storages/Streaming/StreamingStoreSource.cpp
+++ b/src/Storages/Streaming/StreamingStoreSource.cpp
@@ -18,6 +18,9 @@ StreamingStoreSource::StreamingStoreSource(
     Poco::Logger * log_)
     : StreamingStoreSourceBase(header, storage_snapshot_, std::move(context_), log_, ProcessorID::StreamingStoreSourceID)
 {
+    if (sn > 0)
+        last_sn = sn - 1;
+
     const auto & settings = query_context->getSettingsRef();
     if (settings.record_consume_batch_count.value != 0)
         record_consume_batch_count = static_cast<UInt32>(settings.record_consume_batch_count.value);
@@ -147,6 +150,8 @@ void StreamingStoreSource::doResetStartSN(Int64 sn)
             nativelog_reader->resetSequenceNumber(sn);
         else
             kafka_reader->resetOffset(sn);
+
+        LOG_INFO(log, "Reset start sn={}", sn);
     }
 }
 }

--- a/tests/stream/test_stream_smoke/0098_fixed_issues2.yaml
+++ b/tests/stream/test_stream_smoke/0098_fixed_issues2.yaml
@@ -1,0 +1,97 @@
+test_suite_name: fixed_issues2
+tag: smoke
+test_suite_config:
+  tests_2_run:
+    ids_2_run:
+      - all
+    tags_2_run: [ ]
+    tags_2_skip:
+      default:
+        - todo
+        - to_support
+        - change
+        - bug
+        - sample
+      cluster:
+        - view
+        - cluster_table_bug
+comments: Tests covering fixed issues smoke cases.
+
+tests:
+  - id: 0
+    tags:
+      - query state
+      - query state compatibility
+      - in subquery
+    name: recover the query with in subquery
+    description: recover the query with in subquery
+    steps:
+      - statements:
+          - client: python
+            query_type: table
+            query: drop stream if exists fixed_issues2_stream;
+
+          - client: python
+            query_type: table
+            exists: fixed_issues2_stream
+            exists_wait: 2
+            wait: 1
+            query: create stream fixed_issues2_stream(i int);
+
+          - client: python
+            query_type: table
+            depends_on_stream: fixed_issues2_stream
+            wait: 1
+            query: insert into fixed_issues2_stream(i) values(1);
+
+          - client: python
+            query_id: fixed-issues2-1
+            query_type: stream
+            wait: 1
+            query: subscribe to select i in (select i from table(fixed_issues2_stream)), multi_if(i in (select i from table(fixed_issues2_stream)), 1, 0) as t from fixed_issues2_stream settings seek_to='earliest', checkpoint_interval=1;
+
+          - client: python
+            query_id: fixed-issues2-2
+            query_type: stream
+            wait: 1
+            query: subscribe to with cte as (select 1), cte2 as (select multi_if(i in (cte), '1', '2') as t from fixed_issues2_stream where t = '1') select t from cte2 settings seek_to='earliest', checkpoint_interval=1
+
+          - client: python
+            query_type: type
+            depends_on: fixed-issues2-2
+            wait: 3
+            query: kill query where query_id='fixed-issues2-1' or query_id='fixed-issues2-2';
+
+          - client: python
+            query_id: fixed-issues2-1-1
+            query_type: stream
+            wait: 1
+            query: recover from 'fixed-issues2-1';
+
+          - client: python
+            query_id: fixed-issues2-2-1
+            query_type: stream
+            wait: 1
+            query: recover from 'fixed-issues2-2';
+
+          - client: python
+            depends_on: fixed-issues2-2
+            query_type: table
+            wait: 1
+            kill: fixed-issues2-1,fixed-issues2-2
+            kill_wait: 2
+            query: insert into fixed_issues2_stream(i) values(1);
+
+    expected_results:
+      - query_id: fixed-issues2-1
+        expected_results:
+          - ['True', 1]
+      - query_id: fixed-issues2-1-1
+        expected_results:
+          - ['True', 1]
+      - query_id: fixed-issues2-2
+        expected_results:
+          - ['1']
+      - query_id: fixed-issues2-2-1
+        expected_results:
+          - ['1']

--- a/tests/stream/test_stream_smoke/0098_fixed_issues2.yaml
+++ b/tests/stream/test_stream_smoke/0098_fixed_issues2.yaml
@@ -78,9 +78,16 @@ tests:
             depends_on: fixed-issues2-2
             query_type: table
             wait: 1
-            kill: fixed-issues2-1,fixed-issues2-2
-            kill_wait: 2
             query: insert into fixed_issues2_stream(i) values(1);
+  
+          - client: python
+            query_type: table
+            wait: 3
+            query: unsubscribe to 'fixed-issues2-1';
+  
+          - client: python
+            query_type: table
+            query: unsubscribe to 'fixed-issues2-2';
 
     expected_results:
       - query_id: fixed-issues2-1


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
- improve compatibility of the checkpointed  dag processor's header
- fix incorrect checkpointed sn if only exists historical data

Fix #421 