### PR TITLE
CI: docker-compose override for hybrid configuration and update conta…

### DIFF
--- a/tests/cluster/deployment/docker-compose-p1k1.override.yaml
+++ b/tests/cluster/deployment/docker-compose-p1k1.override.yaml
@@ -1,0 +1,6 @@
+version: "3.7"
+services:
+  p1:
+    entrypoint: >
+      /bin/bash -c "sed -i'' 's/preallocate: true/preallocate: false/g' /etc/proton-server/config.yaml && sed -i'' 's/default_hash_table: memory/default_hash_table: hybrid/g' /etc/proton-server/config.yaml && sed -i'' 's/default_hash_join: memory/default_hash_join: hybrid/g' /etc/proton-server/config.yaml && sed -i'' 's/max_hot_keys: 100000/max_hot_keys: 2/g' /etc/proton-server/config.yaml && sed -i'' 's/ level: information/ level: debug/g' /etc/proton-server/config.yaml && /entrypoint.sh"
+

--- a/tests/cluster/run.sh
+++ b/tests/cluster/run.sh
@@ -71,19 +71,25 @@ function test_hybrid_config() {
         echo "FULL_LOG_DIR set to $FULL_LOG_DIR"
         bash log.sh --init
 
-        run_and_echo docker-compose -f ./deployment/docker-compose-p${NODES}k1.yaml -f ./deployment/docker-compose-p${NODES}k1.override.yaml -p "smoke_1" up -d
+        run_and_echo docker-compose -f ./deployment/docker-compose-p${NODES}k1.yaml -f ./deployment/docker-compose-p${NODES}k1.override.yaml -p "${DOCKER_PROJECT}" up -d
         run_and_echo sleep 5
         run_and_echo docker ps -a
 
+        # Determine container name for hybrid config verification
+        container_name="${CONTAINER_NAME_PREFIX}_proton-server"
+        if [ "${NODES}" != "1" ]; then
+            container_name="${CONTAINER_NAME_PREFIX}_proton-server1"
+        fi
+
         for field in "${HYBRID_FIELDS[@]}"; do
-            if ! run_and_echo docker exec 0_proton-server1 grep -q "$field" "/etc/proton-server/config.yaml"; then
+            if ! run_and_echo docker exec "${container_name}" grep -q "$field" "/etc/proton-server/config.yaml"; then
                 MISSING_FIELD=$field
-                run_and_echo docker exec 0_proton-server1 grep hybrid "/etc/proton-server/config.yaml"
+                run_and_echo docker exec "${container_name}" grep hybrid "/etc/proton-server/config.yaml"
                 break
             fi
         done
 
-        run_and_echo docker-compose -f ./deployment/docker-compose-p${NODES}k1.yaml -f ./deployment/docker-compose-p${NODES}k1.override.yaml -p "smoke_1" down -v
+        run_and_echo docker-compose -f ./deployment/docker-compose-p${NODES}k1.yaml -f ./deployment/docker-compose-p${NODES}k1.override.yaml -p "${DOCKER_PROJECT}" down -v
         run_and_echo sleep 10
         run_and_echo docker ps -a
 


### PR DESCRIPTION
…iner name handling in run script

fix #991
Please write user-readable short description of the changes:
after release build. we will trigger hybrid and non-hybrid smoke test suites.
original failure was missing tests/cluster/deployment/docker-compose-p1k1.override.yaml in [hybrid] mode.

now we added.

