### PR TITLE
fix null arena for counted value map

### DIFF
--- a/src/AggregateFunctions/Streaming/CountedValueMap.h
+++ b/src/AggregateFunctions/Streaming/CountedValueMap.h
@@ -59,7 +59,7 @@ public:
     using Map = std::conditional_t<std::is_nothrow_copy_constructible<Compare>::value, BTreeMap, STDMap>;
     using size_type = typename Map::size_type;
 
-    CountedValueMap() = default;
+    CountedValueMap() : CountedValueMap(1000) { }
     explicit CountedValueMap(size_type max_size_, Compare && comp = Compare{})
         : max_size(max_size_), arena(std::make_unique<CountedValueArena<T>>()), m(std::move(comp))
     {


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Fix #749 