### PR TITLE
Feat/issue 1005 mat view cpu util

### DIFF
--- a/src/Interpreters/StreamStateLog.cpp
+++ b/src/Interpreters/StreamStateLog.cpp
@@ -158,6 +158,16 @@ void addMaterializedViewLog(const StorageMaterializedView * mv, const AddElem & 
     add_elem(storage_id, "recover_times", metrics->recover_times, /*state_string_value=*/"", /*dimension=*/mv_type);
     add_elem(storage_id, "memory_usage", metrics->memory_usage, /*state_string_value=*/"", /*dimension=*/mv_type);
 
+    /// CPU usage percentage (100% = 1 core, 200% = 2 cores, matches 'top' output)
+    /// state_value: Store with 2 decimal precision (1650 = 16.50%)
+    /// state_string_value: Store human-readable format (e.g., "16.5%")
+    add_elem(
+        storage_id,
+        "cpu_usage_percent",
+        static_cast<UInt64>(metrics.cpu_usage_percentage * 100),
+        /*state_string_value=*/fmt::format("{:.1f}%", metrics.cpu_usage_percentage),
+        /*dimension=*/mv_type);
+
     /// Checkpoint metrics
     add_elem(storage_id, "checkpoint_storage_size", metrics->ckpt_storage_size, /*state_string_value=*/"", /*dimension=*/mv_type);
     if (metrics->ckpt_request_metrics)

--- a/src/Interpreters/StreamStateLog.cpp
+++ b/src/Interpreters/StreamStateLog.cpp
@@ -150,13 +150,13 @@ void addMaterializedViewLog(const StorageMaterializedView * mv, const AddElem & 
     const auto * mv_type = "materialized_view";
 
     const auto & storage_id = mv->getStorageID();
-    add_elem(storage_id, "status", 0, /*state_string_value=*/metrics->status, /*dimension=*/mv_type);
+    add_elem(storage_id, "status", 0, /*state_string_value=*/metrics.status, /*dimension=*/mv_type);
 
-    const auto & [last_mv_err, last_ts] = metrics->last_err_msg_and_ts;
+    const auto & [last_mv_err, last_ts] = metrics.last_err_msg_and_ts;
     /// encode last_ts in `state_value`
     add_elem(storage_id, "last_error_message", last_ts, /*state_string_value=*/last_mv_err, /*dimension=*/mv_type);
-    add_elem(storage_id, "recover_times", metrics->recover_times, /*state_string_value=*/"", /*dimension=*/mv_type);
-    add_elem(storage_id, "memory_usage", metrics->memory_usage, /*state_string_value=*/"", /*dimension=*/mv_type);
+    add_elem(storage_id, "recover_times", metrics.recover_times, /*state_string_value=*/"", /*dimension=*/mv_type);
+    add_elem(storage_id, "memory_usage", metrics.memory_usage, /*state_string_value=*/"", /*dimension=*/mv_type);
 
     /// CPU usage percentage (100% = 1 core, 200% = 2 cores, matches 'top' output)
     /// state_value: Store with 2 decimal precision (1650 = 16.50%)
@@ -169,28 +169,27 @@ void addMaterializedViewLog(const StorageMaterializedView * mv, const AddElem & 
         /*dimension=*/mv_type);
 
     /// Checkpoint metrics
-    add_elem(storage_id, "checkpoint_storage_size", metrics->ckpt_storage_size, /*state_string_value=*/"", /*dimension=*/mv_type);
-    if (metrics->ckpt_request_metrics)
+    add_elem(storage_id, "checkpoint_storage_size", metrics.ckpt_storage_size, /*state_string_value=*/"", /*dimension=*/mv_type);
+    if (metrics.ckpt_request_metrics)
     {
         add_elem(
             storage_id,
             "last_checkpoint_bytes",
-            metrics->ckpt_request_metrics->total_bytes.load(),
+            metrics.ckpt_request_metrics->total_bytes.load(),
             /*state_string_value=*/"",
             /*dimension=*/mv_type);
         add_elem(
             storage_id,
             "last_checkpoint_elapsed_ms",
-            metrics->ckpt_request_metrics->stopwatch.elapsedMilliseconds(),
+            metrics.ckpt_request_metrics->stopwatch.elapsedMilliseconds(),
             /*state_string_value=*/"",
             /*dimension=*/mv_type);
     }
 
     /// Source stream metrics
-    for (const auto & s_metrics : metrics->source_metrics)
+    for (const auto & s_metrics : metrics.source_metrics)
     {
-        const auto source
-            = s_metrics->description.empty() ? s_metrics->name : fmt::format("{}[{}]", s_metrics->name, s_metrics->description);
+        const auto & source = s_metrics->description.empty() ? s_metrics->name : s_metrics->description;
 
         auto [low_sn, high_sn] = s_metrics->low_high_sn_range;
         if (low_sn >= 0)

--- a/src/Interpreters/StreamStateLog.cpp
+++ b/src/Interpreters/StreamStateLog.cpp
@@ -168,6 +168,20 @@ void addMaterializedViewLog(const StorageMaterializedView * mv, const AddElem & 
         /*state_string_value=*/fmt::format("{:.1f}%", metrics.cpu_usage_percentage),
         /*dimension=*/mv_type);
 
+    /// Thread IDs for the MatView execution
+    /// state_value: Store thread count
+    /// state_string_value: Store comma-separated thread IDs
+    if (!metrics.thread_ids.empty())
+    {
+        add_elem(
+            storage_id,
+            "thread_ids",
+            metrics.thread_ids.size(),
+            /*state_string_value=*/fmt::format("{}", fmt::join(metrics.thread_ids, ",")),
+            /*dimension=*/mv_type);
+    }
+
+
     /// Checkpoint metrics
     add_elem(storage_id, "checkpoint_storage_size", metrics.ckpt_storage_size, /*state_string_value=*/"", /*dimension=*/mv_type);
     if (metrics.ckpt_request_metrics)

--- a/src/Storages/MatView/StorageMaterializedView.h
+++ b/src/Storages/MatView/StorageMaterializedView.h
@@ -167,6 +167,9 @@ private:
         mutable std::atomic<Int64> last_elapsed_microseconds{0};
 
         std::vector<std::string> processors_last_error_message;
+
+        /// Cached static pipeline data (collected once when pipeline is built)
+        std::vector<UInt64> cached_thread_ids;
     };
 
     struct Metrics
@@ -176,6 +179,7 @@ private:
         Int64 recover_times;
         Int64 memory_usage;
         Float64 cpu_usage_percentage;
+        std::vector<UInt64> thread_ids;
         UInt64 ckpt_storage_size;
         CheckpointRequestMetricsPtr ckpt_request_metrics;
         Streaming::StreamingSourceMetricsPtrs source_metrics;
@@ -345,10 +349,16 @@ private:
 
     void logToDLQ(const std::vector<std::shared_ptr<Streaming::ISource>> &);
 
+    struct PipelineMetrics
+    {
+        Int64 memory_usage = 0;
+        Float64 cpu_usage_percentage = 0.0;
+        std::vector<UInt64> thread_ids;
+    };
+
     /// Internal Metrics methods
-    Int64 getMemoryUsage() const;
-    /// Returns CPU utilization percentage (100% = 1 core)
-    Float64 getCPUUsagePercentage() const;
+    /// Get all pipeline metrics in a single call (efficient)
+    PipelineMetrics getPipelineMetrics() const;
     Streaming::StreamingSourceMetricsPtrs getStreamingSourceMetrics() const;
     CheckpointRequestMetricsPtr getCheckpointRequestMetrics() const;
     UInt64 getLogStoreDiskSize() const;

--- a/src/Storages/MatView/StorageMaterializedView.h
+++ b/src/Storages/MatView/StorageMaterializedView.h
@@ -291,7 +291,7 @@ public:
     UInt64 writtenBytes(bool reset = true, bool external_ingress = false) override;
     UInt64 writtenRows(bool reset = true, bool external_ingress = false) override;
 
-    std::shared_ptr<Metrics> getMetrics() const;
+    Metrics getMetrics() const;
 
     /// Pause/Resume/Abort/Recover the background pipeline execution
     /// \return error code

--- a/src/Storages/MatView/StorageMaterializedView.h
+++ b/src/Storages/MatView/StorageMaterializedView.h
@@ -162,6 +162,10 @@ private:
         std::atomic<uint64_t> written_bytes;
         std::atomic<uint64_t> written_rows;
 
+        /// For delta-based CPU tracking (real-time usage)
+        mutable std::atomic<Int64> last_cpu_microseconds{0};
+        mutable std::atomic<Int64> last_elapsed_microseconds{0};
+
         std::vector<std::string> processors_last_error_message;
     };
 
@@ -171,6 +175,7 @@ private:
         std::pair<String, Int64> last_err_msg_and_ts;
         Int64 recover_times;
         Int64 memory_usage;
+        Float64 cpu_usage_percentage;
         UInt64 ckpt_storage_size;
         CheckpointRequestMetricsPtr ckpt_request_metrics;
         Streaming::StreamingSourceMetricsPtrs source_metrics;
@@ -342,6 +347,8 @@ private:
 
     /// Internal Metrics methods
     Int64 getMemoryUsage() const;
+    /// Returns CPU utilization percentage (100% = 1 core)
+    Float64 getCPUUsagePercentage() const;
     Streaming::StreamingSourceMetricsPtrs getStreamingSourceMetrics() const;
     CheckpointRequestMetricsPtr getCheckpointRequestMetrics() const;
     UInt64 getLogStoreDiskSize() const;

--- a/src/Storages/MatView/StorageMaterializedView_Metrics.cpp
+++ b/src/Storages/MatView/StorageMaterializedView_Metrics.cpp
@@ -7,6 +7,12 @@
 
 #include <ranges>
 
+namespace ProfileEvents
+{
+extern const Event UserTimeMicroseconds;
+extern const Event SystemTimeMicroseconds;
+}
+
 namespace DB
 {
 Int64 StorageMaterializedView::getMetricTime(bool reset)
@@ -71,6 +77,52 @@ Int64 StorageMaterializedView::getMemoryUsage() const
     return query_status_info.memory_usage;
 }
 
+Float64 StorageMaterializedView::getCPUUsagePercentage() const
+{
+    /// Calculate real-time CPU usage using delta tracking.
+    /// This shows instantaneous usage like 'top' rather than lifetime average.
+    auto query_context_holder = pipeline_state.query_context;
+    auto block_io = pipeline_state.io.load();
+    if (!block_io || !block_io->process_list_entry)
+        return 0.0;
+
+    auto query_status_info = block_io->process_list_entry->getQueryStatus()->getInfo(
+        /*get_thread_list=*/false, /*get_profile_events=*/true, /*get_settings=*/false);
+
+    if (!query_status_info.profile_counters || query_status_info.elapsed_microseconds == 0)
+        return 0.0;
+
+    /// Get current CPU usage from ProfileEvents
+    const auto & counters = *query_status_info.profile_counters;
+    Int64 user_time = counters[ProfileEvents::UserTimeMicroseconds];
+    Int64 system_time = counters[ProfileEvents::SystemTimeMicroseconds];
+    Int64 current_cpu_microseconds = user_time + system_time;
+    Int64 current_elapsed_microseconds = query_status_info.elapsed_microseconds;
+
+    /// Get previous values for delta calculation
+    Int64 prev_cpu = pipeline_state.last_cpu_microseconds.load(std::memory_order_relaxed);
+    Int64 prev_elapsed = pipeline_state.last_elapsed_microseconds.load(std::memory_order_relaxed);
+
+    /// Update stored values for next calculation
+    pipeline_state.last_cpu_microseconds.store(current_cpu_microseconds, std::memory_order_relaxed);
+    pipeline_state.last_elapsed_microseconds.store(current_elapsed_microseconds, std::memory_order_relaxed);
+
+    /// First sample or after reset - return 0 to avoid misleading spike
+    if (prev_elapsed == 0 || current_elapsed_microseconds <= prev_elapsed)
+        return 0.0;
+
+    /// Calculate delta-based CPU percentage (real-time usage)
+    Int64 cpu_delta = current_cpu_microseconds - prev_cpu;
+    Int64 elapsed_delta = current_elapsed_microseconds - prev_elapsed;
+
+    /// Handle edge cases: negative delta (shouldn't happen) or no time passed
+    if (cpu_delta < 0 || elapsed_delta <= 0)
+        return 0.0;
+
+    /// Real-time CPU percentage: 100% = 1 core, 200% = 2 cores, etc.
+    return (static_cast<Float64>(cpu_delta) / static_cast<Float64>(elapsed_delta)) * 100.0;
+}
+
 UInt64 StorageMaterializedView::getCheckpointSize() const
 {
     if (!curr_ckpt_ctx)
@@ -128,6 +180,7 @@ std::shared_ptr<StorageMaterializedView::Metrics> StorageMaterializedView::getMe
         .last_err_msg_and_ts = lastErrorMessageAndTimestamp(),
         .recover_times = getRetryTimes(),
         .memory_usage = getMemoryUsage(),
+        .cpu_usage_percentage = getCPUUsagePercentage(),
         .ckpt_storage_size = getCheckpointSize(),
         .ckpt_request_metrics = getCheckpointRequestMetrics(),
         .source_metrics = getStreamingSourceMetrics(),

--- a/src/Storages/MatView/StorageMaterializedView_Metrics.cpp
+++ b/src/Storages/MatView/StorageMaterializedView_Metrics.cpp
@@ -173,9 +173,9 @@ Streaming::StreamingSourceMetricsPtrs StorageMaterializedView::getStreamingSourc
     return {};
 }
 
-std::shared_ptr<StorageMaterializedView::Metrics> StorageMaterializedView::getMetrics() const
+StorageMaterializedView::Metrics StorageMaterializedView::getMetrics() const
 {
-    return std::make_shared<Metrics>(Metrics{
+    return Metrics{
         .status = String{magic_enum::enum_name(getPipelineStatus())},
         .last_err_msg_and_ts = lastErrorMessageAndTimestamp(),
         .recover_times = getRetryTimes(),
@@ -184,6 +184,6 @@ std::shared_ptr<StorageMaterializedView::Metrics> StorageMaterializedView::getMe
         .ckpt_storage_size = getCheckpointSize(),
         .ckpt_request_metrics = getCheckpointRequestMetrics(),
         .source_metrics = getStreamingSourceMetrics(),
-    });
+    };
 }
 }

