### PR TITLE
some Kafka external stream small fixes

### DIFF
--- a/src/Storages/ExternalStream/Kafka/Consumer.h
+++ b/src/Storages/ExternalStream/Kafka/Consumer.h
@@ -23,7 +23,7 @@ public:
 
     std::vector<Int64> getOffsetsForTimestamps(const std::string & topic, const std::vector<klog::PartitionTimestamp> & partition_timestamps, int32_t timeout_ms = 5000) const;
 
-    void startConsume(Topic & topic, Int32 parition, Int64 offset = RD_KAFKA_OFFSET_END);
+    void startConsume(Topic & topic, Int32 parition, Int64 offset = RD_KAFKA_OFFSET_END, bool check_offset = false);
     void stopConsume(Topic & topic, Int32 parition);
 
     using Callback = std::function<void(void * rkmessage, size_t total_count, void * data)>;

--- a/src/Storages/ExternalStream/Kafka/KafkaSource.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.h
@@ -40,6 +40,9 @@ public:
 
     Chunk generate() override;
 
+protected:
+    void onCancel() override;
+
 private:
     void calculateColumnPositions();
     void initFormatExecutor();
@@ -89,7 +92,7 @@ private:
 
     /// Indicates that the source has already consumed all messages it is supposed to read [for non-streaming queries].
     bool reached_the_end = false;
-    bool consume_started = false;
+    std::atomic_flag consume_started;
 
     ExternalStreamCounterPtr external_stream_counter;
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

* fixed: if topic gets deleted when a query is running, it could not read new data since offsets are reset.
* fixed: in streaming mode, if offset is out-of-range (i.e. bigger than the high watermark), set it to 'latest'.
* checkpoint related logs refinements.
