### PR TITLE
fix empty parameters check for map_cast

### DIFF
--- a/src/Functions/map.cpp
+++ b/src/Functions/map.cpp
@@ -135,7 +135,7 @@ public:
                 "Function {} requires even number of arguments, but {} given", getName(), arguments.size());
 
         /// proton : starts
-        if (checkAndGetDataType<DataTypeArray>(arguments[0].get()) || checkAndGetDataType<DataTypeMap>(arguments[0].get()))
+        if (!arguments.empty() && (checkAndGetDataType<DataTypeArray>(arguments[0].get()) || checkAndGetDataType<DataTypeMap>(arguments[0].get())))
             /// Proxy to map_from_arrays
             return getReturnTypeImplForArrays(arguments, getName());
         /// proton : ends
@@ -157,7 +157,7 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         /// proton : starts
-        if (checkAndGetDataType<DataTypeArray>(arguments[0].type.get()) || checkAndGetDataType<DataTypeMap>(arguments[0].type.get()))
+        if (!arguments.empty() && (checkAndGetDataType<DataTypeArray>(arguments[0].type.get()) || checkAndGetDataType<DataTypeMap>(arguments[0].type.get())))
             /// Proxy to map_from_arrays
             return function_map_from_arrays->build(arguments)->execute(arguments, result_type, input_rows_count, /*dry_run=*/false);
         /// proton : ends


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
Fixed #947 