### PR TITLE
cherry-pick: Do not warn about kvm-clock

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -628,8 +628,10 @@ static void sanityChecks(Server * server)
 #if defined(OS_LINUX)
     try
     {
-        if (readString("/sys/devices/system/clocksource/clocksource0/current_clocksource").find("tsc") == std::string::npos)
-            server->context()->addWarningMessage("Linux is not using fast TSC clock source. Performance can be degraded.");
+        const char * filename = "/sys/devices/system/clocksource/clocksource0/current_clocksource";
+        String clocksource = readString(filename);
+        if (clocksource.find("tsc") == std::string::npos && clocksource.find("kvm-clock") == std::string::npos)
+            server.context()->addWarningMessage("Linux is not using a fast clock source. Performance can be degraded. Check " + String(filename));
     }
     catch (...)
     {


### PR DESCRIPTION
Cherry-picked: https://github.com/ClickHouse/ClickHouse/commit/b57332f9ac3de07dd5fa337ee376cb596c99e57a

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
