### PR TITLE
CI: release build: Skips Python package installation due to uname -m …

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -222,8 +222,10 @@ jobs:
         cp -r $GITHUB_WORKSPACE/contrib/google-protobuf/src/google/protobuf/*.proto ./resources/protos/google/protobuf/
         rm -rf resources/protos/google/protobuf/unittest_*
 
-        # build docker image for both Docker Hub and GHCR
-        docker build . --network host --build-arg single_binary_location_url=http://localhost:8080/proton \
+        # build docker image (skip Python UDF pieces on ARM64)
+        docker build . --network host \
+          --build-arg ENABLE_PYTHON_UDF=0 \
+          --build-arg single_binary_location_url=http://localhost:8080/proton \
           -t timeplus/proton:${GITHUB_SHA}_arm64v8 \
           -t ghcr.io/timeplus-io/proton:${GITHUB_SHA}_arm64v8
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -19,6 +19,7 @@ ARG deb_location_url=""
 # docker build . --network host --build-arg single_binary_location_url=http://192.168.0.16:8000/build_docker/programs/proton -t timeplus/proton
 # note: proton-odbc-bridge is not supported there.
 ARG single_binary_location_url=""
+ARG ENABLE_PYTHON_UDF=1
 
 # see https://github.com/moby/moby/issues/4032#issuecomment-192327844
 ARG DEBIAN_FRONTEND=noninteractive
@@ -129,8 +130,15 @@ RUN chown -R timeplus:timeplus /var/lib/proton /var/log/proton-server /etc/proto
 # Run pip as timeplus so installed files are not root-owned
 USER 101:101
 
-RUN /usr/share/proton/bin/python3.10 -m pip install --upgrade truststore \
- && /usr/share/proton/bin/python3.10 -m pip install --force-reinstall --no-cache-dir -t /usr/share/proton/lib/python3.10/site-packages timeplus-neutrino==0.1.12
+# Skip Python package installation on ARM64 since Python UDF is unsupported.
+# Also allow opting out via build-arg ENABLE_PYTHON_UDF=0.
+RUN arch="$(uname -m)" \
+ && if [ "${ENABLE_PYTHON_UDF}" = "1" ] && ! echo "${arch}" | grep -qiE '^(aarch64|arm64)$'; then \
+      /usr/share/proton/bin/python3.10 -m pip install --upgrade pip truststore \
+      && /usr/share/proton/bin/python3.10 -m pip install --no-cache-dir --timeout 180 --retries 8 -t /usr/share/proton/lib/python3.10/site-packages timeplus-neutrino==0.1.12 ; \
+    else \
+      echo "Skipping Python package install (ENABLE_PYTHON_UDF=${ENABLE_PYTHON_UDF}, arch=${arch})" ; \
+    fi
 VOLUME /var/lib/proton
 
 ENV PROTON_CONFIG /etc/proton-server/config.yaml


### PR DESCRIPTION
…→ aarch64 (#10810)

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix #986