### PR TITLE
bugfix: KafkaSource deconstructor should not throw exceptions

### DIFF
--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -77,7 +77,14 @@ KafkaSource::~KafkaSource()
     if (consume_started)
     {
         LOG_INFO(logger, "Stop consuming from topic={} shard={}", topic->name(), shard);
-        consumer->stopConsume(*topic, shard);
+        try
+        {
+            consumer->stopConsume(*topic, shard);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(logger, fmt::format("Failed to stop consuming from topic={} shard={}", topic->name(), shard));
+        }
     }
 }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes: