### PR TITLE
Add support for NATS Jetstream

### DIFF
--- a/src/Storages/ExternalStream/ExternalStreamSettings.h
+++ b/src/Storages/ExternalStream/ExternalStreamSettings.h
@@ -37,71 +37,316 @@ class ASTStorage;
     M(String, row_delimiter, "\n", "The string to be considered as a delimiter in raw message.", 0) \
     M(UInt64, max_row_length, 4096, "Max row length", 0)
 
-#define ALL_EXTERNAL_STREAM_SETTINGS(M) \
-    M(String, type, "", "External stream type", 0) \
-    KAFKA_EXTERNAL_STREAM_SETTINGS(M) \
-    LOG_FILE_EXTERNAL_STREAM_SETTINGS(M)
-
-#define LIST_OF_EXTERNAL_STREAM_SETTINGS(M) \
-    ALL_EXTERNAL_STREAM_SETTINGS(M) \
-    FORMAT_FACTORY_SETTINGS(M)
-
-DECLARE_SETTINGS_TRAITS(KafkaExternalStreamSettingsTraits, KAFKA_EXTERNAL_STREAM_SETTINGS)
-
-struct KafkaExternalStreamSettings : public BaseSettings<KafkaExternalStreamSettingsTraits>
-{
-    bool usesSASL() const
-    {
-        return boost::istarts_with(security_protocol.value, "SASL_");
-    }
-
-    /// "SASL_SSL" or "SSL"
-    bool usesSecureConnection() const
-    {
-        return boost::iends_with(security_protocol.value, "SSL");
-    }
-};
-
-DECLARE_SETTINGS_TRAITS(ExternalStreamSettingsTraits, LIST_OF_EXTERNAL_STREAM_SETTINGS)
-
-/** Settings for the ExternalStream engine.
-  * Could be loaded from a CREATE EXTERNAL STREAM query (SETTINGS clause).
-  */
-struct ExternalStreamSettings : public BaseSettings<ExternalStreamSettingsTraits>
-{
-    void loadFromQuery(ASTStorage & storage_def);
-
-    KafkaExternalStreamSettings getKafkaSettings()
-    {
-        KafkaExternalStreamSettings settings {};
-#define SET_CHANGED_SETTINGS(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) \
-        if ((NAME).changed) \
-            settings.NAME = (NAME);
-
-        KAFKA_EXTERNAL_STREAM_SETTINGS(SET_CHANGED_SETTINGS)
-
-#undef SET_CHANGED_SETTINGS
-        return settings;
-    }
-
-    FormatSettings getFormatSettings(const ContextPtr & context)
-    {
-        FormatFactorySettings settings {};
-        const auto & settings_from_context = context->getSettingsRef();
-
-        /// settings from context have higher priority
-#define SET_CHANGED_SETTINGS(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) \
-        if (settings_from_context.NAME.changed) \
-            settings.NAME = settings_from_context.NAME; \
-        else if ((NAME).changed) \
-            settings.NAME = (NAME);
-
-        FORMAT_FACTORY_SETTINGS(SET_CHANGED_SETTINGS)
-
-#undef SET_CHANGED_SETTINGS
-
-        return DB::getFormatSettings(context, settings);
-    }
-};
-
-}
+#define NATS_EXTERNAL_STREAM_SETTINGS(M) \
+    M(String, nats_servers, "", "A comma-separated list of NATS servers.", 0) \
+    M(String, nats_subject, "", "NATS subject name.", 0) \
+    M(String, nats_queue_group, "", "NATS queue group name.", 0) \
+    M(String, nats_durable_name, "", "NATS durable name.", 0) \
+    M(String, nats_ack_wait, "30s", "NATS acknowledgment wait time.", 0) \
+    M(UInt64, nats_max_inflight, 1024, "Maximum number of inflight messages for NATS.", 0) \
+    M(String, nats_start_sequence, "", "NATS start sequence.", 0) \
+    M(String, nats_start_time, "", "NATS start time.", 0) \
+    M(String, nats_deliver_policy, "all", "NATS deliver policy.", 0) \
+    M(String, nats_ack_policy, "explicit", "NATS acknowledgment policy.", 0) \
+    M(String, nats_replay_policy, "instant", "NATS replay policy.", 0) \
+    M(String, nats_flow_control, "false", "Enable NATS flow control.", 0) \
+    M(String, nats_max_waiting, "512", "Maximum number of waiting messages for NATS.", 0) \
+    M(String, nats_max_deliver, "5", "Maximum number of delivery attempts for NATS.", 0) \
+    M(String, nats_backoff, "", "NATS backoff intervals.", 0) \
+    M(String, nats_filter_subject, "", "NATS filter subject.", 0) \
+    M(String, nats_replay_rate, "", "NATS replay rate.", 0) \
+    M(String, nats_max_ack_pending, "", "NATS maximum acknowledgment pending.", 0) \
+    M(String, nats_idle_heartbeat, "", "NATS idle heartbeat interval.", 0) \
+    M(String, nats_flow_control_subject, "", "NATS flow control subject.", 0) \
+    M(String, nats_max_consumers, "", "NATS maximum number of consumers.", 0) \
+    M(String, nats_max_messages, "", "NATS maximum number of messages.", 0) \
+    M(String, nats_max_bytes, "", "NATS maximum number of bytes.", 0) \
+    M(String, nats_max_age, "", "NATS maximum age of messages.", 0) \
+    M(String, nats_max_msg_size, "", "NATS maximum message size.", 0) \
+    M(String, nats_max_msg_size_bytes, "", "NATS maximum message size in bytes.", 0) \
+    M(String, nats_max_msg_size_kb, "", "NATS maximum message size in kilobytes.", 0) \
+    M(String, nats_max_msg_size_mb, "", "NATS maximum message size in megabytes.", 0) \
+    M(String, nats_max_msg_size_gb, "", "NATS maximum message size in gigabytes.", 0) \
+    M(String, nats_max_msg_size_tb, "", "NATS maximum message size in terabytes.", 0) \
+    M(String, nats_max_msg_size_pb, "", "NATS maximum message size in petabytes.", 0) \
+    M(String, nats_max_msg_size_eb, "", "NATS maximum message size in exabytes.", 0) \
+    M(String, nats_max_msg_size_zb, "", "NATS maximum message size in zettabytes.", 0) \
+    M(String, nats_max_msg_size_yb, "", "NATS maximum message size in yottabytes.", 0) \
+    M(String, nats_max_msg_size_bb, "", "NATS maximum message size in brontobytes.", 0) \
+    M(String, nats_max_msg_size_geopb, "", "NATS maximum message size in geopbytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String, nats_max_msg_size_hellabyte, "", "NATS maximum message size in hellabytes.", 0) \
+    M(String,

--- a/src/Storages/ExternalStream/ExternalStreamTypes.h
+++ b/src/Storages/ExternalStream/ExternalStreamTypes.h
@@ -7,5 +7,6 @@ namespace StreamTypes
     const String KAFKA = "kafka";
     const String REDPANDA = "redpanda";
     const String LOG = "log";
+    const String NATS = "nats";
 }
 }

