### PR TITLE
bugfix: window functions didn't work with Kafka external streams

### DIFF
--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -488,11 +488,6 @@ Pipe Kafka::read(
     pipes.reserve(shards_to_query.size());
 
     {
-        /// Make _tp_time always available, otherwise window functions won't work with Kafka external streams.
-        Names cns = column_names;
-        if (std::ranges::none_of(column_names, [](const auto & name) { return name == ProtonConsts::RESERVED_EVENT_TIME; }))
-            cns.push_back(ProtonConsts::RESERVED_EVENT_TIME);
-
         auto header = storage_snapshot->getSampleBlockForColumns(column_names);
 
         auto seek_to_info = query_info.seek_to_info;

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.cpp
@@ -263,7 +263,7 @@ void KafkaSource::initFormatExecutor()
     auto input_format = FormatFactory::instance().getInputFormat(
         data_format,
         read_buffer,
-        non_virtual_header,
+        physical_header,
         query_context,
         max_block_size,
         kafka.getFormatSettings(query_context));


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

closes #631 
