### PR TITLE
enhancement: more and better logs for kafka external stream

### DIFF
--- a/src/Storages/ExternalStream/Kafka/Consumer.cpp
+++ b/src/Storages/ExternalStream/Kafka/Consumer.cpp
@@ -14,7 +14,7 @@ namespace RdKafka
 {
 
 /// Consumer will take the ownership of `rk_conf`.
-Consumer::Consumer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, Poco::Logger * logger_) : logger(logger_)
+Consumer::Consumer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix)
 {
     char errstr[512];
     auto * conf = rd_kafka_conf_dup(&rk_conf);
@@ -27,7 +27,8 @@ Consumer::Consumer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, Poco
         throw Exception(klog::mapErrorCode(rd_kafka_last_error()), "Failed to create kafka handle: {}", errstr);
     }
 
-    LOG_INFO(logger, "Created consumer {}", name());
+    logger = &Poco::Logger::get(fmt::format("{}.{}", logger_name_prefix, name()));
+    LOG_INFO(logger, "Created consumer");
 
     poller.scheduleOrThrowOnError([this, poll_timeout_ms] { backgroundPoll(poll_timeout_ms); });
 }

--- a/src/Storages/ExternalStream/Kafka/Consumer.h
+++ b/src/Storages/ExternalStream/Kafka/Consumer.h
@@ -15,7 +15,7 @@ namespace RdKafka
 class Consumer : boost::noncopyable
 {
 public:
-    Consumer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, Poco::Logger * logger_);
+    Consumer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix);
     ~Consumer()
     {
         stopped.test_and_set();
@@ -33,8 +33,9 @@ public:
 
     void consumeBatch(Topic & topic, Int32 partition, uint32_t count, int32_t timeout_ms, Callback callback, ErrorCallback error_callback) const;
 
-private:
     std::string name() const { return rd_kafka_name(rk.get()); }
+
+private:
     void backgroundPoll(UInt64 poll_timeout_ms) const;
 
     klog::KafkaPtr rk {nullptr, rd_kafka_destroy};

--- a/src/Storages/ExternalStream/Kafka/ConsumerPool.h
+++ b/src/Storages/ExternalStream/Kafka/ConsumerPool.h
@@ -43,12 +43,12 @@ public:
     using Entry = IConsumerPool::Entry;
     using Base = PoolBase<Consumer>;
 
-    ConsumerPool(unsigned size, const StorageID & storage_id, rd_kafka_conf_t & conf, UInt64 poll_timeout_ms_, Poco::Logger * consumer_logger_)
+    ConsumerPool(unsigned size, const StorageID & storage_id, rd_kafka_conf_t & conf, UInt64 poll_timeout_ms_, const String & consumer_logger_name_prefix_)
        : Base(size,
         &Poco::Logger::get("RdKafkaConsumerPool (" + storage_id.getFullNameNotQuoted() + ")"))
         , rd_conf(conf)
         , poll_timeout_ms(poll_timeout_ms_)
-        , consumer_logger(consumer_logger_)
+        , consumer_logger_name_prefix(consumer_logger_name_prefix_)
     {
     }
 
@@ -68,13 +68,13 @@ protected:
     /** Creates a new object to put in the pool. */
     std::shared_ptr<Consumer> allocObject() override
     {
-        return std::make_shared<Consumer>(rd_conf, poll_timeout_ms, consumer_logger);
+        return std::make_shared<Consumer>(rd_conf, poll_timeout_ms, consumer_logger_name_prefix);
     }
 
 private:
     rd_kafka_conf_t & rd_conf;
     UInt64 poll_timeout_ms {0};
-    Poco::Logger * consumer_logger;
+    String consumer_logger_name_prefix;
 };
 
 }

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -31,6 +31,7 @@ public:
     static int onStats(struct rd_kafka_s * rk, char * json, size_t json_len, void * opaque);
     static void onError(struct rd_kafka_s * rk, int err, const char * reason, void * opaque);
     static void onThrottle(struct rd_kafka_s * rk, const char * broker_name, int32_t broker_id, int throttle_time_ms, void * opaque);
+    static void onLog(const struct rd_kafka_s * rk, int level, const char * fac, const char * buf);
 
     Kafka(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, ExternalStreamCounterPtr external_stream_counter_, ContextPtr context);
     ~Kafka() override = default;

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -27,7 +27,7 @@ KafkaSource::KafkaSource(
     Kafka & kafka_,
     const Block & header_,
     const StorageSnapshotPtr & storage_snapshot_,
-    RdKafka::ConsumerPool::Entry consumer_,
+    const RdKafka::ConsumerPool::Entry & consumer_,
     RdKafka::TopicPtr topic_,
     Int32 shard_,
     Int64 offset_,
@@ -50,7 +50,7 @@ KafkaSource::KafkaSource(
     , ckpt_data(kafka.topicName(), shard)
     , external_stream_counter(external_stream_counter_)
     , query_context(std::move(query_context_))
-    , logger(&Poco::Logger::get(fmt::format("{}(source-{})", kafka.getLoggerName(), query_context->getCurrentQueryId())))
+    , logger(&Poco::Logger::get(fmt::format("{}.{}", kafka.getLoggerName(), consumer->name())))
 {
     assert(external_stream_counter);
 

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.h
@@ -23,7 +23,7 @@ public:
         Kafka & kafka_,
         const Block & header_,
         const StorageSnapshotPtr & storage_snapshot_,
-        RdKafka::ConsumerPool::Entry consumer_,
+        const RdKafka::ConsumerPool::Entry & consumer_,
         RdKafka::TopicPtr topic_,
         Int32 shard_,
         Int64 offset_,

--- a/src/Storages/ExternalStream/Kafka/Producer.cpp
+++ b/src/Storages/ExternalStream/Kafka/Producer.cpp
@@ -14,7 +14,7 @@ namespace RdKafka
 {
 
 /// Producer will take the ownership of `rk_conf`.
-Producer::Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, Poco::Logger * logger_) : logger(logger_)
+Producer::Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix)
 {
     char errstr[512];
     auto * conf = rd_kafka_conf_dup(&rk_conf);
@@ -26,6 +26,9 @@ Producer::Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, Poco
         rd_kafka_conf_destroy(conf);
         throw Exception(klog::mapErrorCode(rd_kafka_last_error()), "Failed to create kafka handle: {}", errstr);
     }
+
+    logger = &Poco::Logger::get(fmt::format("{}.{}", logger_name_prefix, name()));
+    LOG_INFO(logger, "Created producer");
 
     poller.scheduleOrThrowOnError([this, poll_timeout_ms] { backgroundPoll(poll_timeout_ms); });
 }

--- a/src/Storages/ExternalStream/Kafka/Producer.h
+++ b/src/Storages/ExternalStream/Kafka/Producer.h
@@ -14,7 +14,7 @@ namespace RdKafka
 class Producer : boost::noncopyable
 {
 public:
-    Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, Poco::Logger * logger_);
+    Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix);
     ~Producer()
     {
         stopped.test_and_set();
@@ -22,8 +22,9 @@ public:
 
     rd_kafka_t * getHandle() const { return rk.get(); }
 
-private:
     std::string name() const { return rd_kafka_name(rk.get()); }
+
+private:
     void backgroundPoll(UInt64 poll_timeout_ms) const;
 
     klog::KafkaPtr rk {nullptr, rd_kafka_destroy};


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Better log handling for kafka external stream:
* use Poco::Logger to output librdkafka internal logs instead of using stderr ( default by the library )
* added consumer name to consumer related logs
* added producer name to producer related logs
* removed some redundant information