### PR TITLE
Bugfix/issue 820 fix incorrect code name

### DIFF
--- a/src/Interpreters/Streaming/PartitionByVisitor.cpp
+++ b/src/Interpreters/Streaming/PartitionByVisitor.cpp
@@ -55,7 +55,7 @@ void PartitionByMatcher::visit(ASTPtr & ast, Data & data)
 
             /// Convert function to window function.
             /// Always show original function
-            node_func->code_name = DB::serializeAST(*node_func);
+            node_func->makeCurrentCodeName();
             node_func->window_definition = data.win_define->clone();
             node_func->is_window_function = true;
         }

--- a/src/Interpreters/Streaming/SubstituteStreamingFunction.cpp
+++ b/src/Interpreters/Streaming/SubstituteStreamingFunction.cpp
@@ -146,8 +146,7 @@ void StreamingFunctionData::visit(DB::ASTFunction & func, DB::ASTPtr)
                 if (!func_alias_name->empty())
                 {
                     /// Always show original function
-                    if (func.code_name.empty())
-                        func.code_name = DB::serializeAST(func);
+                    func.makeCurrentCodeName();
 
                     func.name = *func_alias_name;
                     if (!func.arguments)

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -641,6 +641,20 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
     }
 }
 
+/// proton: starts.
+void ASTFunction::makeCurrentCodeName()
+{
+    if (!code_name.empty())
+        return;
+
+    WriteBufferFromOwnString buf;
+    IAST::FormatSettings settings(buf, /*one_line=*/true);
+    FormatState state;
+    formatImplWithoutAlias(settings, state, FormatStateStacked());
+    code_name = buf.str();
+}
+/// proton: ends.
+
 String getFunctionName(const IAST * ast)
 {
     String res;

--- a/src/Parsers/ASTFunction.h
+++ b/src/Parsers/ASTFunction.h
@@ -59,6 +59,10 @@ public:
 
     std::string getWindowDescription() const;
 
+    /// proton: starts. Generates the one-line formatting string (without aliases) for the current function and assigns it to code_name.
+    void makeCurrentCodeName();
+    /// proton: ends.
+
 protected:
     void formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void appendColumnNameImpl(WriteBuffer & ostr) const override;

--- a/tests/queries_ported/0_stateless/99005_explain_syntax_bug.reference
+++ b/tests/queries_ported/0_stateless/99005_explain_syntax_bug.reference
@@ -1,0 +1,6 @@
+SELECT
+  count() OVER (PARTITION BY i) AS x, lag(x)
+FROM
+  changelog(`99005_stream`, i)
+GROUP BY
+  i

--- a/tests/queries_ported/0_stateless/99005_explain_syntax_bug.sql
+++ b/tests/queries_ported/0_stateless/99005_explain_syntax_bug.sql
@@ -1,0 +1,6 @@
+DROP STREAM IF EXISTS 99005_stream;
+CREATE STREAM 99005_stream(i int, v int);
+
+EXPLAIN SYNTAX select count() over (partition by i) as x, lag(x) from changelog(99005_stream, i);
+
+DROP STREAM 99005_stream;


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
This fix #820 