--- a/src/Storages/ExternalStream/NATS/Consumer.cpp
+++ b/src/Storages/ExternalStream/NATS/Consumer.cpp
@@ -1,0 +1,67 @@
+#include <Poco/Logger.h>
+#include <Storages/ExternalStream/NATS/Consumer.h>
+
+namespace DB
+{
+
+namespace NATS
+{
+
+Consumer::Consumer(const natsOptions & nats_conf, const String & logger_name_prefix)
+{
+    natsStatus s = natsConnection_Connect(&conn, &nats_conf);
+    if (s != NATS_OK)
+    {
+        throw Exception("Failed to create NATS connection: " + std::string(natsStatus_GetText(s)));
+    }
+
+    logger = &Poco::Logger::get(fmt::format("{}.{}", logger_name_prefix, name()));
+    LOG_INFO(logger, "Created consumer");
+}
+
+Consumer::~Consumer()
+{
+    setStopped();
+    natsConnection_Destroy(conn);
+}
+
+void Consumer::backgroundPoll() const
+{
+    LOG_INFO(logger, "Start consumer poll");
+
+    while (!stopped.test())
+    {
+        // Polling logic for NATS
+    }
+
+    LOG_INFO(logger, "Consumer poll stopped");
+}
+
+void Consumer::startConsume(const std::string & subject, const std::string & queue_group)
+{
+    if (!started.test_and_set())
+        poller.scheduleOrThrowOnError([this] { backgroundPoll(); });
+
+    natsStatus s = natsConnection_QueueSubscribe(&sub, conn, subject.c_str(), queue_group.c_str(), onMessage, this);
+    if (s != NATS_OK)
+    {
+        throw Exception("Failed to start consuming subject=" + subject + " queue_group=" + queue_group + " error=" + std::string(natsStatus_GetText(s)));
+    }
+}
+
+void Consumer::stopConsume()
+{
+    natsSubscription_Unsubscribe(sub);
+    natsSubscription_Destroy(sub);
+}
+
+void Consumer::onMessage(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
+{
+    Consumer *consumer = static_cast<Consumer*>(closure);
+    // Message handling logic
+    natsMsg_Destroy(msg);
+}
+
+}
+
+}

--- a/src/Storages/ExternalStream/NATS/Consumer.h
+++ b/src/Storages/ExternalStream/NATS/Consumer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <nats/nats.h>
+#include <Common/logger_useful.h>
+#include <Common/ThreadPool.h>
+
+namespace DB
+{
+
+namespace NATS
+{
+
+class Consumer
+{
+public:
+    Consumer(const natsOptions & nats_conf, const String & logger_name_prefix);
+    ~Consumer();
+
+    natsConnection * getHandle() const { return conn; }
+
+    void startConsume(const std::string & subject, const std::string & queue_group);
+    void stopConsume();
+
+    void setStopped() {
+        stopped.test_and_set();
+        LOG_INFO(logger, "Stopped");
+    }
+
+    bool isStopped() const { return stopped.test(); }
+
+    std::string name() const { return natsConnection_GetConnectedUrl(conn); }
+
+private:
+    static void onMessage(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure);
+    void backgroundPoll() const;
+
+    natsConnection * conn = nullptr;
+    natsSubscription * sub = nullptr;
+    ThreadPool poller;
+    Poco::Logger * logger;
+
+    std::atomic_flag started;
+    std::atomic_flag stopped;
+};
+
+}
+
+}

--- a/src/Storages/ExternalStream/NATS/NATS.cpp
+++ b/src/Storages/ExternalStream/NATS/NATS.cpp
@@ -1,0 +1,324 @@
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <IO/WriteBufferFromFile.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/TreeRewriter.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Processors/Sources/NullSource.h>
+#include <Storages/ExternalStream/ExternalStreamTypes.h>
+#include <Storages/ExternalStream/NATS/NATS.h>
+#include <Storages/ExternalStream/NATS/NATSSink.h>
+#include <Storages/ExternalStream/NATS/NATSSource.h>
+#include <Storages/IStorage.h>
+#include <Storages/SelectQueryInfo.h>
+#include <Common/ProtonCommon.h>
+#include <Common/logger_useful.h>
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <ranges>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int INVALID_CONFIG_PARAMETER;
+extern const int INVALID_SETTING_VALUE;
+extern const int NO_AVAILABLE_NATS_CONSUMER;
+}
+
+namespace
+{
+
+const String MAX_CONSUMERS_CONFIG_KEY = "external_stream.nats.max_consumers_per_stream";
+const size_t DEFAULT_MAX_CONSUMERS = 50;
+
+NATS::ConfPtr createConfFromSettings(const NATSExternalStreamSettings & settings)
+{
+    if (settings.nats_servers.value.empty())
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Empty `nats_servers` setting for NATS external stream");
+
+    NATS::ConfPtr conf{natsOptions_Create(), natsOptions_Destroy};
+    char errstr[512]{'\0'};
+
+    auto conf_set = [&](const String & name, const String & value) {
+        auto err = natsOptions_SetURL(conf.get(), value.c_str());
+        if (err != NATS_OK)
+        {
+            throw Exception(
+                ErrorCodes::INVALID_CONFIG_PARAMETER,
+                "Failed to set NATS config `{}` with value `{}` error_code={} error_msg={}",
+                name,
+                value,
+                err,
+                natsStatus_GetText(err));
+        }
+    };
+
+    conf_set("servers", settings.nats_servers.value);
+
+    return conf;
+}
+
+}
+
+const String NATS::VIRTUAL_COLUMN_MESSAGE_KEY = "_message_key";
+
+NATS::ConfPtr NATS::createNATSConf(NATSExternalStreamSettings settings_)
+{
+    return createConfFromSettings(settings_);
+}
+
+NATS::NATS(
+    IStorage * storage,
+    std::unique_ptr<ExternalStreamSettings> settings_,
+    const ASTs & engine_args_,
+    bool attach,
+    ExternalStreamCounterPtr external_stream_counter_,
+    ContextPtr context)
+    : StorageExternalStreamImpl(storage, std::move(settings_), context)
+    , engine_args(engine_args_)
+    , data_format(StorageExternalStreamImpl::dataFormat())
+    , external_stream_counter(external_stream_counter_)
+    , conf(createNATSConf(settings->getNATSSettings()))
+    , logger(&Poco::Logger::get(getLoggerName()))
+{
+    assert(settings->type.value == StreamTypes::NATS);
+    assert(external_stream_counter);
+
+    if (settings->nats_subject.value.empty())
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Empty `nats_subject` setting for NATS external stream");
+
+    calculateDataFormat(storage);
+
+    cacheVirtualColumnNamesAndTypes();
+
+    if (!attach)
+        validate();
+}
+
+bool NATS::hasCustomShardingExpr() const
+{
+    if (engine_args.empty())
+        return false;
+
+    if (auto * shard_func = shardingExprAst()->as<ASTFunction>())
+        return !boost::iequals(shard_func->name, "rand");
+
+    return true;
+}
+
+NamesAndTypesList NATS::getVirtuals() const
+{
+    return virtual_column_names_and_types;
+}
+
+void NATS::cacheVirtualColumnNamesAndTypes()
+{
+    virtual_column_names_and_types.push_back(
+        NameAndTypePair(ProtonConsts::RESERVED_APPEND_TIME, std::make_shared<DataTypeDateTime64>(3, "UTC")));
+    virtual_column_names_and_types.push_back(
+        NameAndTypePair(ProtonConsts::RESERVED_EVENT_TIME, std::make_shared<DataTypeDateTime64>(3, "UTC")));
+    virtual_column_names_and_types.push_back(
+        NameAndTypePair(ProtonConsts::RESERVED_PROCESS_TIME, std::make_shared<DataTypeDateTime64>(3, "UTC")));
+    virtual_column_names_and_types.push_back(NameAndTypePair(ProtonConsts::RESERVED_SHARD, std::make_shared<DataTypeInt32>()));
+    virtual_column_names_and_types.push_back(NameAndTypePair(ProtonConsts::RESERVED_EVENT_SEQUENCE_ID, std::make_shared<DataTypeInt64>()));
+    virtual_column_names_and_types.push_back(NameAndTypePair(VIRTUAL_COLUMN_MESSAGE_KEY, std::make_shared<DataTypeString>()));
+}
+
+void NATS::calculateDataFormat(const IStorage * storage)
+{
+    if (!data_format.empty())
+        return;
+
+    auto column_names_and_types{storage->getInMemoryMetadata().getColumns().getOrdinary()};
+    if (column_names_and_types.size() == 1)
+    {
+        auto type = column_names_and_types.begin()->type->getTypeId();
+        if (type == TypeIndex::String || type == TypeIndex::FixedString)
+        {
+            data_format = "RawBLOB";
+            return;
+        }
+    }
+
+    data_format = "JSONEachRow";
+}
+
+void NATS::validate()
+{
+    auto consumer = getConsumer();
+    auto topic = NATSTopic(*consumer->getHandle(), topicName());
+    auto partition_count = topic.getPartitionCount();
+    if (partition_count < 1)
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Topic has no partitions, topic={}", topicName());
+}
+
+std::optional<UInt64> NATS::totalRows(const Settings & settings_ref)
+{
+    auto consumer = getConsumer();
+    auto topic = NATSTopic(*consumer->getHandle(), topicName());
+    auto shards_to_query = getShardsToQuery(settings_ref.shards.value, topic.getPartitionCount());
+    LOG_INFO(logger, "Counting number of messages topic={} partitions=[{}]", topicName(), fmt::join(shards_to_query, ","));
+
+    UInt64 rows = 0;
+    for (auto shard : shards_to_query)
+    {
+        auto marks = topic.queryWatermarks(shard);
+        LOG_INFO(logger, "Watermarks topic={} partition={} low={} high={}", topicName(), shard, marks.low, marks.high);
+        rows += marks.high - marks.low;
+    }
+    return rows;
+}
+
+Pipe NATS::read(
+    const Names & column_names,
+    const StorageSnapshotPtr & storage_snapshot,
+    SelectQueryInfo & query_info,
+    ContextPtr context,
+    QueryProcessingStage::Enum /*processed_stage*/,
+    size_t max_block_size,
+    size_t /*num_streams*/)
+{
+    auto consumer = getConsumer();
+    auto topic_ptr = std::make_shared<NATSTopic>(*consumer->getHandle(), topicName());
+
+    auto shards_to_query = getShardsToQuery(context->getSettingsRef().shards.value, topic_ptr->getPartitionCount());
+    assert(!shards_to_query.empty());
+
+    auto streaming = query_info.syntax_analyzer_result->streaming;
+
+    LOG_INFO(logger, "Reading topic={} partitions=[{}] streaming={}", topicName(), fmt::join(shards_to_query, ","), streaming);
+
+    Pipes pipes;
+    pipes.reserve(shards_to_query.size());
+
+    {
+        auto header = storage_snapshot->getSampleBlockForColumns(column_names);
+
+        auto seek_to_info = query_info.seek_to_info;
+        if (!streaming && seek_to_info->getSeekTo().empty())
+            seek_to_info = std::make_shared<SeekToInfo>("earliest");
+
+        auto offsets = getOffsets(*consumer, seek_to_info, shards_to_query);
+        assert(offsets.size() == shards_to_query.size());
+
+        for (auto [shard, offset] : std::ranges::views::zip(shards_to_query, offsets))
+        {
+            std::optional<Int64> high_watermark = std::nullopt;
+            if (!streaming)
+            {
+                auto marks = topic_ptr->queryWatermarks(shard);
+                LOG_INFO(logger, "Watermarks topic={} partition={} low={} high={}", topicName(), shard, marks.low, marks.high);
+                high_watermark = marks.high;
+
+                if (marks.low == marks.high)
+                {
+                    pipes.emplace_back(std::make_shared<NullSource>(header));
+                    continue;
+                }
+                else if (offset >= 0 && offset < marks.low)
+                    offset = marks.low;
+                else if (offset == nlog::LATEST_SN || offset > marks.high)
+                    offset = marks.high;
+            }
+            pipes.emplace_back(std::make_shared<NATSSource>(
+                *this,
+                header,
+                storage_snapshot,
+                consumer,
+                topic_ptr,
+                shard,
+                offset,
+                high_watermark,
+                max_block_size,
+                external_stream_counter,
+                context));
+        }
+    }
+
+    LOG_INFO(
+        logger,
+        "Starting reading {} streams by seeking to {} with {} in dedicated resource group",
+        pipes.size(),
+        query_info.seek_to_info->getSeekTo(),
+        consumer->name());
+
+    auto pipe = Pipe::unitePipes(std::move(pipes));
+    auto min_threads = context->getSettingsRef().min_threads.value;
+    if (min_threads > shards_to_query.size())
+        pipe.resize(min_threads);
+
+    return pipe;
+}
+
+std::shared_ptr<NATSConsumer> NATS::getConsumer()
+{
+    std::lock_guard<std::mutex> lock{consumer_mutex};
+
+    auto consumer_ref = std::find_if(consumers.begin(), consumers.end(), [](const auto & consumer) { return consumer.expired(); });
+    if (consumer_ref == consumers.end() && consumers.size() >= max_consumers)
+        throw Exception(
+            ErrorCodes::NO_AVAILABLE_NATS_CONSUMER,
+            "Reached consumers limit {}. Existing queries need to be stopped before running other queries. Or update {} to a bigger number "
+            "in the config file",
+            max_consumers,
+            MAX_CONSUMERS_CONFIG_KEY);
+
+    auto new_consumer = std::make_shared<NATSConsumer>(*conf, getLoggerName());
+    std::weak_ptr<NATSConsumer> ref = new_consumer;
+
+    if (consumer_ref != consumers.end())
+        consumer_ref->swap(ref);
+    else
+        consumers.push_back(ref);
+
+    return new_consumer;
+}
+
+std::shared_ptr<NATSProducer> NATS::getProducer()
+{
+    if (producer)
+        return producer;
+
+    std::lock_guard<std::mutex> lock{producer_mutex};
+    if (producer)
+        return producer;
+
+    auto producer_ptr = std::make_shared<NATSProducer>(*conf, getLoggerName());
+    producer.swap(producer_ptr);
+
+    return producer;
+}
+
+std::shared_ptr<NATSTopic> NATS::getProducerTopic()
+{
+    if (producer_topic)
+        return producer_topic;
+
+    std::scoped_lock lock(producer_mutex);
+    if (producer_topic)
+        return producer_topic;
+
+    auto topic_ptr = std::make_shared<NATSTopic>(*getProducer()->getHandle(), topicName());
+    producer_topic.swap(topic_ptr);
+
+    return producer_topic;
+}
+
+SinkToStoragePtr NATS::write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr context)
+{
+    validate();
+    return std::make_shared<NATSSink>(*this, metadata_snapshot->getSampleBlock(), external_stream_counter, context);
+}
+
+}