--- a/src/Storages/MatView/StorageMaterializedView_Metrics.cpp
+++ b/src/Storages/MatView/StorageMaterializedView_Metrics.cpp
@@ -55,8 +55,10 @@ UInt64 StorageMaterializedView::writtenRows(bool reset, [[maybe_unused]] bool ex
         return pipeline_state.written_rows.load(std::memory_order_relaxed);
 }
 
-Int64 StorageMaterializedView::getMemoryUsage() const
+StorageMaterializedView::PipelineMetrics StorageMaterializedView::getPipelineMetrics() const
 {
+    PipelineMetrics metrics;
+
     /// https://github.com/timeplus-io/proton-enterprise/issues/6170
     /// When the query pipeline recovers from an exception,
     /// it resets the `BlockIO` and query context objects.
@@ -69,58 +71,51 @@ Int64 StorageMaterializedView::getMemoryUsage() const
     auto query_context_holder = pipeline_state.query_context;
     auto block_io = pipeline_state.io.load();
     if (!block_io || !block_io->process_list_entry)
-        return 0;
+        return metrics;
 
-    auto query_status_info = block_io->process_list_entry->getQueryStatus()->getInfo(
-        /*get_thread_list=*/false, /*get_profile_events=*/false, /*get_settings=*/false);
-
-    return query_status_info.memory_usage;
-}
-
-Float64 StorageMaterializedView::getCPUUsagePercentage() const
-{
-    /// Calculate real-time CPU usage using delta tracking.
-    /// This shows instantaneous usage like 'top' rather than lifetime average.
-    auto query_context_holder = pipeline_state.query_context;
-    auto block_io = pipeline_state.io.load();
-    if (!block_io || !block_io->process_list_entry)
-        return 0.0;
-
+    /// Get dynamic metrics only (memory and CPU) - skip static thread_list
     auto query_status_info = block_io->process_list_entry->getQueryStatus()->getInfo(
         /*get_thread_list=*/false, /*get_profile_events=*/true, /*get_settings=*/false);
 
-    if (!query_status_info.profile_counters || query_status_info.elapsed_microseconds == 0)
-        return 0.0;
+    /// Memory usage (dynamic - changes constantly)
+    metrics.memory_usage = query_status_info.memory_usage;
 
-    /// Get current CPU usage from ProfileEvents
-    const auto & counters = *query_status_info.profile_counters;
-    Int64 user_time = counters[ProfileEvents::UserTimeMicroseconds];
-    Int64 system_time = counters[ProfileEvents::SystemTimeMicroseconds];
-    Int64 current_cpu_microseconds = user_time + system_time;
-    Int64 current_elapsed_microseconds = query_status_info.elapsed_microseconds;
+    /// Use cached static data (thread IDs)
+    /// These are collected once when pipeline is built and never change
+    metrics.thread_ids = pipeline_state.cached_thread_ids;
 
-    /// Get previous values for delta calculation
-    Int64 prev_cpu = pipeline_state.last_cpu_microseconds.load(std::memory_order_relaxed);
-    Int64 prev_elapsed = pipeline_state.last_elapsed_microseconds.load(std::memory_order_relaxed);
+    /// CPU usage calculation (dynamic - real-time delta tracking)
+    if (query_status_info.profile_counters && query_status_info.elapsed_microseconds > 0)
+    {
+        const auto & counters = *query_status_info.profile_counters;
+        Int64 user_time = counters[ProfileEvents::UserTimeMicroseconds];
+        Int64 system_time = counters[ProfileEvents::SystemTimeMicroseconds];
+        Int64 current_cpu_microseconds = user_time + system_time;
+        Int64 current_elapsed_microseconds = query_status_info.elapsed_microseconds;
 
-    /// Update stored values for next calculation
-    pipeline_state.last_cpu_microseconds.store(current_cpu_microseconds, std::memory_order_relaxed);
-    pipeline_state.last_elapsed_microseconds.store(current_elapsed_microseconds, std::memory_order_relaxed);
+        /// Get previous values for delta calculation
+        Int64 prev_cpu = pipeline_state.last_cpu_microseconds.load(std::memory_order_relaxed);
+        Int64 prev_elapsed = pipeline_state.last_elapsed_microseconds.load(std::memory_order_relaxed);
 
-    /// First sample or after reset - return 0 to avoid misleading spike
-    if (prev_elapsed == 0 || current_elapsed_microseconds <= prev_elapsed)
-        return 0.0;
+        /// Update stored values for next calculation
+        pipeline_state.last_cpu_microseconds.store(current_cpu_microseconds, std::memory_order_relaxed);
+        pipeline_state.last_elapsed_microseconds.store(current_elapsed_microseconds, std::memory_order_relaxed);
 
-    /// Calculate delta-based CPU percentage (real-time usage)
-    Int64 cpu_delta = current_cpu_microseconds - prev_cpu;
-    Int64 elapsed_delta = current_elapsed_microseconds - prev_elapsed;
+        /// Calculate delta-based CPU percentage (real-time usage)
+        if (prev_elapsed > 0 && current_elapsed_microseconds > prev_elapsed)
+        {
+            Int64 cpu_delta = current_cpu_microseconds - prev_cpu;
+            Int64 elapsed_delta = current_elapsed_microseconds - prev_elapsed;
 
-    /// Handle edge cases: negative delta (shouldn't happen) or no time passed
-    if (cpu_delta < 0 || elapsed_delta <= 0)
-        return 0.0;
+            if (cpu_delta >= 0 && elapsed_delta > 0)
+            {
+                /// Real-time CPU percentage: 100% = 1 core, 200% = 2 cores, etc.
+                metrics.cpu_usage_percentage = (static_cast<Float64>(cpu_delta) / static_cast<Float64>(elapsed_delta)) * 100.0;
+            }
+        }
+    }
 
-    /// Real-time CPU percentage: 100% = 1 core, 200% = 2 cores, etc.
-    return (static_cast<Float64>(cpu_delta) / static_cast<Float64>(elapsed_delta)) * 100.0;
+    return metrics;
 }
 
 UInt64 StorageMaterializedView::getCheckpointSize() const
