### PR TITLE
`cmake ..` will not activate `ENABLE_AWS_S3` by default.

### DIFF
--- a/contrib/aws-cmake/CMakeLists.txt
+++ b/contrib/aws-cmake/CMakeLists.txt
@@ -2,7 +2,7 @@ set(ENABLE_AWS_S3_DEFAULT OFF)
 set(ENABLE_AWS_MSK_IAM_DEFAULT OFF) # proton: added
 
 if(ENABLE_LIBRARIES AND (OS_LINUX OR OS_DARWIN) AND TARGET OpenSSL::Crypto)
-    set(ENABLE_AWS_S3_DEFAULT ON)
+    set(ENABLE_AWS_S3_DEFAULT OFF) # proton: added https://github.com/timeplus-io/proton/issues/918
     set(ENABLE_AWS_MSK_IAM_DEFAULT ON) # proton: added
 endif()
 
@@ -15,6 +15,11 @@ if(ENABLE_AWS_S3 OR ENABLE_AWS_MSK_IAM) # proton: updated
     elseif(NOT (OS_LINUX OR OS_DARWIN))
         message (${RECONFIGURE_MESSAGE_LEVEL} "Can't use AWS SDK with platform ${CMAKE_SYSTEM_NAME}")
     endif()
+endif()
+
+if(NOT ENABLE_AWS_S3)
+    message(STATUS "Not using AWS S3")
+    return()
 endif()
 
 if(NOT (ENABLE_AWS_S3 OR ENABLE_AWS_MSK_IAM)) # proton: updated

--- a/src/configure_config.cmake
+++ b/src/configure_config.cmake
@@ -62,7 +62,7 @@ if (TARGET ch_contrib::datasketches)
     set(USE_DATASKETCHES 1)
 endif()
 if (TARGET ch_contrib::aws_s3)
-    set(USE_AWS_S3 0)
+    set(USE_AWS_S3 1)
 endif()
 # proton: starts
 if (TARGET ch_contrib::aws_msk_iam)


### PR DESCRIPTION

Please write user-readable short description of the changes:
we still have some work to find missing code about aws_s3.
the aws_msk is good for now.
by default: `cmake ..` now will not try build aws_s3.  but -DENABLE_AWS_S3=ON still valid


follow up #921 