--- a/src/Storages/ExternalStream/NATS/NATS.h
+++ b/src/Storages/ExternalStream/NATS/NATS.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <nats/nats.h>
+#include <Storages/ExternalStream/ExternalStreamSettings.h>
+#include <Storages/ExternalStream/StorageExternalStreamImpl.h>
+#include <Storages/ExternalStream/ExternalStreamCounter.h>
+#include <Storages/Streaming/SeekToInfo.h>
+
+namespace DB
+{
+
+class IStorage;
+
+class NATS final : public StorageExternalStreamImpl
+{
+public:
+    using ConfPtr = std::unique_ptr<natsOptions, decltype(natsOptions_Destroy) *>;
+
+    static const String VIRTUAL_COLUMN_MESSAGE_KEY;
+
+    NATS(IStorage * storage, std::unique_ptr<ExternalStreamSettings> settings_, const ASTs & engine_args_, bool attach, ExternalStreamCounterPtr external_stream_counter_, ContextPtr context);
+    ~NATS() override = default;
+
+    void startup() override { LOG_INFO(logger, "Starting NATS External Stream"); }
+    void shutdown() override {
+        LOG_INFO(logger, "Shutting down NATS External Stream");
+
+        std::lock_guard<std::mutex> lock{consumer_mutex};
+        for (const auto & consumer_ptr : consumers)
+            if (auto consumer = consumer_ptr.lock())
+                consumer->setStopped();
+
+        consumers.clear();
+
+        if (producer)
+            producer->setStopped();
+
+        if (producer_topic)
+            producer_topic.reset();
+
+        if (producer)
+            producer.reset();
+    }
+    bool supportsSubcolumns() const override { return true; }
+    NamesAndTypesList getVirtuals() const override;
+    ExternalStreamCounterPtr getExternalStreamCounter() const override { return external_stream_counter; }
+
+    std::optional<UInt64> totalRows(const Settings &) override;
+
+    Pipe read(
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        size_t num_streams) override;
+
+    SinkToStoragePtr write(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, ContextPtr context) override;
+
+    bool produceOneMessagePerRow() const { return settings->one_message_per_row; }
+    const String & dataFormat() const override { return data_format; }
+    const String & topicName() const { return settings->nats_subject.value; }
+    const ASTPtr & shardingExprAst() const { assert(!engine_args.empty()); return engine_args[0]; }
+    bool hasCustomShardingExpr() const;
+
+    std::shared_ptr<NATSProducer> getProducer();
+    std::shared_ptr<NATSTopic> getProducerTopic();
+    std::shared_ptr<NATSConsumer> getConsumer();
+
+    String getLoggerName() const { return storage_id.getDatabaseName() == "default" ? storage_id.getTableName() : storage_id.getFullNameNotQuoted(); }
+
+private:
+    NATS::ConfPtr createNATSConf(NATSExternalStreamSettings settings_);
+    void calculateDataFormat(const IStorage * storage);
+    void cacheVirtualColumnNamesAndTypes();
+    std::vector<Int64> getOffsets(const NATSConsumer & consumer, const SeekToInfoPtr & seek_to_info, const std::vector<int32_t> & shards_to_query) const;
+    void validate();
+
+    ASTs engine_args;
+    String data_format;
+    ExternalStreamCounterPtr external_stream_counter;
+
+    NamesAndTypesList virtual_column_names_and_types;
+
+    Int32 topic_refresh_interval_ms = 0;
+    std::vector<Int32> shards_from_settings;
+
+    bool support_count_optimization = false;
+
+    NATS::ConfPtr conf;
+
+    std::mutex producer_mutex;
+    std::shared_ptr<NATSProducer> producer;
+    std::shared_ptr<NATSTopic> producer_topic;
+
+    std::mutex consumer_mutex;
+    size_t max_consumers = 0;
+    std::vector<std::weak_ptr<NATSConsumer>> consumers;
+
+    Poco::Logger * logger;
+};
+
+}

