### PR TITLE
feat: support Avro format schema

### DIFF
--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -21,6 +21,11 @@ namespace
             return "proto";
         else if (format == "CapnProto")
             return "capnp";
+        else if (format == "Avro")
+            /// Avro schemas are defined in JSON, but using "json" here is not a good idea,
+            /// because there are other schema formats defined in JSON as well, e.g. JSON schema.
+            /// In the Avro official tutorial, it uses "avsc" as its schema file ext, thus we use it here.
+            return "avsc";
         else
             return "";
     }

--- a/tests/stream/test_stream_smoke/0033_format_schema.yaml
+++ b/tests/stream/test_stream_smoke/0033_format_schema.yaml
@@ -178,28 +178,34 @@ tests:
             query_id: fmt-2-1
             wait: 1
             query: |-
-              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS '' TYPE Protobuf;
+              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'anything' TYPE JSON;
           - client: python
             query_type: table
             query_id: fmt-2-2
             wait: 1
             query: |-
-              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'bad' TYPE Protobuf;
+              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS '' TYPE Protobuf;
           - client: python
             query_type: table
             query_id: fmt-2-3
             wait: 1
             query: |-
-              SHOW CREATE FORMAT SCHEMA test_format_schema_error_handling;
+              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'bad' TYPE Protobuf;
           - client: python
             query_type: table
             query_id: fmt-2-4
             wait: 1
             query: |-
-              DROP FORMAT SCHEMA test_format_schema_error_handling;
+              SHOW CREATE FORMAT SCHEMA test_format_schema_error_handling;
           - client: python
             query_type: table
             query_id: fmt-2-5
+            wait: 1
+            query: |-
+              DROP FORMAT SCHEMA test_format_schema_error_handling;
+          - client: python
+            query_type: table
+            query_id: fmt-2-6
             wait: 1
             query: |-
               CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'bad' TYPE Avro;
@@ -207,19 +213,22 @@ tests:
     expected_results:
       - query_id: fmt-2-0
         # unknown format type
-        expected_results: error_code:2613
+        expected_results: error_code:73
       - query_id: fmt-2-1
         # empty body
-        expected_results: error_code:36
+        expected_results: error_code:2613
       - query_id: fmt-2-2
+        # empty body
+        expected_results: error_code:36
+      - query_id: fmt-2-3
         # invalid schema
         expected_results: error_code:434
-      - query_id: fmt-2-3
-        # nonexists
-        expected_results: error_code:2611
       - query_id: fmt-2-4
         # nonexists
         expected_results: error_code:2611
       - query_id: fmt-2-5
+        # nonexists
+        expected_results: error_code:2611
+      - query_id: fmt-2-6
         # incorrect data
         expected_results: error_code:117

--- a/tests/stream/test_stream_smoke/0033_format_schema.yaml
+++ b/tests/stream/test_stream_smoke/0033_format_schema.yaml
@@ -32,6 +32,11 @@ tests:
 
           - client: python
             query_type: table
+            wait: 1
+            query: DROP FORMAT SCHEMA IF EXISTS test_simple_avro_schema;
+
+          - client: python
+            query_type: table
             query_id: fmt-1-0
             wait: 1
             query: |-
@@ -46,41 +51,75 @@ tests:
               ' TYPE Protobuf;
 
           - client: python
+            query_type: table
             query_id: fmt-1-1
+            wait: 1
+            query: |-
+              CREATE OR REPLACE FORMAT SCHEMA test_simple_avro_schema AS '
+              {
+                "namespace": "example.avro",
+                "type": "record",
+                "name": "User",
+                "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "favorite_number",  "type": ["int", "null"]},
+                  {"name": "favorite_color", "type": ["string", "null"]}
+                ]
+              }
+              ' TYPE Avro;
+
+          - client: python
+            query_id: fmt-1-2
             query_end_timer: 7
-            depends_on_done: fmt-1-0
+            depends_on_done: fmt-1-1
             query_type: table
             wait: 5
             query: SHOW FORMAT SCHEMAS;
 
           - client: python
             query_type: table
