### PR TITLE
Use wait instead of sleep for materialized view recovery

### DIFF
--- a/src/Storages/Streaming/StorageMaterializedView.h
+++ b/src/Storages/Streaming/StorageMaterializedView.h
@@ -87,6 +87,9 @@ private:
 
     void checkDependencies() const;
 
+    template <typename Duration>
+    void waitFor(Duration && duration);
+
 private:
     Poco::Logger * log;
 
@@ -97,6 +100,9 @@ private:
     bool is_virtual = false;
 
     std::atomic_flag shutdown_called;
+
+    std::condition_variable wait_cv;
+    std::mutex wait_cv_mutex;
 
     /// Background state
     struct State

--- a/tests/stream/test_stream_smoke/0098_fixed_issues2.yaml
+++ b/tests/stream/test_stream_smoke/0098_fixed_issues2.yaml
@@ -47,13 +47,13 @@ tests:
           - client: python
             query_id: fixed-issues2-1
             query_type: stream
-            wait: 1
+            wait: 2
             query: subscribe to select i in (select i from table(fixed_issues2_stream)), multi_if(i in (select i from table(fixed_issues2_stream)), 1, 0) as t from fixed_issues2_stream settings seek_to='earliest', checkpoint_interval=1;
 
           - client: python
             query_id: fixed-issues2-2
             query_type: stream
-            wait: 1
+            wait: 2
             query: subscribe to with cte as (select 1), cte2 as (select multi_if(i in (cte), '1', '2') as t from fixed_issues2_stream where t = '1') select t from cte2 settings seek_to='earliest', checkpoint_interval=1
 
           - client: python


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
- Use `waitFor` instead of `sleep`, and allow be waked up when shutdown materialized view
- refine the exception log message

This close #637 