### PR TITLE
clickhouse/clickhouse#57899 Delete debug logging in OutputFormatWithU…

### DIFF
--- a/src/Processors/Formats/OutputFormatWithUTF8ValidationAdaptor.h
+++ b/src/Processors/Formats/OutputFormatWithUTF8ValidationAdaptor.h
@@ -46,7 +46,6 @@ public:
 
     void resetFormatterImpl() override
     {
-        LOG_DEBUG(getLogger("RowOutputFormatWithExceptionHandlerAdaptor"), "resetFormatterImpl");
         Base::resetFormatterImpl();
         if (validating_ostr)
             validating_ostr = std::make_unique<WriteBufferValidUTF8>(*Base::getWriteBufferPtr());


### PR DESCRIPTION
…TF8ValidationAdaptor

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix #1011