### PR TITLE
add on_conflict in PostgreSQL external table

### DIFF
--- a/src/Storages/ExternalTable/ExternalTableSettings.h
+++ b/src/Storages/ExternalTable/ExternalTableSettings.h
@@ -35,19 +35,21 @@ class ASTStorage;
     M(String, ssl_cert_file, "", "Path to SSL certificate file", 0) \
     M(String, ssl_key_file, "", "Path to SSL private key file", 0) \
     M(String, database, "default", "The datababse to connect to", 0) \
-    M(String, schema, "", "PostgreSQL schema", 0) \
     M(String, table, "", "The remote database table to which the external table is mapped", 0) \
     M(UInt64, \
       pooled_connections, \
       std::numeric_limits<UInt64>::max(), \
       "Max pooled TCP connections to the database server. If not set, each external table type will pick its default value", \
       0) \
-    /** MongoDB */                       \
+    /** PostgreSQL */ \
+    M(String, schema, "", "PostgreSQL non-default schema", 0) \
+    M(String, on_conflict, "", "PostgreSQL conflict resolution strategy", 0) \
+    /** MongoDB */ \
     M(String, uri, "", "MongoDB server's connection URI", 0) \
     M(String, collection, "", "Remote collection name", 0) \
     M(String, connection_options, "", "MongoDB connection string options as a URL formatted string. e.g. 'authSource=admin&ssl=true'", 0) \
     M(String, oid_columns, "_id", "Comma-separated list of columns that should be treated as oid in the WHERE clause. _id by default", 0) \
-    /** MySQL */  \
+    /** MySQL */ \
     M(Bool, replace_query, false, "Flag that converts 'INSERT INTO' queries to 'REPLACE INTO'", 0) \
     M(String, on_duplicate_clause, "", "The 'ON DUPLICATE KEY on_duplicate_clause' expression that is added to the 'INSERT' query.", 0)
 

--- a/src/Storages/ExternalTable/PostgreSQL.cpp
+++ b/src/Storages/ExternalTable/PostgreSQL.cpp
@@ -5,9 +5,9 @@
 #include "config.h"
 
 #if USE_LIBPQXX
-#    include <Core/PostgreSQL/PoolWithFailover.h>
-#    include <Storages/StoragePostgreSQL.h>
-#    include <Common/parseRemoteDescription.h>
+#include <Core/PostgreSQL/PoolWithFailover.h>
+#include <Storages/StoragePostgreSQL.h>
+#include <Common/parseRemoteDescription.h>
 
 
 namespace DB
@@ -49,6 +49,7 @@ void PostgreSQL::init()
     common_configuration.database = settings->database.value;
     common_configuration.schema = settings->schema.value;
     common_configuration.table = remote_table_name;
+    common_configuration.on_conflict = settings->on_conflict.value;
     replicas_by_priority[0].emplace_back(std::move(common_configuration));
 
     auto connection_pool_size = settings->pooled_connections.changed ? settings->pooled_connections : DEFAULT_CONNECTION_POOL_SIZE;
@@ -67,7 +68,9 @@ void PostgreSQL::init()
         ColumnsDescription{},
         ConstraintsDescription{},
         /*comment=*/"",
-        context);
+        context,
+        settings->schema,
+        settings->on_conflict);
 }
 }
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
Fix #997 


Add `on_conflict` setting for postgresql external table

```sql
CREATE EXTERNAL TABLE pg_local
SETTINGS type='postgresql',
         address='127.0.0.1:5432',
         database='postgres',
         user='postgres',
         password='foo',
         table='dim_products',
         on_conflict='ON CONFLICT (product_id) DO UPDATE SET price=EXCLUDED.price'
``` 