### PR TITLE
support force drop big stream

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -828,6 +828,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(String, replay_time_column, "_tp_append_time", "user specified replay time column, default column is _tp_append_time", 0) \
     M(UInt64, max_events, 0, "Total events to generate for random stream", 0) \
     M(Float, eps, -1., "control the random stream eps in query time, defalut value is -1, if it is 0 means no limit.", 0) \
+    M(Bool, force_drop_big_stream, false, "When enabled, the query can directly force drop big stream greater than configured `max_[stream/partition]_size_to_drop`", 0)   \
 // End of GLOBAL_SETTINGS
 
 #define CONFIGURABLE_GLOBAL_SETTINGS(M) \

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -317,10 +317,10 @@ StorageMergeTree::write(const ASTPtr & /*query*/, const StorageMetadataPtr & met
 void StorageMergeTree::checkTableCanBeDropped(ContextPtr context_) const
 {
     IStorage::checkTableCanBeDropped(context_);
-/// proton: ends.
 
     auto table_id = getStorageID();
-    getContext()->checkTableCanBeDropped(table_id.database_name, table_id.table_name, getTotalActiveSizeInBytes());
+    context_->checkTableCanBeDropped(table_id.database_name, table_id.table_name, getTotalActiveSizeInBytes());
+/// proton: ends.
 }
 
 void StorageMergeTree::drop()

--- a/tests/queries_ported/0_stateless/99006_force_drop.sql
+++ b/tests/queries_ported/0_stateless/99006_force_drop.sql
@@ -1,0 +1,5 @@
+CREATE STREAM 99006_v(id int);
+
+INSERT INTO 99006_v(id) values(3);
+
+DROP STREAM 99006_v settings force_drop_big_stream = true;


### PR DESCRIPTION
Please write user-readable short description of the changes:
add a new settings to force drop a big stream. `settings force_drop_big_stream=true`
fix #822