@@ -175,12 +170,16 @@ Streaming::StreamingSourceMetricsPtrs StorageMaterializedView::getStreamingSourc
 
 StorageMaterializedView::Metrics StorageMaterializedView::getMetrics() const
 {
+    /// Get all pipeline metrics in a single efficient call
+    auto pipeline_metrics = getPipelineMetrics();
+
     return Metrics{
         .status = String{magic_enum::enum_name(getPipelineStatus())},
         .last_err_msg_and_ts = lastErrorMessageAndTimestamp(),
         .recover_times = getRetryTimes(),
-        .memory_usage = getMemoryUsage(),
-        .cpu_usage_percentage = getCPUUsagePercentage(),
+        .memory_usage = pipeline_metrics.memory_usage,
+        .cpu_usage_percentage = pipeline_metrics.cpu_usage_percentage,
+        .thread_ids = std::move(pipeline_metrics.thread_ids),
         .ckpt_storage_size = getCheckpointSize(),
         .ckpt_request_metrics = getCheckpointRequestMetrics(),
         .source_metrics = getStreamingSourceMetrics(),

--- a/src/Storages/MatView/StorageMaterializedView_Pipeline.cpp
+++ b/src/Storages/MatView/StorageMaterializedView_Pipeline.cpp
@@ -323,6 +323,10 @@ void StorageMaterializedView::PipelineState::resetPipeline()
 
         last_streaming_source_metrics.store(std::move(sources_metrics));
     }
+
+    /// Reset CPU tracking to avoid misleading spikes after pause/resume
+    last_cpu_microseconds.store(0, std::memory_order_relaxed);
+    last_elapsed_microseconds.store(0, std::memory_order_relaxed);
 }
 
 bool StorageMaterializedView::initPipeline(bool recovering)

