### PR TITLE
disabled custom serialization

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -589,6 +589,8 @@ void Connection::sendData(const Block & block, const String & name, bool scalar)
             maybe_compressed_out = out;
 
         block_out = std::make_unique<NativeWriter>(*maybe_compressed_out, block.cloneEmpty(), server_revision);
+        if (compatible_with_clickhouse)
+            block_out->setCompatibleWithClickHouse();
     }
 
     if (scalar)
@@ -1107,6 +1109,8 @@ void Connection::setCompatibleWithClickHouse()
         block_logs_in->setCompatibleWithClickHouse();
     if (block_profile_events_in)
         block_profile_events_in->setCompatibleWithClickHouse();
+    if (block_out)
+        block_out->setCompatibleWithClickHouse();
 }
 /// proton: ends
 

--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -145,18 +145,20 @@ Block NativeReader::read()
         setVersionToAggregateFunctions(column.type, true, server_revision);
 
         SerializationPtr serialization;
-        if (server_revision >= DBMS_MIN_REVISION_WITH_CUSTOM_SERIALIZATION)
-        {
-            auto info = column.type->createSerializationInfo({});
-
-            UInt8 has_custom;
-            readBinary(has_custom, istr);
-            if (has_custom)
-                info->deserializeFromKindsBinary(istr);
-
-            serialization = column.type->getSerialization(*info);
-        }
-        else
+        /// proton: starts
+        /// if (server_revision >= DBMS_MIN_REVISION_WITH_CUSTOM_SERIALIZATION)
+        /// {
+        ///     auto info = column.type->createSerializationInfo({});
+        ///
+        ///     UInt8 has_custom;
+        ///     readBinary(has_custom, istr);
+        ///     if (has_custom)
+        ///         info->deserializeFromKindsBinary(istr);
+        ///
+        ///     serialization = column.type->getSerialization(*info);
+        /// }
+        /// else
+        /// proton: ends
         {
             serialization = column.type->getDefaultSerialization();
         }

--- a/src/Formats/NativeWriter.cpp
+++ b/src/Formats/NativeWriter.cpp
@@ -116,17 +116,19 @@ void NativeWriter::write(const Block & block)
 
         /// Serialization. Dynamic, if client supports it.
         SerializationPtr serialization;
-        if (client_revision >= DBMS_MIN_REVISION_WITH_CUSTOM_SERIALIZATION)
-        {
-            auto info = column.type->getSerializationInfo(*column.column);
-            serialization = column.type->getSerialization(*info);
-
-            bool has_custom = info->hasCustomSerialization();
-            writeBinary(static_cast<UInt8>(has_custom), ostr);
-            if (has_custom)
-                info->serialializeKindBinary(ostr);
-        }
-        else
+        /// proton: starts
+        /// if (client_revision >= DBMS_MIN_REVISION_WITH_CUSTOM_SERIALIZATION)
+        /// {
+        ///     auto info = column.type->getSerializationInfo(*column.column);
+        ///     serialization = column.type->getSerialization(*info);
+        ///
+        ///     bool has_custom = info->hasCustomSerialization();
+        ///     writeBinary(static_cast<UInt8>(has_custom), ostr);
+        ///     if (has_custom)
+        ///         info->serialializeKindBinary(ostr);
+        /// }
+        /// else
+        /// proton: ends
         {
             serialization = column.type->getDefaultSerialization();
             column.column = recursiveRemoveSparse(column.column);

--- a/src/Formats/NativeWriter.h
+++ b/src/Formats/NativeWriter.h
@@ -32,6 +32,10 @@ public:
 
     static String getContentType() { return "application/octet-stream"; }
 
+    /// proton: starts
+    void setCompatibleWithClickHouse() { compatible_with_clickhouse = true; }
+    /// proton: ends
+
 private:
     WriteBuffer & ostr;
     Block header;
@@ -40,6 +44,10 @@ private:
     size_t initial_size_of_file;    /// The initial size of the data file, if `append` done. Used for the index.
     /// If you need to write index, then `ostr` must be a CompressedWriteBuffer.
     CompressedWriteBuffer * ostr_concrete = nullptr;
+
+    /// proton: starts
+    bool compatible_with_clickhouse{false};
+    /// proton: ends
 };
 
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Custom serialization does not work well now, disable it for now.