### PR TITLE
Fix ASOF LEFT JOIN performance degradation

### DIFF
--- a/src/Interpreters/RowRefs.cpp
+++ b/src/Interpreters/RowRefs.cpp
@@ -74,9 +74,8 @@ class SortedLookupVector : public SortedLookupVectorBase
 
 
 public:
-    using Keys = std::vector<TKey>;
-    using Entries = PaddedPODArray<Entry>;
-    using RowRefs = PaddedPODArray<RowRef>;
+    using Entries = PODArrayWithStackMemory<Entry, sizeof(Entry)>;
+    using RowRefs = PODArrayWithStackMemory<RowRef, sizeof(RowRef)>;
 
     static constexpr bool is_descending = (inequality == ASOFJoinInequality::Greater || inequality == ASOFJoinInequality::GreaterOrEquals);
     static constexpr bool is_strict = (inequality == ASOFJoinInequality::Less) || (inequality == ASOFJoinInequality::Greater);

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-Jinja2==3.1.3
+Jinja2==3.1.4
 termcolor==2.0.1


### PR DESCRIPTION
fix #694 
credit to https://github.com/ClickHouse/ClickHouse/pull/47544
Please write user-readable short description of the changes:
```
SELECT
  COUNT(*) AS count
FROM
  (
    SELECT
      number % 1000 AS visitor_id, number AS id
    FROM
      system.numbers
    LIMIT 1000000
  ) AS sessions
ASOF LEFT JOIN (
    SELECT
      number % 1000000 AS visitor_id, number AS starting_session_id
    FROM
      system.numbers
    LIMIT 1000000
  ) AS visitors ON (visitors.visitor_id = sessions.visitor_id) AND (visitors.starting_session_id <= sessions.id)
```

before pr:
```
1 row in set. Elapsed: 3.134 sec. Processed 2.09 million rows, 16.74 MB (667.77 thousand rows/s., 5.34 MB/s.)
```
after this pr:
```
1 row in set. Elapsed: 0.258 sec. Processed 2.09 million rows, 16.74 MB (8.10 million rows/s., 64.78 MB/s.)
```