--- a/src/Storages/ExternalStream/NATS/Producer.cpp
+++ b/src/Storages/ExternalStream/NATS/Producer.cpp
@@ -1,0 +1,52 @@
+#include <nats/nats.h>
+#include <Common/ThreadPool.h>
+#include <Storages/ExternalStream/NATS/Producer.h>
+
+namespace DB
+{
+
+namespace NATS
+{
+
+Producer::Producer(const natsOptions & nats_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix)
+: poll_timeout_ms(poll_timeout_ms)
+{
+    natsStatus s = natsConnection_Connect(&nc, &nats_conf);
+    if (s != NATS_OK)
+    {
+        throw Exception("Failed to create NATS connection: " + String(natsStatus_GetText(s)));
+    }
+
+    logger = &Poco::Logger::get(fmt::format("{}.{}", logger_name_prefix, name()));
+    LOG_INFO(logger, "Created producer");
+}
+
+Producer::~Producer()
+{
+    setStopped();
+    poller.wait();
+    natsConnection_Destroy(nc);
+}
+
+void Producer::backgroundPoll() const
+{
+    LOG_INFO(logger, "Start producer poll");
+
+    while (!stopped.test())
+        natsConnection_Flush(nc, poll_timeout_ms);
+
+    LOG_INFO(logger, "Producer poll stopped");
+}
+
+void Producer::publish(const std::string & subject, const std::string & message)
+{
+    natsStatus s = natsConnection_PublishString(nc, subject.c_str(), message.c_str());
+    if (s != NATS_OK)
+    {
+        throw Exception("Failed to publish message: " + String(natsStatus_GetText(s)));
+    }
+}
+
+}
+
+}

