### PR TITLE
fix: Kafka external stream parseFormat crash

### DIFF
--- a/src/Storages/ExternalStream/Kafka/KafkaSource.h
+++ b/src/Storages/ExternalStream/Kafka/KafkaSource.h
@@ -66,8 +66,6 @@ private:
     Block physical_header;
     Chunk header_chunk;
 
-    std::shared_ptr<ExpressionActions> convert_non_virtual_to_physical_action = nullptr;
-
     std::unique_ptr<StreamingFormatExecutor> format_executor;
     ReadBufferFromMemory read_buffer;
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

fixes #754