-            query_id: fmt-1-2
+            query_id: fmt-1-3
             depends_on_done: fmt-1-0
             wait: 1
             query: |
               SHOW CREATE FORMAT SCHEMA test_simple_protobuf_schema;
 
           - client: python
-            query_id: fmt-1-3
+            query_type: table
+            query_id: fmt-1-4
+            depends_on_done: fmt-1-1
+            wait: 1
+            query: |
+              SHOW CREATE FORMAT SCHEMA test_simple_avro_schema;
+
+          - client: python
+            query_id: fmt-1-5
             query_type: table
             depends_on_done: fmt-1-0
             wait: 1
             query: DROP FORMAT SCHEMA test_simple_protobuf_schema;
 
           - client: python
-            query_id: fmt-1-4
+            query_id: fmt-1-6
+            query_type: table
+            depends_on_done: fmt-1-1
+            wait: 1
+            query: DROP FORMAT SCHEMA test_simple_avro_schema;
+
+          - client: python
+            query_id: fmt-1-7
             query_end_timer: 7
-            depends_on_done: fmt-1-3
+            depends_on_done: fmt-1-6
             query_type: table
             wait: 5
             query: SHOW FORMAT SCHEMAS;
 
     expected_results:
-      - query_id: fmt-1-1
+      - query_id: fmt-1-2
         expected_results:
           - [ 'test_simple_protobuf_schema', 'Protobuf' ]
-      - query_id: fmt-1-2
+          - [ 'test_simple_avro_schema', 'Avro' ]
+      - query_id: fmt-1-3
         expected_results:
         -
           - |-
@@ -96,6 +135,24 @@ tests:
             $$
             TYPE Protobuf
       - query_id: fmt-1-4
+        expected_results:
+        -
+          - |-
+            CREATE FORMAT SCHEMA test_simple_avro_schema AS
+            $$
+            {
+              "namespace": "example.avro",
+              "type": "record",
+              "name": "User",
+              "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "favorite_number",  "type": ["int", "null"]},
+                {"name": "favorite_color", "type": ["string", "null"]}
+              ]
+            }
+            $$
+            TYPE Avro
+      - query_id: fmt-1-7
         expected_results: []
 
   - id: 2
@@ -115,7 +172,7 @@ tests:
             query_id: fmt-2-0
             wait: 1
             query: |-
-              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'anything' TYPE Avro;
+              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'anything' TYPE BadType;
           - client: python
             query_type: table
             query_id: fmt-2-1
@@ -140,6 +197,12 @@ tests:
             wait: 1
             query: |-
               DROP FORMAT SCHEMA test_format_schema_error_handling;
+          - client: python
+            query_type: table
+            query_id: fmt-2-5
+            wait: 1
+            query: |-
+              CREATE OR REPLACE FORMAT SCHEMA test_format_schema_error_handling AS 'bad' TYPE Avro;
 
     expected_results:
       - query_id: fmt-2-0
@@ -157,3 +220,6 @@ tests:
       - query_id: fmt-2-4
         # nonexists
         expected_results: error_code:2611
+      - query_id: fmt-2-5
+        # incorrect data
+        expected_results: error_code:117


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Added support for Avro format schema:

### Create Format Schema

```sql
proton :) create format schema user as '
                   {
                     "namespace": "example.avro",
                     "type": "record",
                     "name": "User",
                     "fields": [
                         {"name": "name", "type": "string"},
                         {"name": "favorite_number",  "type": ["int", "null"]},
                         {"name": "favorite_color", "type": ["string", "null"]}
                     ]
                   }
           ' TYPE Avro;

proton :) show format schemas;

SHOW FORMAT SCHEMAS

Query id: 3af17bfe-0996-45ea-be47-f314e04828e8

┌─name──────┬─type─────┐
│ user      │ Avro     │
└───────────┴──────────┘

2 rows in set. Elapsed: 0.006 sec.
```

### Use The Schema

```sql
CREATE EXTERNAL STREAM ex_users
(
  `name` string,
  `favorite_number` nullable(int32),
  `favorite_color` nullable(string)
)
SETTINGS type = 'kafka', brokers = 'localhost:9092', topic = 'my_topic', data_format = 'Avro', format_schema = 'user';
```

### Limitations

For now, only read operation is supported, no write operation.