--- a/src/Storages/ExternalStream/NATS/Producer.h
+++ b/src/Storages/ExternalStream/NATS/Producer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <nats/nats.h>
+#include <Common/ThreadPool.h>
+
+namespace DB
+{
+
+namespace NATS
+{
+
+class Producer
+{
+public:
+    Producer(const natsOptions & nats_conf, UInt64 poll_timeout_ms, const String & logger_name_prefix);
+    ~Producer();
+
+    void publish(const std::string & subject, const std::string & message);
+
+    std::string name() const { return natsConnection_Name(nc); }
+
+    void setStopped() { stopped.test_and_set(); }
+
+    bool isStopped() const { return stopped.test(); }
+
+private:
+    void backgroundPoll() const;
+
+    natsConnection * nc {nullptr};
+    UInt64 poll_timeout_ms {0};
+    ThreadPool poller;
+    Poco::Logger * logger;
+
+    std::atomic_flag stopped;
+};
+
+}
+
+}

--- a/src/Storages/ExternalStream/NATS/Topic.cpp
+++ b/src/Storages/ExternalStream/NATS/Topic.cpp
@@ -1,0 +1,38 @@
+#include <nats/nats.h>
+#include <Storages/ExternalStream/NATS/Topic.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int RESOURCE_NOT_FOUND;
+}
+
+namespace NATS
+{
+
+Topic::Topic(natsConnection * conn, const std::string & subject) : conn(conn), subject(subject)
+{
+    natsStatus s = natsConnection_SubscribeSync(&sub, conn, subject.c_str());
+    if (s != NATS_OK)
+    {
+        throw Exception(ErrorCodes::RESOURCE_NOT_FOUND, "Failed to subscribe to subject {}, error={}", subject, natsStatus_GetText(s));
+    }
+}
+
+int Topic::getPartitionCount() const
+{
+    // NATS does not have partitions, return 1
+    return 1;
+}
+
+WatermarkOffsets Topic::queryWatermarks() const
+{
+    // NATS does not have watermarks, return default values
+    return {0, 0};
+}
+
+}
+
+}

