### PR TITLE
buffix: check create_directories error properly

### DIFF
--- a/src/Storages/ExternalStream/StorageExternalStreamImpl.cpp
+++ b/src/Storages/ExternalStream/StorageExternalStreamImpl.cpp
@@ -12,7 +12,8 @@ void StorageExternalStreamImpl::createTempDirIfNotExists() const
 {
     std::error_code err;
     /// create_directories will do nothing if the directory already exists.
-    if (!fs::create_directories(tmpdir, err))
+    fs::create_directories(tmpdir, err);
+    if (err)
         throw Exception(ErrorCodes::CANNOT_CREATE_DIRECTORY, "Failed to create external stream temproary directory, error_code={}, error_mesage={}", err.value(), err.message());
 }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

It didn't check the error returned by create_directores properly and caused failure if the temporory directory already exists when it tries to create it.