### PR TITLE
Feature/issue 849 enable compile with clang-18

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -164,7 +164,7 @@
 	url = https://github.com/ClickHouse-Extras/NuRaft.git
 [submodule "contrib/datasketches-cpp"]
 	path = contrib/datasketches-cpp
-	url = https://github.com/ClickHouse-Extras/datasketches-cpp.git
+	url = https://github.com/apache/datasketches-cpp.git
 [submodule "contrib/yaml-cpp"]
 	path = contrib/yaml-cpp
 	url = https://github.com/ClickHouse-Extras/yaml-cpp.git

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -47,5 +47,9 @@ if (COMPILER_CLANG)
     no_warning(thread-safety-negative) # experimental flag, too many false positives
     no_warning(enum-constexpr-conversion) # breaks magic-enum library in clang-16
     no_warning(unsafe-buffer-usage) # too aggressive
+    no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values" in clang-18
+    no_warning(deprecated-declarations) # conflicts with "type is deprecated" in clang-18
+    no_warning(missing-field-initializers) # conflicts with "missing field initializer" in clang-18
+    no_warning(thread-safety-reference-return) # conflicts with "returning variable by reference requires holding mutex exclusively" in clang-18
     # TODO Enable conversion, sign-conversion, double-promotion warnings.
 endif ()


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:

Enable proton to be compiled with clang-18

https://github.com/timeplus-io/proton/issues/849