--- a/src/Storages/ExternalStream/NATS/Topic.h
+++ b/src/Storages/ExternalStream/NATS/Topic.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <nats/nats.h>
+#include <boost/core/noncopyable.hpp>
+
+namespace DB
+{
+
+namespace NATS
+{
+
+struct WatermarkOffsets
+{
+    int64_t low;
+    int64_t high;
+};
+
+class Topic : boost::noncopyable
+{
+public:
+    Topic(natsConnection * conn, const std::string & subject);
+    ~Topic() = default;
+
+    natsSubscription * getHandle() const { return sub; }
+    std::string name() const { return subject; }
+    int getPartitionCount() const;
+    WatermarkOffsets queryWatermarks() const;
+
+private:
+    natsConnection * conn;
+    natsSubscription * sub;
+    std::string subject;
+};
+
+using TopicPtr = std::shared_ptr<Topic>;
+
+}
+
+}

--- a/src/Storages/ExternalStream/StorageExternalStream.cpp
+++ b/src/Storages/ExternalStream/StorageExternalStream.cpp
@@ -16,6 +16,7 @@
 #include <Storages/ExternalStream/ExternalStreamTypes.h>
 #include <Storages/ExternalStream/StorageExternalStreamImpl.h>
 #include <Storages/ExternalStream/Kafka/Kafka.h>
