### PR TITLE
Simplified consumer management for Kafka external stream

### DIFF
--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -960,3 +960,12 @@ send_crash_reports:
     endpoint: 'https://6f33034cfe684dd7a3ab9875e57b1c8d@o388870.ingest.sentry.io/5226277'
     # Uncomment to disable proton internal DNS caching.
     # disable_internal_dns_cache: 1
+
+# External stream related configurations
+external_stream:
+    kafka:
+        # Defines how many consumers can be created for each Kafka external stream.
+        # When a SELECT query on a Kafka external stream is executed, a consumer
+        # will be created for that query. That means, no more than `max_consumers_per_stream`
+        # SELECT queries can be executed in parallel on the same Kafka external stream.
+        max_consumers_per_stream: 50

--- a/src/Storages/ExternalStream/Kafka/Consumer.h
+++ b/src/Storages/ExternalStream/Kafka/Consumer.h
@@ -48,8 +48,8 @@ private:
     ThreadPool poller;
     Poco::Logger * logger;
 
-    std::atomic_flag started = ATOMIC_FLAG_INIT;
-    std::atomic_flag stopped = ATOMIC_FLAG_INIT;
+    std::atomic_flag started;
+    std::atomic_flag stopped;
 };
 
 }

--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -499,7 +499,7 @@ std::shared_ptr<RdKafka::Consumer> Kafka::getConsumer()
     auto new_consumer = std::make_shared<RdKafka::Consumer>(*conf, poll_timeout_ms, getLoggerName());
     std::weak_ptr<RdKafka::Consumer> ref = new_consumer;
 
