### PR TITLE
smoke fix: specify exact version for river package installation in co…

### DIFF
--- a/tests/cluster/smoke/0041_python_udf_river/config.yaml
+++ b/tests/cluster/smoke/0041_python_udf_river/config.yaml
@@ -14,7 +14,7 @@ setup:
   steps:
     # river
     - type: query
-      sql: SYSTEM INSTALL PYTHON PACKAGE 'river';
+      sql: SYSTEM INSTALL PYTHON PACKAGE 'river==0.22.0';
 
     - type: wait
       time: 15


### PR DESCRIPTION
…nfig

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
python package 'river' released a new version yesterday, but does not contain python3.10 prebuilt whl. On Ubuntu 22.04 (Python 3.10), pip now falls back to building from source, which breaks our CI. (It requires to install rust compiler)
upstream ticket: https://github.com/online-ml/river/issues/1728