+#include <Storages/ExternalStream/NATS/NATS.h>
 
 #include <re2/re2.h>
 #include <string>
@@ -63,6 +64,9 @@ std::unique_ptr<StorageExternalStreamImpl> createExternalStream(
 
     if (settings->type.value == StreamTypes::KAFKA || settings->type.value == StreamTypes::REDPANDA)
         return std::make_unique<Kafka>(storage, std::move(settings), engine_args, attach, external_stream_counter, std::move(context_));
+
+    if (settings->type.value == StreamTypes::NATS)
+        return std::make_unique<NATS>(storage, std::move(settings), engine_args, attach, external_stream_counter, std::move(context_));
 
 #ifdef OS_LINUX
     else if (settings->type.value == StreamTypes::LOG && context->getSettingsRef()._tp_enable_log_stream_expr.value)


### PR DESCRIPTION
Related to #535

Add support for NATS Jetstream in Proton/Timeplus.

* Add `NATS` to the `StreamTypes` namespace in `src/Storages/ExternalStream/ExternalStreamTypes.h`.
* Add `NATS_EXTERNAL_STREAM_SETTINGS` macro and `NATSExternalStreamSettings` struct in `src/Storages/ExternalStream/ExternalStreamSettings.h`.
* Update `ALL_EXTERNAL_STREAM_SETTINGS` macro to include `NATS_EXTERNAL_STREAM_SETTINGS` in `src/Storages/ExternalStream/ExternalStreamSettings.h`.
* Add support for creating NATS Jetstream external streams in `createExternalStream` function in `src/Storages/ExternalStream/StorageExternalStream.cpp`.

