### PR TITLE
listen for 0.0.0.0 instead 127.1 by default

### DIFF
--- a/docker/test/proton_unit_test/Dockerfile
+++ b/docker/test/proton_unit_test/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t ghcr.io/timeplus-io/proton-unit-test .
-ARG FROM_TAG=latest
+ARG FROM_TAG=fae41f7606bb
+# https://github.com/timeplus-io/proton-enterprise/issues/5737
 FROM clickhouse/unit-test:$FROM_TAG
 
 COPY unit_tests_dbms /

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -415,8 +415,9 @@ std::vector<std::string> getListenHosts(const Poco::Util::AbstractConfiguration 
     auto listen_hosts = DB::getMultipleValuesFromConfig(config, "", "listen_host");
     if (listen_hosts.empty())
     {
-        listen_hosts.emplace_back("::1");
-        listen_hosts.emplace_back("127.0.0.1");
+        if (Poco::Net::SecureServerSocket::supportsIPv6())
+            listen_hosts.emplace_back("::1");
+        listen_hosts.emplace_back("0.0.0.0");
     }
     return listen_hosts;
 }

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -97,6 +97,8 @@
 #include <Server/RestRouterHandlers/RestRouterFactory.h>
 #include <Common/Config/ExternalGrokPatterns.h>
 
+#include <Poco/Net/NetworkInterface.h>
+
 #include <v8.h>
 
 namespace DB
@@ -104,6 +106,25 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int UNSUPPORTED;
+}
+
+
+bool networkInterfaceSupportsIPv6()
+{
+    try
+    {
+        for (const auto & ni : Poco::Net::NetworkInterface::list())
+        {
+            if (ni.supportsIPv6())
+                return true;
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+
+    return false;
 }
 }
 /// proton: ends
@@ -415,7 +436,8 @@ std::vector<std::string> getListenHosts(const Poco::Util::AbstractConfiguration 
     auto listen_hosts = DB::getMultipleValuesFromConfig(config, "", "listen_host");
     if (listen_hosts.empty())
     {
-        if (Poco::Net::SecureServerSocket::supportsIPv6())
+        /// check system level support ipv6 and network interface level support ipv6
+        if (Poco::Net::Socket::supportsIPv6() && networkInterfaceSupportsIPv6())
             listen_hosts.emplace_back("::1");
         listen_hosts.emplace_back("0.0.0.0");
     }

--- a/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
+++ b/tests/stream/test_stream_smoke/0030_two_level_global_aggr.yaml
@@ -143,7 +143,7 @@ tests:
         - client: python
           query_type: table
           depends_on_stream: test_31_multishards_stream
-          wait: 1
+          wait: 2
           query: |
             insert into test_31_multishards_stream(i, v) values(101, 'test');
 
@@ -151,7 +151,7 @@ tests:
           query_type: stream
           query_id: 3100-1
           depends_on_stream: test_31_multishards_stream
-          wait: 1
+          wait: 2
           query: |
             recover from '3100';
 


### PR DESCRIPTION
Please write user-readable short description of the changes:
fix #813 

below is my mac device output for this pr `./proton-server` start log:  we can connect with `./proton-client`
, keep the ipv6 still
```
2024.08.07 21:55:45.869556 [ 297974 ] {} <Information> Application: Available RAM: 16.00 GiB; physical cores: 8; logical cores: 8.
2024.08.07 21:55:45.869596 [ 297974 ] {} <Information> Application: Listening for http://[::1]:3218
2024.08.07 21:55:45.869607 [ 297974 ] {} <Information> Application: Listening for http://[::1]:8123
2024.08.07 21:55:45.869616 [ 297974 ] {} <Information> Application: Listening for native protocol (tcp): [::1]:8463
2024.08.07 21:55:45.869624 [ 297974 ] {} <Information> Application: Listening for snapshot server (tcp): [::1]:7587
2024.08.07 21:55:45.869635 [ 297974 ] {} <Information> Application: Listening for PostgreSQL compatibility protocol: [::1]:5432
2024.08.07 21:55:45.869643 [ 297974 ] {} <Information> Application: Listening for Prometheus: http://[::1]:9363
2024.08.07 21:55:45.869652 [ 297974 ] {} <Information> Application: Listening for http://0.0.0.0:3218
2024.08.07 21:55:45.869660 [ 297974 ] {} <Information> Application: Listening for http://0.0.0.0:8123
2024.08.07 21:55:45.869670 [ 297974 ] {} <Information> Application: Listening for native protocol (tcp): 0.0.0.0:8463
2024.08.07 21:55:45.869678 [ 297974 ] {} <Information> Application: Listening for snapshot server (tcp): 0.0.0.0:7587
2024.08.07 21:55:45.869687 [ 297974 ] {} <Information> Application: Listening for PostgreSQL compatibility protocol: 0.0.0.0:5432
2024.08.07 21:55:45.869697 [ 297974 ] {} <Information> Application: Listening for Prometheus: http://0.0.0.0:9363
2024.08.07 21:55:45.869699 [ 297974 ] {} <Information> Application: Ready for connections.

```

what is the impact?
for example I am using python driver to connect to another server proton-server(binary start with ./proton-server), 
for now, this can be directly connected, previous I need edit conf and restart. (same sub-network)

but the docker side already supported/work, this pr only make the binary default listen host changed a bit.