### PR TITLE
bugfix: invalid Protobuf schema could crash proton-client

### DIFF
--- a/src/Formats/ProtobufSerializer.cpp
+++ b/src/Formats/ProtobufSerializer.cpp
@@ -147,31 +147,9 @@ namespace
     // Should we pack repeated values while storing them.
     bool shouldPackRepeated(const FieldDescriptor & field_descriptor)
     {
-        if (!field_descriptor.is_repeated())
-            return false;
-        switch (field_descriptor.type())
-        {
-            case FieldTypeId::TYPE_INT32:
-            case FieldTypeId::TYPE_UINT32:
-            case FieldTypeId::TYPE_SINT32:
-            case FieldTypeId::TYPE_INT64:
-            case FieldTypeId::TYPE_UINT64:
-            case FieldTypeId::TYPE_SINT64:
-            case FieldTypeId::TYPE_FIXED32:
-            case FieldTypeId::TYPE_SFIXED32:
-            case FieldTypeId::TYPE_FIXED64:
-            case FieldTypeId::TYPE_SFIXED64:
-            case FieldTypeId::TYPE_FLOAT:
-            case FieldTypeId::TYPE_DOUBLE:
-            case FieldTypeId::TYPE_BOOL:
-            case FieldTypeId::TYPE_ENUM:
-                break;
-            default:
-                return false;
-        }
-        if (field_descriptor.options().has_packed())
-            return field_descriptor.options().packed();
-        return field_descriptor.file()->syntax() == google::protobuf::FileDescriptor::SYNTAX_PROTO3;
+        /// proton: starts
+        return field_descriptor.is_packed();
+        /// proton: ends
     }
 
     WriteBuffer & writeIndent(WriteBuffer & out, size_t size) { return out << String(size * 4, ' '); }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

We have encountered a case that, when a bad Protobuf format schema is used, it could crash `proton-client` with `Aborted` error.

For example, given the following schema:

```protobuf
syntax = "proto3";
message Bad {
    int32 int8_col = 1;
    int32 int16_col = 2;
    int32 int32_col = 3;
    int64 int64_col = 4;
    uint32 uint8_col = 5;
    uint32 uint16_col = 6;
    uint32 uint32_col = 7;
    uint64 uint64_col = 8;
    float float32_col = 9;
    double float64_col = 10;
    string decimal32_col = 11;  // Store as string due to lack of decimal type
    string decimal64_col = 12;  // Store as string due to lack of decimal type
    string decimal128_col = 13; // Store as string due to lack of decimal type
    string decimal256_col = 14; // Store as string due to lack of decimal type
    string string_col = 15;
    string fixed_string_col = 16; // No fixed string, use string with length validation if needed
    string date_col = 17; // Use string, assuming format like 'YYYY-MM-DD'
    int32 date32_col = 18; // Unix epoch days
    string datetime_col = 19; // Use string, assuming format like 'YYYY-MM-DDTHH:MM:SS'
    int64 datetime64_col = 20; // Unix epoch milliseconds
    string datetime_tz_col = 21; // Use string, including timezone information
    string uuid_col = 22; // UUIDs are strings in Protobuf
    uint32 ipv4_col = 23; // Store as uint32
    bytes ipv6_col = 24; // Store as bytes
    bool bool_col = 25;
    repeated int32 array_col = 26;
    repeated TupleCol tuple_col = 27;
    // Map is not supported in proto3, nested arrays are used
    repeated uint32 nested_col_id = 28;
    repeated string nested_col_value = 29;
    int32 nullable_col = 30; // Nullable types are handled by presence of the field
    // Enums are supported in Protobuf
    string enum8_col = 31;
    string  enum16_col = 32;
    string random_string_col = 33;
    int32 random_int_col = 34;
    int64 tp_time = 35; // Unix epoch milliseconds for datetime64
}
```

Notice that, the field `tuple_col` has a type of `TupleCol` which is not defined in the schema. Assume there is a stream maps to that schema call `my_stream`. If someone run this query with `proton-client`:

```sql
select * from my_stream format Protobuf settings format_schema='bad_schema:Bad';
```

(assume the schema is saved as `bad_schema.proto`)

`proto-client` will be aborted.