-    std::lock_guard<std::mutex> lock(consumer_mutex);
+    std::lock_guard<std::mutex> lock{consumer_mutex};
     for (auto & consumer : consumers)
     {
         /// if a consumer is gone, replace it with the new one, so that `consumers` won't keep growing forever.
@@ -518,7 +518,7 @@ std::shared_ptr<RdKafka::Producer> Kafka::getProducer()
     if (producer)
         return producer;
 
-    std::scoped_lock lock(producer_mutex);
+    std::lock_guard<std::mutex> lock{producer_mutex};
     /// Check again in case of losing the race
     if (producer)
         return producer;

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -14,11 +14,6 @@ namespace DB
 
 class IStorage;
 
-namespace ErrorCodes
-{
-extern const int NO_AVAILABLE_KAFKA_CONSUMER;
-}
-
 class Kafka final : public StorageExternalStreamImpl
 {
 public:
@@ -125,6 +120,7 @@ private:
     /// A Consumer can only be used by one source at the same time (technically speaking, it can be used by multple sources as long as each source read from a different topic,
     /// but we will leave this as an enhancement later, probably when we introduce the `Connection` concept), thus we need a consumer pool.
     std::mutex consumer_mutex;
+    size_t max_consumers = 0;
     std::vector<std::weak_ptr<RdKafka::Consumer>> consumers;
 
     Poco::Logger * logger;

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -6,7 +6,6 @@
 #include <Storages/ExternalStream/StorageExternalStreamImpl.h>
 #include <Storages/ExternalStream/ExternalStreamCounter.h>
 #include <Storages/ExternalStream/Kafka/Consumer.h>
-#include <Storages/ExternalStream/Kafka/ConsumerPool.h>
 #include <Storages/ExternalStream/Kafka/Producer.h>
 #include <Storages/Streaming/SeekToInfo.h>
 
@@ -44,13 +43,21 @@ public:
     void shutdown() override {
         LOG_INFO(logger, "Shutting down Kafka External Stream");
 
-        consumer_pool->shutdown();
-        if (producer)
-            producer->shutdown();
-
         /// Must release all resources here rather than relying on the deconstructor.
         /// Because the `Kafka` instance will not be destroyed immediately when the external stream gets dropped.
-        consumer_pool.reset();
+        {
+            std::lock_guard<std::mutex> lock(consumer_mutex);
+            for (auto & consumer_ptr : consumers)
+                /// if the consumer is still running, mark it stopped
+                if (auto consumer = consumer_ptr.lock())
+                    consumer->setStopped();
+
+            std::vector<std::weak_ptr<RdKafka::Consumer>> empty_consumers;
+            consumers.swap(empty_consumers);
+        }
+
+        if (producer)
+            producer->setStopped();
         if (producer_topic)
         {
             // producer_topic.reset();
@@ -90,15 +97,7 @@ public:
 
     std::shared_ptr<RdKafka::Producer> getProducer();
     std::shared_ptr<RdKafka::Topic> getProducerTopic();
-
-    RdKafka::ConsumerPool::Entry getConsumer() const
-    {
-        assert(consumer_pool);
-        auto entry = consumer_pool->get(/*max_wait_ms=*/ 1000);
-        if (entry.isNull())
-            throw Exception(ErrorCodes::NO_AVAILABLE_KAFKA_CONSUMER, "No consumers were available");
-        return entry;
-    }
+    std::shared_ptr<RdKafka::Consumer> getConsumer();
 
     String getLoggerName() const { return storage_id.getDatabaseName() == "default" ? storage_id.getTableName() : storage_id.getFullNameNotQuoted(); }
 
@@ -106,9 +105,9 @@ private:
     Kafka::ConfPtr createRdConf(KafkaExternalStreamSettings settings_);
     void calculateDataFormat(const IStorage * storage);
     void cacheVirtualColumnNamesAndTypes();
-    std::vector<Int64> getOffsets(const SeekToInfoPtr & seek_to_info, const std::vector<int32_t> & shards_to_query) const;
+    std::vector<Int64> getOffsets(const RdKafka::Consumer & consumer, const SeekToInfoPtr & seek_to_info, const std::vector<int32_t> & shards_to_query) const;
     void validateMessageKey(const String & message_key, IStorage * storage, const ContextPtr & context);
-    void validate() const;
+    void validate();
 
     ASTs engine_args;
     String data_format;
@@ -122,13 +121,17 @@ private:
     fs::path broker_ca_file;
 
     ConfPtr conf;
+    UInt64 poll_timeout_ms = 0;
+
     /// The Producer instance and Topic instance can be used by multiple sinks at the same time, thus we only need one of each.
     std::mutex producer_mutex;
     std::shared_ptr<RdKafka::Producer> producer;
     std::shared_ptr<RdKafka::Topic> producer_topic;
+
     /// A Consumer can only be used by one source at the same time (technically speaking, it can be used by multple sources as long as each source read from a different topic,
     /// but we will leave this as an enhancement later, probably when we introduce the `Connection` concept), thus we need a consumer pool.
-    RdKafka::ConsumerPoolPtr consumer_pool;
+    std::mutex consumer_mutex;
+    std::vector<std::weak_ptr<RdKafka::Consumer>> consumers;
 
     Poco::Logger * logger;
 };

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.h
@@ -4,7 +4,7 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <Processors/Streaming/ISource.h>
 #include <Storages/ExternalStream/ExternalStreamCounter.h>
-#include <Storages/ExternalStream/Kafka/ConsumerPool.h>
+#include <Storages/ExternalStream/Kafka/Consumer.h>
 #include <Storages/ExternalStream/Kafka/Topic.h>
 #include <Storages/IStorage.h>
 #include <Storages/StorageSnapshot.h>
@@ -23,7 +23,7 @@ public:
         Kafka & kafka_,
         const Block & header_,
         const StorageSnapshotPtr & storage_snapshot_,
-        const RdKafka::ConsumerPool::Entry & consumer_,
+        std::shared_ptr<RdKafka::Consumer> consumer_,
         RdKafka::TopicPtr topic_,
         Int32 shard_,
         Int64 offset_,
@@ -80,7 +80,7 @@ private:
     UInt32 record_consume_batch_count = 1000;
     Int32 record_consume_timeout_ms = 100;
 
-    RdKafka::ConsumerPool::Entry consumer;
+    std::shared_ptr<RdKafka::Consumer> consumer;
     RdKafka::TopicPtr topic;
     Int32 shard;
     Int64 offset;

--- a/src/Storages/ExternalStream/Kafka/Producer.cpp
+++ b/src/Storages/ExternalStream/Kafka/Producer.cpp
@@ -33,6 +33,11 @@ Producer::Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, cons
     poller.scheduleOrThrowOnError([this, poll_timeout_ms] { backgroundPoll(poll_timeout_ms); });
 }
 
+Producer::~Producer() {
+    setStopped();
+    poller.wait();
+}
+
 void Producer::backgroundPoll(UInt64 poll_timeout_ms) const
 {
     LOG_INFO(logger, "Start producer poll");

--- a/src/Storages/ExternalStream/Kafka/Producer.h
+++ b/src/Storages/ExternalStream/Kafka/Producer.h
@@ -15,13 +15,13 @@ class Producer : boost::noncopyable
 {
 public:
     Producer(const rd_kafka_conf_t & rk_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix);
-    ~Producer() { shutdown(); }
+    ~Producer();
 
     rd_kafka_t * getHandle() const { return rk.get(); }
 
     std::string name() const { return rd_kafka_name(rk.get()); }
 
-    void shutdown() { stopped.test_and_set(); }
+    void setStopped() { stopped.test_and_set(); }
 
     bool isStopped() const { return stopped.test(); }
 

--- a/src/Storages/ExternalStream/Kafka/Producer.h
+++ b/src/Storages/ExternalStream/Kafka/Producer.h
@@ -32,7 +32,7 @@ private:
     ThreadPool poller;
     Poco::Logger * logger;
 
-    std::atomic_flag stopped = ATOMIC_FLAG_INIT;
+    std::atomic_flag stopped;
 };
 
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Simplified consumer management for Kafka external stream, this also break the dependency between `Kafka` and `KafkaSource` when Proton tries to shutdown the things. It's observed that it's possible a Proton termination could be blocked due to `Kafka` waiting for everything is shutdown. Since the stop order is not guaranteed, such dependency should not exist.

Also, there was a drawback with the current consumer pool implementation, which is that, pooled consumers are never cleaned up until the external stream is shutdown. Which means, if there are a lot concurrent ad-hoc queries happen at some time, there are a lot consumers will get created and pooled, and they might be never used again in a later time.