### PR TITLE
Disable alter command for external table / stream

### DIFF
--- a/src/Databases/ApacheIceberg/DatabaseIceberg.cpp
+++ b/src/Databases/ApacheIceberg/DatabaseIceberg.cpp
@@ -261,6 +261,7 @@ StoragePtr DatabaseApacheIceberg::tryGetTable(const String & name [[maybe_unused
             /*table_id_=*/StorageID{getDatabaseName(), name},
             context_,
             ColumnsDescription(table_metadata.getSchema()),
+            /*schema_version=*/1,
             /*comment=*/"",
             &stream_storage,
             /*attach=*/false);

--- a/src/Storages/ExternalStream/StorageExternalStream.cpp
+++ b/src/Storages/ExternalStream/StorageExternalStream.cpp
@@ -1,6 +1,10 @@
 #include <Storages/ExternalStream/StorageExternalStream.h>
 
 #include <IO/Kafka/Connection.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromFile.h>
+#include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -19,11 +23,6 @@
 #include <Storages/IStorage_fwd.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageFactory.h>
-
-#include <IO/ReadBufferFromFile.h>
-#include <IO/ReadHelpers.h>
-#include <IO/WriteBufferFromFile.h>
-#include <IO/WriteHelpers.h>
 
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/Net/KeyFileHandler.h>
@@ -238,6 +237,7 @@ StorageExternalStream::StorageExternalStream(
     const StorageID & table_id_,
     ContextPtr context_,
     const ColumnsDescription & columns_,
+    Int32 schema_version,
     const String & comment,
     ASTStorage * storage_def,
     bool attach)
@@ -253,6 +253,7 @@ StorageExternalStream::StorageExternalStream(
     ColumnsDescription columns = initColumnsDescription(columns_, *external_stream_settings, context_);
 
     StorageInMemoryMetadata storage_metadata;
+    storage_metadata.setVersion(schema_version);
     storage_metadata.setComment(comment);
     if (storage_def->partition_by != nullptr)
     {
@@ -290,6 +291,11 @@ void StorageExternalStream::read(
     getNested()->read(query_plan, column_names, storage_snapshot, query_info, context_, processed_stage, max_block_size, num_streams);
 }
 
+void StorageExternalStream::alter(const AlterCommands &, ContextPtr, AlterLockHolder &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Alter command is not supported for external stream yet");
+}
+
 void registerStorageExternalStream(StorageFactory & factory)
 {
     /** * ExternalStream engine arguments : ExternalStream(shard_by_expr)
@@ -300,7 +306,7 @@ void registerStorageExternalStream(StorageFactory & factory)
 
         if (args.storage_def->settings != nullptr)
             return StorageExternalStream::create(
-                args.engine_args, args.table_id, args.getContext(), args.columns, args.comment, args.storage_def, args.attach);
+                args.engine_args, args.table_id, args.getContext(), args.columns, args.schema_version, args.comment, args.storage_def, args.attach);
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "External stream requires correct settings setup");
     };

--- a/src/Storages/ExternalStream/StorageExternalStream.h
+++ b/src/Storages/ExternalStream/StorageExternalStream.h
@@ -66,12 +66,15 @@ public:
 
     std::optional<String> preferredColumn() const override { return external_stream->preferredColumn(); }
 
+    void alter(const AlterCommands & commands, ContextPtr context, AlterLockHolder & alter_lock_holder) override;
+
 protected:
     StorageExternalStream(
         const ASTs & engine_args,
         const StorageID & table_id_,
         ContextPtr context_,
         const ColumnsDescription & columns_,
+        Int32 schema_version,
         const String & comment,
         ASTStorage * storage_def,
         bool attach);

--- a/src/Storages/ExternalTable/ExternalTableFactory.cpp
+++ b/src/Storages/ExternalTable/ExternalTableFactory.cpp
@@ -77,6 +77,8 @@ StoragePtr ExternalTableFactory::getExternalTable(const StorageFactory::Argument
         }
     }
 
+    storage_metadata.setVersion(args.schema_version);
+
     return creators.at(type)(args.table_id, storage_metadata, std::move(external_table_settings), args.attach, context);
 }
 

--- a/src/Storages/ExternalTable/StorageExternalTable.h
+++ b/src/Storages/ExternalTable/StorageExternalTable.h
@@ -47,6 +47,11 @@ public:
 
     void updateTableSchema(bool retry_in_background);
 
+    void alter(const AlterCommands &, ContextPtr, AlterLockHolder &) override
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Alter command is not supported for external table yet");
+    }
+
 protected:
     StorageExternalTable(
         const StorageID & table_id,


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
Disable the alter command for external table and stream. Implementing alter is a little complicated as column descriptions may be dynamic (empty in DDL) and raise exception in using existing alterTable.