### PR TITLE
CI: Package binaries into tar.gz for faster downloads in manual trigger b…

### DIFF
--- a/.github/workflows/manual_trigger_build.yml
+++ b/.github/workflows/manual_trigger_build.yml
@@ -440,6 +440,17 @@ jobs:
           echo "BINARY_NAME=proton_${COMMIT_HASH}_${ARCH}" >> $GITHUB_ENV
           echo "BINARY_PATH=${{ env.build_directory }}/programs/proton_${COMMIT_HASH}_${ARCH}" >> $GITHUB_ENV
 
+          # Package the binary into a tar.gz for faster downloads
+          TARBALL_NAME="proton_${COMMIT_HASH}_${ARCH}.tar.gz"
+          TARBALL_PATH="${{ env.build_directory }}/programs/${TARBALL_NAME}"
+          echo "Packaging binary tarball: $TARBALL_NAME"
+          tar -czf "$TARBALL_PATH" -C "$(dirname "$STRIPPED_BINARY")" "$(basename "$STRIPPED_BINARY")"
+          ls -lh "$TARBALL_PATH"
+
+          # Export tarball info for subsequent steps
+          echo "TARBALL_NAME=$TARBALL_NAME" >> $GITHUB_ENV
+          echo "TARBALL_PATH=$TARBALL_PATH" >> $GITHUB_ENV
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
@@ -447,7 +458,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload Artifact To S3
+      - name: Upload Artifact To S3 (tar.gz)
         run: |
           # Improve S3 upload reliability with specific options
           max_attempts=5
@@ -463,8 +474,8 @@ jobs:
                --only-show-errors \
                --cli-connect-timeout 30 \
                --cli-read-timeout 600 \
-               "${{ env.BINARY_PATH }}" \
-               "s3://tp-internal2/proton-oss/native_build_macOS/${{ env.BINARY_NAME }}"; then
+               "${{ env.TARBALL_PATH }}" \
+               "s3://tp-internal2/proton-oss/native_build_macOS/${{ env.TARBALL_NAME }}"; then
               echo "Upload successful"
               break
             else
@@ -483,7 +494,7 @@ jobs:
             fi
           done
 
-      - name: Print SHA256 Checksum
+      - name: Print SHA256 Checksum (tar.gz)
         run: |
-          STRIPPED_BINARY=${{ env.build_directory }}/programs/${{ env.BINARY_NAME }}
-          shasum -a 256 $STRIPPED_BINARY
+          TARBALL=${{ env.TARBALL_PATH }}
+          shasum -a 256 "$TARBALL"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -495,7 +495,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   Build_Native_Darwin_arm64:
-    needs: update_version
+    needs: Build_Linux_X86_64 # Gate the job behind the Linux x86_64 job so the release exists before uploads.
     runs-on: [self-hosted, macOS, ARM64]
     env:
       build_directory: ${{ github.workspace }}/build


### PR DESCRIPTION

Please write user-readable short description of the changes:
fix #1000 
# Gate the job behind the Linux x86_64 job so the release exists before uploads.
failed action: 

https://github.com/timeplus-io/proton/actions/runs/18739642885/job/53453412417

```
Run STRIPPED_BINARY=/Volumes/41plus/proton-oss-action/actions-runner/_work/proton/proton/build/programs/proton-v3.0.4-Darwin-arm64
  STRIPPED_BINARY=/Volumes/41plus/proton-oss-action/actions-runner/_work/proton/proton/build/programs/proton-v3.0.4-Darwin-arm64
  PYTHON_PACKAGE=/Volumes/41plus/proton-oss-action/actions-runner/_work/proton/proton/build/programs/python-Darwin-arm64.tar.gz
  TARBALL=${STRIPPED_BINARY}.tar.gz
  
  # Create tar.gz package for faster downloads
  echo "Packaging binary tarball..."
  tar -czf "$TARBALL" -C "$(dirname "$STRIPPED_BINARY")" "$(basename "$STRIPPED_BINARY")"
  ls -lh "$TARBALL"
  
  # Function to upload asset with retry
  upload_asset_with_retry() {
    local max_attempts=5
    local attempt=1
    local wait_time=15
    local file_path="$1"
    local tag="$2"
    
    while [ $attempt -le $max_attempts ]; do
      echo "Upload attempt $attempt of $max_attempts for $(basename $file_path)"
      
      if gh release upload "$tag" "$file_path" --clobber --repo timeplus-io/proton; then
        echo "Upload completed successfully"
        return 0
      else
        local status=$?
        echo "Upload failed on attempt $attempt with status $status"
        
        if [ $attempt -eq $max_attempts ]; then
          echo "All upload attempts failed"
          return 1
        fi
        
        echo "Waiting $wait_time seconds before retry..."
        sleep $wait_time
        wait_time=$((wait_time * 2))  # Exponential backoff
        attempt=$((attempt + 1))
      fi
    done
  }
  
  # Upload tarball with retry
  if ! upload_asset_with_retry "$TARBALL" "v3.0.4"; then
    echo "Tarball upload failed after all attempts"
    exit 1
  fi
  
  # Upload Python package with retry
  if ! upload_asset_with_retry "$PYTHON_PACKAGE" "v3.0.4"; then
    echo "Python package upload failed after all attempts"
    exit 1
  fi
  shell: /bin/bash -e {0}
  env:
    build_directory: /Volumes/41plus/proton-oss-action/actions-runner/_work/proton/proton/build
    build_type: RelWithDebInfo
    LATEST_TAG: v3.0.4
    AWS_DEFAULT_REGION: ***
    AWS_REGION: ***
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    GITHUB_TOKEN: ***
Packaging binary tarball...
-rw-r--r--  1 re  staff    84M Oct 22 23:43 /Volumes/41plus/proton-oss-action/actions-runner/_work/proton/proton/build/programs/proton-v3.0.4-Darwin-arm64.tar.gz
Upload attempt 1 of 5 for proton-v3.0.4-Darwin-arm64.tar.gz
release not found
Upload failed on attempt 1 with status 1
Waiting 15 seconds before retry...
Upload attempt 2 of 5 for proton-v3.0.4-Darwin-arm64.tar.gz
release not found
Upload failed on attempt 2 with status 1
Waiting 30 seconds before retry...
Upload attempt 3 of 5 for proton-v3.0.4-Darwin-arm64.tar.gz
release not found
Upload failed on attempt 3 with status 1
Waiting 60 seconds before retry...
Upload attempt 4 of 5 for proton-v3.0.4-Darwin-arm64.tar.gz
release not found
Upload failed on attempt 4 with status 1
Waiting 120 seconds before retry...
Upload attempt 5 of 5 for proton-v3.0.4-Darwin-arm64.tar.gz
release not found
Upload failed on attempt 5 with status 1
All upload attempts failed
Tarball upload failed after all attempts
Error: Process completed with exit code 1.
```


follow up #1001 