### PR TITLE
pin the proton image version for those case where init sql script nee…

### DIFF
--- a/examples/awesome-sensor-logger/docker-compose.yml
+++ b/examples/awesome-sensor-logger/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   proton:
-     image: ghcr.io/timeplus-io/proton:latest
+     image: ghcr.io/timeplus-io/proton::1.5.8-rc
      pull_policy: always
      ports:
        - 3218:3218 #http port for JDBC driver, default streaming mode

--- a/examples/coinbase/docker-compose.yml
+++ b/examples/coinbase/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 name: coinbase
 services:
   proton:
-    image: ghcr.io/timeplus-io/proton:latest
+    image: ghcr.io/timeplus-io/proton:1.5.8-rc
     pull_policy: always
     ports:
     - "3218:3218" # HTTP Streaming

--- a/examples/hackernews/compose.yaml
+++ b/examples/hackernews/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   proton:
-    image: ghcr.io/timeplus-io/proton:latest
+    image: ghcr.io/timeplus-io/proton::1.5.8-rc
     pull_policy: always
     ports:
       - 8463:8463


### PR DESCRIPTION
there seems some issue introduced from `1.5.9` that the init sql script will cause proton down.

this PR use `1.5.8` as proton image versions for those examples that need init sql script.

An other fix is required to check why the init script cause proton down