### PR TITLE
allow disable backfill from historical store for VersioendKV

### DIFF
--- a/src/Storages/Streaming/StorageStream.cpp
+++ b/src/Storages/Streaming/StorageStream.cpp
@@ -1009,10 +1009,8 @@ StorageStream::ShardsToRead StorageStream::getRequiredShardsToRead(ContextPtr co
         /// 1) For non-inmemory keyed storage stream, we always back fill from historical store (e.g. VersionedKV, ChangelogKV)
         /// 2) Do time travel with settings `enable_backfill_from_historical_store = true`
         bool require_back_fill_from_historical = false;
-        if (!isInmemory() && Streaming::isKeyedStorage(dataStreamSemantic()))
-            require_back_fill_from_historical = true;
-        else if (!query_info.seek_to_info->getSeekTo().empty() && settings_ref.enable_backfill_from_historical_store.value)
-            require_back_fill_from_historical = true;
+        if (!isInmemory() && (Streaming::isKeyedStorage(dataStreamSemantic()) || !query_info.seek_to_info->getSeekTo().empty()))
+            require_back_fill_from_historical = settings_ref.enable_backfill_from_historical_store.value;
 
         result.mode = require_back_fill_from_historical ? QueryMode::STREAMING_CONCAT : QueryMode::STREAMING;
     }


### PR DESCRIPTION
_PR_ checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
This fix #674 