### PR TITLE
fix postgres numeric column parsing error (#10953)

### DIFF
--- a/src/DataTypes/DataTypesDecimal.cpp
+++ b/src/DataTypes/DataTypesDecimal.cpp
@@ -111,7 +111,7 @@ void registerDataTypeDecimal(DataTypeFactory & factory)
 
     factory.registerDataType("decimal", create, DataTypeFactory::CaseInsensitive);
     /// factory.registerAlias("DEC", "decimal", DataTypeFactory::CaseInsensitive);
-    /// factory.registerAlias("NUMERIC", "decimal", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("NUMERIC", "decimal", DataTypeFactory::CaseInsensitive);
     /// factory.registerAlias("FIXED", "decimal", DataTypeFactory::CaseInsensitive);
 
     /// proton: starts

--- a/tests/cluster/smoke/0045_external_table_postgres/03_external_table_postgres_secure.yaml
+++ b/tests/cluster/smoke/0045_external_table_postgres/03_external_table_postgres_secure.yaml
@@ -1,5 +1,6 @@
 tags:
   - materialized view
+  - skip    # setting 'secure' has no actual effect in pg ext
 
 description: |
   Test PostgreSQL external table with secure=true

--- a/tests/cluster/smoke/0045_external_table_postgres/04_external_table_postgres_column_type.yaml
+++ b/tests/cluster/smoke/0045_external_table_postgres/04_external_table_postgres_column_type.yaml
@@ -1,0 +1,46 @@
+tags:
+  - materialized view
+
+description: |
+  Test PostgreSQL external table with secure=true
+  Main Steps:
+    1.Create postgres table with numeric-type columns and ingest data
+    2.Create postgresql external table
+    3.Check external table data
+
+steps:
+  - type: command
+    node: [s1]
+    shell: docker exec <<.CONTAINER_NAME_PREFIX>>_postgres psql -U postgres -c "DROP TABLE IF EXISTS test_table;"
+
+  - type: command
+    node: [s1]
+    shell: docker exec <<.CONTAINER_NAME_PREFIX>>_postgres psql -U postgres -c "CREATE TABLE test_table (id SERIAL PRIMARY KEY, price NUMERIC(10,2), quantity numeric);"
+
+  - type: command
+    node: [s1]
+    shell: docker exec <<.CONTAINER_NAME_PREFIX>>_postgres psql -U postgres -c "INSERT INTO test_table (price, quantity) VALUES (19.99, 1.234);"
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL TABLE pg_ext
+      SETTINGS type='postgresql', address='postgres:5432', 
+               user='postgres', password='postgres', 
+               database='postgres', table='test_table';
+
+  - name: pg-4-1
+    type: stream
+    query: SELECT price, quantity FROM pg_ext;
+    schema:
+      - name: price
+        type: nullable(decimal(10, 2))
+      - name: quantity
+        type: nullable(decimal(38, 19))
+
+  - type: check
+    target_name: pg-4-1
+    expected_result:
+      - ['19.99', '1.234']


### PR DESCRIPTION

Please write user-readable short description of the changes:
Fix: Can not create external table to pg table like

```
CREATE TABLE numeric_test (
    id SERIAL PRIMARY KEY,
    price NUMERIC(10,2),
    quantity NUMERIC(8,3)
);
```

Below error is got in creation:
Received exception from server:
Code: 50. DB::Exception: Received from localhost:8463. DB::Exception: Failed to create stream 'default.test1', error=Unknown data type family: numeric: while fetching postgresql table structure. (UNKNOWN_TYPE)