--- a/src/Storages/MatView/StorageMaterializedView_Pipeline.cpp
+++ b/src/Storages/MatView/StorageMaterializedView_Pipeline.cpp
@@ -327,6 +327,9 @@ void StorageMaterializedView::PipelineState::resetPipeline()
     /// Reset CPU tracking to avoid misleading spikes after pause/resume
     last_cpu_microseconds.store(0, std::memory_order_relaxed);
     last_elapsed_microseconds.store(0, std::memory_order_relaxed);
+
+    /// Clear cached static pipeline data
+    cached_thread_ids.clear();
 }
 
 bool StorageMaterializedView::initPipeline(bool recovering)
@@ -673,6 +676,16 @@ void StorageMaterializedView::buildBackgroundPipeline()
 
         /// Other threads may call `shutdown` to cancel the pipeline execution (via `process_list_entry->cancelQuery(true)`)
         chassert(io && io->process_list_entry && io->pipeline.initialized());
+
+        /// Collect static pipeline data once (thread IDs)
+        /// These don't change during pipeline execution, so cache them to avoid repeated collection
+        if (io->process_list_entry)
+        {
+            auto static_info = io->process_list_entry->getQueryStatus()->getInfo(
+                /*get_thread_list=*/true, /*get_profile_events=*/false, /*get_settings=*/false);
+            pipeline_state.cached_thread_ids = std::move(static_info.thread_ids);
+        }
+
         pipeline_state.io.store(io);
         pipeline_state.validated.store(true);
         pipeline_state.validated.notify_all();


### PR DESCRIPTION

Please write user-readable short description of the changes:
fix #1005

New metric: cpu_usage_percent in system.stream_state_log
Usage
```
  SELECT
      name,
      state_value / 100.0 as cpu_percent,
      state_string_value                   -- "16.5%" format
  FROM system.stream_state_log
  WHERE state_name = 'cpu_usage_percent'

  -- Note: 100% = 1 core (same as 'top' command)
```


Calculate CPU usage over the sampling interval formula:

```
  cpu_percentage = (Δ CPU_time / Δ Wall_time) × 100

  Examples:

  Idle MatView:
  Time T+0s: Total CPU = 27sec, Elapsed = 600sec
  Time T+5s: Total CPU = 27sec, Elapsed = 605sec
  Result: (0 / 5sec) × 100 = 0% ✓ Correctly shows idle

  Active MatView:
  Time T+0s: Total CPU = 27sec, Elapsed = 600sec
  Time T+5s: Total CPU = 32sec, Elapsed = 605sec
  Result: (5sec / 5sec) × 100 = 100% ✓ Using 1 full core
```
