### PR TITLE
Fix multiIf in information_schema.tables

### DIFF
--- a/src/Storages/System/InformationSchema/tables.sql
+++ b/src/Storages/System/InformationSchema/tables.sql
@@ -13,5 +13,5 @@ SELECT
     database AS table_catalog,
     database AS table_schema,
     name AS table_name,
-    multiIf(is_temporary, 4, engine like '%View', 2, engine LIKE 'System%', 5, has_own_data = 0, 3, 1) AS table_type
+    multi_if(is_temporary, 4, engine like '%View', 2, engine LIKE 'System%', 5, has_own_data = 0, 3, 1) AS table_type
 FROM system.tables


### PR DESCRIPTION
I am working a seatunnel sink and it will check information_schema.tables
```sql
SELECT TABLE_NAME FROM information_schema.tables 
WHERE TABLE_CATALOG = 'internal' AND TABLE_SCHEMA = ? AND TABLE_NAME = ? 
ORDER BY TABLE_NAME
```

I hit error "Caused by: java.sql.BatchUpdateException: Code: 46. DB::Exception: Unknown function multiIf. Maybe you meant: ['multi_if','multiply']. (UNKNOWN_FUNCTION) (version 1.5.15)"

I guess there is an issue for the view definition.
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/42b9379f-80f8-4c37-88b6-aa18960c8135">


PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
