### PR TITLE
force drop system log in recreation

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -657,6 +657,7 @@ void SystemLog<LogElement>::prepareTable()
             {
                 auto query_context = Context::createCopy(context);
                 query_context->makeQueryContext();
+                query_context->setSetting("enable_dependency_check", false);
 
                 String query = fmt::format("DROP STREAM IF EXISTS {}", table_id.getFullTableName());
                 executeNonInsertQuery(


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
tested by manually changed the StreamStateLog schema in code. The stream was recreated with success.
