### PR TITLE
bugfix: possible double-free error when KafkaSink frees message payload.

### DIFF
--- a/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.cpp
@@ -48,7 +48,7 @@ ChunkSharder::ChunkSharder()
     random_sharding = true;
 }
 
-BlocksWithShard ChunkSharder::shard(Block block, Int32 shard_cnt) const
+BlocksWithShard ChunkSharder::shard(Block block, Int32 shard_cnt)
 {
     /// no topics have zero partitions
     assert(shard_cnt > 0);

--- a/src/Storages/ExternalStream/Kafka/KafkaSink.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSink.h
@@ -21,13 +21,14 @@ public:
     ChunkSharder(ExpressionActionsPtr sharding_expr_, const String & column_name);
     ChunkSharder();
 
-    BlocksWithShard shard(Block block, Int32 shard_cnt) const;
+    BlocksWithShard shard(Block block, Int32 shard_cnt);
 
 private:
-    Int32 getNextShardIndex(Int32 /*shard_cnt*/) const noexcept
+    Int32 getNextShardIndex(Int32 shard_cnt) noexcept
     {
-        /// let librdkafka decides
-        return RD_KAFKA_PARTITION_UA;
+        if (next_shard >= shard_cnt)
+            next_shard = 0;
+        return next_shard++;
     }
 
     BlocksWithShard doSharding(Block block, Int32 shard_cnt) const;
@@ -37,6 +38,7 @@ private:
     ExpressionActionsPtr sharding_expr;
     String sharding_key_column_name;
     bool random_sharding = false;
+    Int32 next_shard = 0;
 };
 
 }


### PR DESCRIPTION
We call `rd_kafka_produce_batch` with RD_KAFKA_MSG_F_FREE flag, which means if a message's `err` is empty, librdkafka will free the message's payload, otherwise, the application is responsible for freeing it. However, the implementation of `rd_kafka_produce_batch` does not work in that way exactly. There is one case that, if `RD_KAFKA_PARTITION_UA` is used, then when calling the partitioner fails, `rd_kafka_produce_batch` will still free the message payload, which violates the promise. Reference:
https://github.com/confluentinc/librdkafka/blob/c96878a32bdc668287cf9b11c7b32e810f762376/src/rdkafka_msg.c#L797.

There is one known situation will trigger this issue:
* create a kafka topic and make sure that topic has more than 1 partitions (not sure why it requires more than 1 paritions)
* create an external stream
* start inserting data to that stream in a streaming way
* delete the kafka topic
* then double-free error happens

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
