### PR TITLE
tweak default sharding rule for one shard stream with primary keys

### DIFF
--- a/src/Interpreters/Streaming/DDLHelper.cpp
+++ b/src/Interpreters/Streaming/DDLHelper.cpp
@@ -175,9 +175,9 @@ void prepareEngine(ASTCreateQuery & create, ContextPtr ctx)
     if (expr.empty())
     {
         /// Default sharding expr:
-        /// 1) If has primary keys, default is `weak_hash32(<primary_keys>)`
+        /// 1) If has multiple shards and has primary keys, default is `weak_hash32(<primary_keys>)`
         /// 2) Otherwise, default is `rand()`
-        if (create.storage->primary_key)
+        if (shards > 1 && create.storage->primary_key)
             sharding_expr = makeASTFunction("weak_hash32", create.storage->primary_key->clone());
         else
             sharding_expr = makeASTFunction("rand");


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
This close #708 