### PR TITLE
 backport named collection updates

### DIFF
--- a/src/Common/NamedCollections/NamedCollectionConfiguration.cpp
+++ b/src/Common/NamedCollections/NamedCollectionConfiguration.cpp
@@ -1,8 +1,8 @@
 #include <Common/NamedCollections/NamedCollectionConfiguration.h>
 #include <Poco/Util/XMLConfiguration.h>
 #include <Common/Exception.h>
-#include <Common/SettingsChanges.h>
 #include <Common/FieldVisitorToString.h>
+#include <Common/SettingsChanges.h>
 #include <magic_enum.hpp>
 
 

--- a/src/Common/NamedCollections/NamedCollections.cpp
+++ b/src/Common/NamedCollections/NamedCollections.cpp
@@ -1,10 +1,13 @@
-#include "NamedCollections.h"
+#include <Common/NamedCollections/NamedCollections.h>
 
 #include <Interpreters/Context.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <Common/NamedCollections/NamedCollectionConfiguration.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <Common/FieldVisitorToString.h>
+
+#include <fmt/ranges.h>
 
 
 namespace DB
@@ -12,9 +15,9 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int NAMED_COLLECTION_DOESNT_EXIST;
-    extern const int NAMED_COLLECTION_ALREADY_EXISTS;
     extern const int NAMED_COLLECTION_IS_IMMUTABLE;
+    extern const int BAD_ARGUMENTS;
+    extern const int NOT_IMPLEMENTED;
 }
 
 namespace Configuration = NamedCollectionConfiguration;
@@ -175,27 +178,14 @@ public:
 NamedCollection::NamedCollection(
     ImplPtr pimpl_,
     const std::string & collection_name_,
-    SourceId source_id_,
-    bool is_mutable_)
+    const bool is_mutable_)
     : pimpl(std::move(pimpl_))
     , collection_name(collection_name_)
-    , source_id(source_id_)
     , is_mutable(is_mutable_)
 {
 }
 
-MutableNamedCollectionPtr NamedCollection::create(
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & collection_name,
-    const std::string & collection_path,
-    const Keys & keys,
-    SourceId source_id,
-    bool is_mutable)
-{
-    auto impl = Impl::create(config, collection_name, collection_path, keys);
-    return std::unique_ptr<NamedCollection>(
-        new NamedCollection(std::move(impl), collection_name, source_id, is_mutable));
-}
+NamedCollection::~NamedCollection() = default;
 
 bool NamedCollection::has(const Key & key) const
 {
@@ -296,8 +286,7 @@ MutableNamedCollectionPtr NamedCollection::duplicate() const
     std::lock_guard lock(mutex);
     auto impl = pimpl->createCopy(collection_name);
     return std::unique_ptr<NamedCollection>(
-        new NamedCollection(
-            std::move(impl), collection_name, SourceId::NONE, true));
+        new NamedCollection(std::move(impl), collection_name, true));
 }
 
 NamedCollection::Keys NamedCollection::getKeys(ssize_t depth, const std::string & prefix) const
@@ -331,6 +320,133 @@ std::string NamedCollection::dumpStructure() const
 std::unique_lock<std::mutex> NamedCollection::lock()
 {
     return std::unique_lock(mutex);
+}
+
+
+void NamedCollection::update(const ASTAlterNamedCollectionQuery & /*query*/)
+{
+    throw Exception(
+        ErrorCodes::NOT_IMPLEMENTED,
+        "update() not implemented for NamedCollection base class.");
+}
+
+NamedCollectionFromConfig::NamedCollectionFromConfig(
+    const Poco::Util::AbstractConfiguration & config_,
+    const std::string & collection_name_,
+    const std::string & collection_path_,
+    const Keys & keys_)
+    : NamedCollection(Impl::create(config_, collection_name_, collection_path_, keys_), collection_name_, /* is_mutable */ false)
+{
+}
+
+MutableNamedCollectionPtr NamedCollectionFromConfig::create(
+    const Poco::Util::AbstractConfiguration & config_,
+    const std::string & collection_name_,
+    const std::string & collection_path_,
+    const Keys & keys_)
+{
+    return std::unique_ptr<NamedCollection>(
+        new NamedCollectionFromConfig(config_, collection_name_, collection_path_, keys_));
+}
+
+
+MutableNamedCollectionPtr NamedCollectionFromSQL::create(const ASTCreateNamedCollectionQuery & query)
+{
+    return std::unique_ptr<NamedCollection>(new NamedCollectionFromSQL(query));
+}
+
+NamedCollectionFromSQL::NamedCollectionFromSQL(const ASTCreateNamedCollectionQuery & query_)
+    : NamedCollection(nullptr, query_.collection_name, true)
+    , create_query_ptr(query_.clone()->as<ASTCreateNamedCollectionQuery &>())
+{
+    const auto config = NamedCollectionConfiguration::createConfiguration(collection_name, create_query_ptr.changes, create_query_ptr.overridability);
+
+    std::set<std::string, std::less<>> keys;
+    for (const auto & [name, _] : create_query_ptr.changes)
+        keys.insert(name);
+
+    pimpl = Impl::create(*config, collection_name, "", keys);
+}
+
+String NamedCollectionFromSQL::getCreateStatement(bool show_secrects)
+{
+    auto & changes = create_query_ptr.changes;
+    std::sort(
+        changes.begin(), changes.end(),
+        [](const SettingChange & lhs, const SettingChange & rhs) { return lhs.name < rhs.name; });
+
+    return create_query_ptr.formatWithPossiblyHidingSensitiveData(
+        /*max_length=*/0,
+        /*one_line=*/true,
+        /*show_secrets=*/show_secrects);
+}
+
+void NamedCollectionFromSQL::update(const ASTAlterNamedCollectionQuery & alter_query)
+{
+    std::lock_guard lock(mutex);
+
+    std::unordered_map<std::string, Field> result_changes_map;
+    for (const auto & [name, value] : alter_query.changes)
+    {
+        auto [it, inserted] = result_changes_map.emplace(name, value);
+        if (!inserted)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Value with key `{}` is used twice in the SET query (collection name: {})",
+                name, alter_query.collection_name);
+        }
+    }
+
+    for (const auto & [name, value] : create_query_ptr.changes)
+        result_changes_map.emplace(name, value);
+
+    std::unordered_map<std::string, bool> result_overridability_map;
+    for (const auto & [name, value] : alter_query.overridability)
+        result_overridability_map.emplace(name, value);
+    for (const auto & [name, value] : create_query_ptr.overridability)
+        result_overridability_map.emplace(name, value);
+
+    for (const auto & delete_key : alter_query.delete_keys)
+    {
+        auto it = result_changes_map.find(delete_key);
+        if (it == result_changes_map.end())
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Cannot delete key `{}` because it does not exist in collection",
+                delete_key);
+        }
+
+        result_changes_map.erase(it);
+        auto it_override = result_overridability_map.find(delete_key);
+        if (it_override != result_overridability_map.end())
+            result_overridability_map.erase(it_override);
+    }
+
+    create_query_ptr.changes.clear();
+    for (const auto & [name, value] : result_changes_map)
+        create_query_ptr.changes.emplace_back(name, value);
+    create_query_ptr.overridability = std::move(result_overridability_map);
+
+    if (create_query_ptr.changes.empty())
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Named collection cannot be empty (collection name: {})",
+            collection_name);
+
+    chassert(create_query_ptr.collection_name == alter_query.collection_name);
+    for (const auto & [name, value] : alter_query.changes)
+    {
+        auto it_override = alter_query.overridability.find(name);
+        if (it_override != alter_query.overridability.end())
+            setOrUpdate<String, true>(name, convertFieldToString(value), it_override->second);
+        else
+            setOrUpdate<String, true>(name, convertFieldToString(value), {});
+    }
+
+    for (const auto & key : alter_query.delete_keys)
+        remove<true>(key);
 }
 
 template String NamedCollection::get<String>(const NamedCollection::Key & key) const;

--- a/src/Common/NamedCollections/NamedCollections.h
+++ b/src/Common/NamedCollections/NamedCollections.h
@@ -1,6 +1,9 @@
 #pragma once
-#include <Interpreters/Context.h>
+
 #include <Common/NamedCollections/NamedCollections_fwd.h>
+#include <Parsers/ASTCreateNamedCollectionQuery.h>
+#include <Parsers/ASTAlterNamedCollectionQuery.h>
+
 
 namespace Poco { namespace Util { class AbstractConfiguration; } }
 
@@ -24,18 +27,12 @@ public:
     using Keys = std::set<Key, std::less<>>;
     enum class SourceId : uint8_t
     {
+        /// None source_id is possible only if the object is a
+        /// duplicate of some named collection. See `duplicate` method.
         NONE = 0,
         CONFIG = 1,
         SQL = 2,
     };
-
-    static MutableNamedCollectionPtr create(
-        const Poco::Util::AbstractConfiguration & config,
-        const std::string & collection_name,
-        const std::string & collection_path,
-        const Keys & keys,
-        SourceId source_id_,
-        bool is_mutable_);
 
     bool has(const Key & key) const;
 
@@ -61,6 +58,7 @@ public:
 
     template <bool locked = false> void remove(const Key & key);
 
+    /// Creates mutable, with NONE source id full copy.
     MutableNamedCollectionPtr duplicate() const;
 
     Keys getKeys(ssize_t depth = -1, const std::string & prefix = "") const;
@@ -76,25 +74,72 @@ public:
 
     bool isMutable() const { return is_mutable; }
 
-    SourceId getSourceId() const { return source_id; }
+    virtual SourceId getSourceId() const { return SourceId::NONE; }
 
-private:
+    virtual String getCreateStatement(bool /*show_secrects*/) { return  {}; }
+
+    virtual void update(const ASTAlterNamedCollectionQuery & query);
+
+    virtual ~NamedCollection();
+
+protected:
     class Impl;
     using ImplPtr = std::unique_ptr<Impl>;
-
     NamedCollection(
         ImplPtr pimpl_,
         const std::string & collection_name,
-        SourceId source_id,
-        bool is_mutable);
+        bool is_mutable_
+    );
 
     void assertMutable() const;
 
+
     ImplPtr pimpl;
     const std::string collection_name;
-    const SourceId source_id;
     const bool is_mutable;
     mutable std::mutex mutex;
+};
+
+class NamedCollectionFromSQL final : public NamedCollection
+{
+public:
+    static MutableNamedCollectionPtr create(const ASTCreateNamedCollectionQuery & query);
+
+    String getCreateStatement(bool show_secrects) override;
+
+    void update(const ASTAlterNamedCollectionQuery & query) override;
+
+    NamedCollection::SourceId getSourceId() const override { return SourceId::SQL; }
+
+private:
+    explicit NamedCollectionFromSQL(const ASTCreateNamedCollectionQuery & query_);
+
+    ASTCreateNamedCollectionQuery create_query_ptr;
+};
+
+class NamedCollectionFromConfig final : public NamedCollection
+{
+public:
+
+    static MutableNamedCollectionPtr create(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & collection_name,
+        const std::string & collection_path,
+        const Keys & keys);
+
+    String getCreateStatement(bool /*show_secrects*/) override { return {}; }
+
+    void update(const ASTAlterNamedCollectionQuery & /*query*/) override { NamedCollection::assertMutable(); }
+
+    NamedCollection::SourceId getSourceId() const override { return SourceId::CONFIG; }
+
+private:
+
+    NamedCollectionFromConfig(
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & collection_name,
+        const std::string & collection_path,
+        const Keys & keys);
 };
 
 }

--- a/src/Common/NamedCollections/NamedCollectionsFactory.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.cpp
@@ -1,8 +1,10 @@
-#include <Common/NamedCollections/NamedCollectionsFactory.h>
-#include <Common/NamedCollections/NamedCollectionConfiguration.h>
-#include <Common/NamedCollections/NamedCollectionsMetadataStorage.h>
 #include <base/sleep.h>
+#include <Common/NamedCollections/NamedCollectionConfiguration.h>
+#include <Common/NamedCollections/NamedCollectionsFactory.h>
+#include <Common/NamedCollections/NamedCollectionsMetadataStorage.h>
 #include <Common/ZooKeeper/KeeperException.h>
+#include <Core/BackgroundSchedulePool.h>
+#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -12,6 +14,7 @@ namespace ErrorCodes
     extern const int NAMED_COLLECTION_DOESNT_EXIST;
     extern const int NAMED_COLLECTION_ALREADY_EXISTS;
     extern const int NAMED_COLLECTION_IS_IMMUTABLE;
+    extern const int LOGICAL_ERROR;
 }
 
 NamedCollectionFactory & NamedCollectionFactory::instance()
@@ -92,7 +95,7 @@ MutableNamedCollectionPtr NamedCollectionFactory::getMutable(
             "There is no named collection `{}`",
             collection_name);
     }
-    else if (!collection->isMutable())
+    if (!collection->isMutable())
     {
         throw Exception(
             ErrorCodes::NAMED_COLLECTION_IS_IMMUTABLE,
@@ -197,8 +200,8 @@ namespace
                 keys.emplace(path.substr(collection_prefix.size() + 1));
         }
 
-        return NamedCollection::create(
-            config, collection_name, collection_prefix, keys, NamedCollection::SourceId::CONFIG, /* is_mutable */false);
+        return NamedCollectionFromConfig::create(
+            config, collection_name, collection_prefix, keys);
     }
 
     NamedCollectionsMap getNamedCollections(const Poco::Util::AbstractConfiguration & config)
@@ -236,7 +239,7 @@ bool NamedCollectionFactory::loadIfNot([[maybe_unused]] std::lock_guard<std::mut
     loadFromConfig(context->getConfigRef(), lock);
     loadFromSQL(lock);
 
-    if (metadata_storage->supportsPeriodicUpdate())
+    if (metadata_storage->isReplicated())
     {
         update_task = context->getSchedulePool().createTask("NamedCollectionsMetadataStorage", [this]{ updateFunc(); });
         update_task->activate();
@@ -318,33 +321,37 @@ void NamedCollectionFactory::updateFromSQL(const ASTAlterNamedCollectionQuery & 
     std::lock_guard lock(mutex);
     loadIfNot(lock);
 
-    if (!exists(query.collection_name, lock))
+    auto collection_name = query.collection_name;
+    if (!exists(collection_name, lock))
     {
         if (query.if_exists)
             return;
 
         throw Exception(
             ErrorCodes::NAMED_COLLECTION_DOESNT_EXIST,
-            "Cannot remove collection `{}`, because it doesn't exist",
-            query.collection_name);
+            "Cannot update collection `{}`, because it doesn't exist",
+            collection_name);
     }
+    auto updated_collection_ptr = metadata_storage->update(query);
 
-    metadata_storage->update(query);
-
-    auto collection = getMutable(query.collection_name, lock);
-    auto collection_lock = collection->lock();
-
-    for (const auto & [name, value] : query.changes)
+    auto it = loaded_named_collections.find(collection_name);
+    if (it == loaded_named_collections.end())
     {
-        auto it_override = query.overridability.find(name);
-        if (it_override != query.overridability.end())
-            collection->setOrUpdate<String, true>(name, convertFieldToString(value), it_override->second);
-        else
-            collection->setOrUpdate<String, true>(name, convertFieldToString(value), {});
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "The named collection {} unexpectedly does not exist.",
+            collection_name);
     }
 
-    for (const auto & key : query.delete_keys)
-        collection->remove<true>(key);
+    if (!it->second->isMutable())
+    {
+        throw Exception(
+            ErrorCodes::NAMED_COLLECTION_IS_IMMUTABLE,
+            "Cannot get collection `{}` for modification, "
+            "because collection was defined as immutable",
+            collection_name);
+    }
+    it->second = updated_collection_ptr;
 }
 
 void NamedCollectionFactory::reloadFromSQL()
@@ -356,6 +363,13 @@ void NamedCollectionFactory::reloadFromSQL()
     auto collections = metadata_storage->getAll();
     removeById(NamedCollection::SourceId::SQL, lock);
     add(std::move(collections), lock);
+}
+
+bool NamedCollectionFactory::usesReplicatedStorage()
+{
+    std::lock_guard lock(mutex);
+    loadIfNot(lock);
+    return metadata_storage->isReplicated();
 }
 
 void NamedCollectionFactory::updateFunc()

--- a/src/Common/NamedCollections/NamedCollectionsFactory.h
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.h
@@ -1,7 +1,10 @@
 #pragma once
+
 #include <Common/NamedCollections/NamedCollections.h>
 #include <Common/NamedCollections/NamedCollectionsMetadataStorage.h>
 #include <Common/logger_useful.h>
+#include <Core/BackgroundSchedulePoolTaskHolder.h>
+#include <boost/noncopyable.hpp>
 
 namespace DB
 {
@@ -34,6 +37,8 @@ public:
 
     void updateFromSQL(const ASTAlterNamedCollectionQuery & query);
 
+    bool usesReplicatedStorage();
+
     void loadIfNot();
 
     void shutdown();
@@ -42,12 +47,12 @@ protected:
     mutable NamedCollectionsMap loaded_named_collections;
     mutable std::mutex mutex;
 
-    LoggerPtr log = getLogger("NamedCollectionFactory");
+    const LoggerPtr log = getLogger("NamedCollectionFactory");
 
     bool loaded = false;
     std::atomic<bool> shutdown_called = false;
     std::unique_ptr<NamedCollectionsMetadataStorage> metadata_storage;
-    BackgroundSchedulePool::TaskHolder update_task;
+    BackgroundSchedulePoolTaskHolder update_task;
 
     bool loadIfNot(std::lock_guard<std::mutex> & lock);
 

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.cpp
@@ -1,18 +1,22 @@
-#include <Common/NamedCollections/NamedCollectionsMetadataStorage.h>
+#include <filesystem>
+#include <IO/FileEncryptionCommon.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromFile.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+#include <Parsers/ParserCreateQuery.h>
+#include <Parsers/parseQuery.h>
+#include <Parsers/formatAST.h>
+#include <boost/algorithm/hex.hpp>
 #include <Common/NamedCollections/NamedCollectionConfiguration.h>
-#include <Common/escapeForFileName.h>
-#include <Common/logger_useful.h>
+#include <Common/NamedCollections/NamedCollectionsMetadataStorage.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ZooKeeper/KeeperException.h>
 // #include <Common/ZooKeeper/ZooKeeper.h>
-#include <IO/WriteBufferFromFile.h>
-#include <IO/ReadBufferFromFile.h>
-#include <IO/WriteHelpers.h>
-#include <Parsers/parseQuery.h>
-#include <Parsers/ParserCreateQuery.h>
-#include <Parsers/formatAST.h>
-#include <Interpreters/Context.h>
-#include <filesystem>
+#include <Common/escapeForFileName.h>
+#include <Common/logger_useful.h>
 
 namespace fs = std::filesystem;
 
@@ -25,25 +29,13 @@ namespace ErrorCodes
     extern const int INVALID_CONFIG_PARAMETER;
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 static const std::string named_collections_storage_config_path = "named_collections_storage";
 
 namespace
 {
-    MutableNamedCollectionPtr createNamedCollectionFromAST(const ASTCreateNamedCollectionQuery & query)
-    {
-        const auto & collection_name = query.collection_name;
-        const auto config = NamedCollectionConfiguration::createConfiguration(collection_name, query.changes, query.overridability);
-
-        std::set<std::string, std::less<>> keys;
-        for (const auto & [name, _] : query.changes)
-            keys.insert(name);
-
-        return NamedCollection::create(
-            *config, collection_name, "", keys, NamedCollection::SourceId::SQL, /* is_mutable */true);
-    }
-
     std::string getFileName(const std::string & collection_name)
     {
         return escapeForFileName(collection_name) + ".sql";
@@ -67,15 +59,15 @@ public:
 
     virtual bool removeIfExists(const std::string & path) = 0;
 
-    virtual bool supportsPeriodicUpdate() const = 0;
+    virtual bool isReplicated() const = 0;
 
     virtual bool waitUpdate(size_t /* timeout */) { return false; }
 };
 
 
-class NamedCollectionsMetadataStorage::LocalStorage : public INamedCollectionsStorage, private WithContext
+class NamedCollectionsMetadataStorage::LocalStorage : public INamedCollectionsStorage, protected WithContext
 {
-private:
+protected:
     std::string root_path;
 
 public:
@@ -89,7 +81,7 @@ public:
 
     ~LocalStorage() override = default;
 
-    bool supportsPeriodicUpdate() const override { return false; }
+    bool isReplicated() const override { return false; }
 
     std::vector<std::string> list() const override
     {
@@ -115,64 +107,80 @@ public:
         return elements;
     }
 
-    bool exists(const std::string & path) const override
+    bool exists(const std::string & file_name) const override
     {
-        return fs::exists(getPath(path));
+        return fs::exists(getPath(file_name));
     }
 
-    std::string read(const std::string & path) const override
+    std::string read(const std::string & file_name) const override
     {
-        ReadBufferFromFile in(getPath(path));
+        ReadBufferFromFile in(getPath(file_name));
         std::string data;
         readStringUntilEOF(data, in);
+        return readHook(data);
+    }
+
+    virtual std::string readHook(const std::string & data) const
+    {
         return data;
     }
 
-    void write(const std::string & path, const std::string & data, bool replace) override
+    void write(const std::string & file_name, const std::string & data, bool replace) override
     {
-        if (!replace && fs::exists(path))
+        if (!replace && fs::exists(file_name))
         {
             throw Exception(
                 ErrorCodes::NAMED_COLLECTION_ALREADY_EXISTS,
                 "Metadata file {} for named collection already exists",
-                path);
+                file_name);
         }
 
         fs::create_directories(root_path);
 
-        auto tmp_path = getPath(path + ".tmp");
-        WriteBufferFromFile out(tmp_path, data.size(), O_WRONLY | O_CREAT | O_EXCL);
-        writeString(data, out);
+        auto tmp_path = getPath(file_name + ".tmp");
+        auto write_data = writeHook(data);
+        WriteBufferFromFile out(tmp_path, write_data.size(), O_WRONLY | O_CREAT | O_EXCL);
+        writeString(write_data, out);
 
         out.next();
         if (getContext()->getSettingsRef().fsync_metadata)
             out.sync();
         out.close();
 
-        fs::rename(tmp_path, getPath(path));
+        fs::rename(tmp_path, getPath(file_name));
     }
 
-    void remove(const std::string & path) override
+    virtual std::string writeHook(const std::string & data) const
     {
-        if (!removeIfExists(getPath(path)))
+        return data;
+    }
+
+    void remove(const std::string & file_name) override
+    {
+        if (!removeIfExists(file_name))
         {
             throw Exception(
                 ErrorCodes::NAMED_COLLECTION_DOESNT_EXIST,
-                "Cannot remove `{}`, because it doesn't exist", path);
+                "Cannot remove `{}`, because it doesn't exist", file_name);
         }
     }
 
-    bool removeIfExists(const std::string & path) override
+    bool removeIfExists(const std::string & file_name) override
     {
-        return fs::remove(getPath(path));
+        return fs::remove(getPath(file_name));
+    }
+
+protected:
+    std::string getPath(const std::string & file_name) const
+    {
+        const auto file_name_as_path = fs::path(file_name);
+        if (file_name_as_path.is_absolute())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Filename {} cannot be an absolute path", file_name);
+
+        return fs::path(root_path) / file_name_as_path;
     }
 
 private:
-    std::string getPath(const std::string & path) const
-    {
-        return fs::path(root_path) / path;
-    }
-
     /// Delete .tmp files. They could be left undeleted in case of
     /// some exception or abrupt server restart.
     void cleanup()
@@ -189,6 +197,88 @@ private:
     }
 };
 
+#if USE_SSL
+
+template <typename BaseMetadataStorage>
+class NamedCollectionsMetadataStorageEncrypted : public BaseMetadataStorage
+{
+public:
+    NamedCollectionsMetadataStorageEncrypted(ContextPtr context_, const std::string & path_)
+        : BaseMetadataStorage(context_, path_)
+    {
+        const auto & config = BaseMetadataStorage::getContext()->getConfigRef();
+        auto key_hex = config.getRawString("named_collections_storage.key_hex", "");
+        try
+        {
+            key = boost::algorithm::unhex(key_hex);
+            key_fingerprint = FileEncryption::calculateKeyFingerprint(key);
+        }
+        catch (const std::exception &)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot read key_hex, check for valid characters [0-9a-fA-F] and length");
+        }
+
+        algorithm = FileEncryption::parseAlgorithmFromString(config.getString("named_collections_storage.algorithm", "aes_128_ctr"));
+    }
+
+    std::string readHook(const std::string & data) const override
+    {
+        ReadBufferFromString in(data);
+
+        FileEncryption::Header header;
+        try
+        {
+            header.read(in);
+        }
+        catch (Exception & e)
+        {
+            e.addMessage("While reading the header of encrypted data");
+            throw;
+        }
+
+        Memory<> encrypted_buffer(in.available());
+        size_t bytes_read = 0;
+        while (bytes_read < encrypted_buffer.size() && !in.eof())
+        {
+            bytes_read += in.read(encrypted_buffer.data() + bytes_read, encrypted_buffer.size() - bytes_read);
+        }
+
+        std::string decrypted_buffer;
+        decrypted_buffer.resize(bytes_read);
+        FileEncryption::Encryptor encryptor(header.algorithm, key, header.init_vector);
+        encryptor.decrypt(encrypted_buffer.data(), bytes_read, decrypted_buffer.data());
+
+        return decrypted_buffer;
+    }
+
+    std::string writeHook(const std::string & data) const override
+    {
+        FileEncryption::Header header{
+            .algorithm = algorithm,
+            .key_fingerprint = key_fingerprint,
+            .init_vector = FileEncryption::InitVector::random()
+        };
+
+        FileEncryption::Encryptor encryptor(header.algorithm, key, header.init_vector);
+        WriteBufferFromOwnString out;
+        header.write(out);
+        encryptor.encrypt(data.data(), data.size(), out);
+        return std::string(out.str());
+    }
+
+private:
+    std::string key;
+    UInt128 key_fingerprint;
+    FileEncryption::Algorithm algorithm;
+};
+
+class NamedCollectionsMetadataStorage::LocalStorageEncrypted : public NamedCollectionsMetadataStorageEncrypted<NamedCollectionsMetadataStorage::LocalStorage>
+{
+    using NamedCollectionsMetadataStorageEncrypted<NamedCollectionsMetadataStorage::LocalStorage>::NamedCollectionsMetadataStorageEncrypted;
+};
+
+#endif
+
 NamedCollectionsMetadataStorage::NamedCollectionsMetadataStorage(
     std::shared_ptr<INamedCollectionsStorage> storage_,
     ContextPtr context_)
@@ -200,7 +290,7 @@ NamedCollectionsMetadataStorage::NamedCollectionsMetadataStorage(
 MutableNamedCollectionPtr NamedCollectionsMetadataStorage::get(const std::string & collection_name) const
 {
     const auto query = readCreateQuery(collection_name);
-    return createNamedCollectionFromAST(query);
+    return NamedCollectionFromSQL::create(query);
 }
 
 NamedCollectionsMap NamedCollectionsMetadataStorage::getAll() const
@@ -220,10 +310,11 @@ NamedCollectionsMap NamedCollectionsMetadataStorage::getAll() const
     return result;
 }
 
-MutableNamedCollectionPtr NamedCollectionsMetadataStorage::create(const ASTCreateNamedCollectionQuery & query)
+MutableNamedCollectionPtr NamedCollectionsMetadataStorage::create(const ASTCreateNamedCollectionQuery & create_query)
 {
-    writeCreateQuery(query);
-    return createNamedCollectionFromAST(query);
+    auto collection_ptr = NamedCollectionFromSQL::create(create_query);
+    writeCreateQuery(create_query.collection_name, collection_ptr->getCreateStatement(true));
+    return collection_ptr;
 }
 
 void NamedCollectionsMetadataStorage::remove(const std::string & collection_name)
@@ -236,64 +327,14 @@ bool NamedCollectionsMetadataStorage::removeIfExists(const std::string & collect
     return storage->removeIfExists(getFileName(collection_name));
 }
 
-void NamedCollectionsMetadataStorage::update(const ASTAlterNamedCollectionQuery & query)
+MutableNamedCollectionPtr NamedCollectionsMetadataStorage::update(const ASTAlterNamedCollectionQuery & query)
 {
     auto create_query = readCreateQuery(query.collection_name);
+    auto collection_ptr = NamedCollectionFromSQL::create(create_query);
+    collection_ptr->update(query);
+    writeCreateQuery(query.collection_name, collection_ptr->getCreateStatement(true), true);
 
-    std::unordered_map<std::string, Field> result_changes_map;
-    for (const auto & [name, value] : query.changes)
-    {
-        auto [it, inserted] = result_changes_map.emplace(name, value);
-        if (!inserted)
-        {
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Value with key `{}` is used twice in the SET query (collection name: {})",
-                name, query.collection_name);
-        }
-    }
-
-    for (const auto & [name, value] : create_query.changes)
-        result_changes_map.emplace(name, value);
-
-    std::unordered_map<std::string, bool> result_overridability_map;
-    for (const auto & [name, value] : query.overridability)
-        result_overridability_map.emplace(name, value);
-    for (const auto & [name, value] : create_query.overridability)
-        result_overridability_map.emplace(name, value);
-
-    for (const auto & delete_key : query.delete_keys)
-    {
-        auto it = result_changes_map.find(delete_key);
-        if (it == result_changes_map.end())
-        {
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Cannot delete key `{}` because it does not exist in collection",
-                delete_key);
-        }
-        else
-        {
-            result_changes_map.erase(it);
-            auto it_override = result_overridability_map.find(delete_key);
-            if (it_override != result_overridability_map.end())
-                result_overridability_map.erase(it_override);
-        }
-    }
-
-    create_query.changes.clear();
-    for (const auto & [name, value] : result_changes_map)
-        create_query.changes.emplace_back(name, value);
-    create_query.overridability = std::move(result_overridability_map);
-
-    if (create_query.changes.empty())
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Named collection cannot be empty (collection name: {})",
-            query.collection_name);
-
-    chassert(create_query.collection_name == query.collection_name);
-    writeCreateQuery(create_query, true);
+    return collection_ptr;
 }
 
 std::vector<std::string> NamedCollectionsMetadataStorage::listCollections() const
@@ -302,7 +343,7 @@ std::vector<std::string> NamedCollectionsMetadataStorage::listCollections() cons
     std::vector<std::string> collections;
     collections.reserve(paths.size());
     for (const auto & path : paths)
-        collections.push_back(std::filesystem::path(path).stem());
+        collections.push_back(unescapeForFileName(std::filesystem::path(path).stem()));
     return collections;
 }
 
@@ -318,25 +359,19 @@ ASTCreateNamedCollectionQuery NamedCollectionsMetadataStorage::readCreateQuery(c
     return create_query;
 }
 
-void NamedCollectionsMetadataStorage::writeCreateQuery(const ASTCreateNamedCollectionQuery & query, bool replace)
+void NamedCollectionsMetadataStorage::writeCreateQuery(const String & collection_name, const String & create_statement, bool replace)
 {
-    auto normalized_query = query.clone();
-    auto & changes = typeid_cast<ASTCreateNamedCollectionQuery *>(normalized_query.get())->changes;
-    ::sort(
-        changes.begin(), changes.end(),
-        [](const SettingChange & lhs, const SettingChange & rhs) { return lhs.name < rhs.name; });
-
-    storage->write(getFileName(query.collection_name), serializeAST(*normalized_query), replace);
+    storage->write(getFileName(collection_name), create_statement, replace);
 }
 
-bool NamedCollectionsMetadataStorage::supportsPeriodicUpdate() const
+bool NamedCollectionsMetadataStorage::isReplicated() const
 {
-    return storage->supportsPeriodicUpdate();
+    return storage->isReplicated();
 }
 
 bool NamedCollectionsMetadataStorage::waitUpdate()
 {
-    if (!storage->supportsPeriodicUpdate())
+    if (!storage->isReplicated())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Periodic updates are not supported");
 
     const auto & config = Context::getGlobalContextInstance()->getConfigRef();
@@ -350,7 +385,7 @@ std::unique_ptr<NamedCollectionsMetadataStorage> NamedCollectionsMetadataStorage
     const auto & config = context_->getConfigRef();
     const auto storage_type = config.getString(named_collections_storage_config_path + ".type", "local");
 
-    if (storage_type == "local")
+    if (storage_type == "local" || storage_type == "local_encrypted")
     {
         const auto path = config.getString(
             named_collections_storage_config_path + ".path",
@@ -359,7 +394,18 @@ std::unique_ptr<NamedCollectionsMetadataStorage> NamedCollectionsMetadataStorage
         LOG_TRACE(getLogger("NamedCollectionsMetadataStorage"),
                   "Using local storage for named collections at path: {}", path);
 
-        auto local_storage = std::make_unique<NamedCollectionsMetadataStorage::LocalStorage>(context_, path);
+        std::unique_ptr<INamedCollectionsStorage> local_storage;
+        if (storage_type == "local")
+            local_storage = std::make_unique<NamedCollectionsMetadataStorage::LocalStorage>(context_, path);
+        else if (storage_type == "local_encrypted")
+        {
+#if USE_SSL
+            local_storage = std::make_unique<NamedCollectionsMetadataStorage::LocalStorageEncrypted>(context_, path);
+#else
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Named collections encryption requires building with SSL support");
+#endif
+        }
+
         return std::unique_ptr<NamedCollectionsMetadataStorage>(
             new NamedCollectionsMetadataStorage(std::move(local_storage), context_));
     }

--- a/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
+++ b/src/Common/NamedCollections/NamedCollectionsMetadataStorage.h
@@ -3,7 +3,7 @@
 #include <Parsers/ASTAlterNamedCollectionQuery.h>
 #include <Parsers/ASTDropNamedCollectionQuery.h>
 #include <Common/NamedCollections/NamedCollections.h>
-#include <Core/BackgroundSchedulePool.h>
+#include <Interpreters/Context_fwd.h>
 
 namespace DB
 {
@@ -23,18 +23,19 @@ public:
 
     bool removeIfExists(const std::string & collection_name);
 
-    void update(const ASTAlterNamedCollectionQuery & query);
+    MutableNamedCollectionPtr update(const ASTAlterNamedCollectionQuery & query);
 
     void shutdown();
 
     /// Return true if update was made
     bool waitUpdate();
 
-    bool supportsPeriodicUpdate() const;
+    bool isReplicated() const;
 
 private:
     class INamedCollectionsStorage;
     class LocalStorage;
+    class LocalStorageEncrypted;
 
     std::shared_ptr<INamedCollectionsStorage> storage;
 
@@ -44,7 +45,7 @@ private:
 
     ASTCreateNamedCollectionQuery readCreateQuery(const std::string & collection_name) const;
 
-    void writeCreateQuery(const ASTCreateNamedCollectionQuery & query, bool replace = false);
+    void writeCreateQuery(const String & collection_name, const String & create_statement, bool replace = false);
 };
 
 

--- a/src/Common/NamedCollections/NamedCollections_fwd.h
+++ b/src/Common/NamedCollections/NamedCollections_fwd.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <map>
 
 namespace DB

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -19,7 +19,6 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int INCORRECT_DISK_INDEX;
-    extern const int DATA_ENCRYPTION_ERROR;
     extern const int NOT_IMPLEMENTED;
 }
 
@@ -42,87 +41,201 @@ namespace
         }
     }
 
+    /// Reads encryption keys from the configuration.
+    void getKeysFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix,
+                           std::map<UInt64, String> & out_keys_by_id, Strings & out_keys_without_id)
+    {
+        Strings config_keys;
+        config.keys(config_prefix, config_keys);
+
+        for (const std::string & config_key : config_keys)
+        {
+            String key;
+            std::optional<UInt64> key_id;
+
+            if ((config_key == "key") || config_key.starts_with("key["))
+            {
+                String key_path = config_prefix + "." + config_key;
+                key = config.getString(key_path);
+                String key_id_path = key_path + "[@id]";
+                if (config.has(key_id_path))
+                    key_id = config.getUInt64(key_id_path);
+            }
+            else if ((config_key == "key_hex") || config_key.starts_with("key_hex["))
+            {
+                String key_path = config_prefix + "." + config_key;
+                key = unhexKey(config.getString(key_path));
+                String key_id_path = key_path + "[@id]";
+                if (config.has(key_id_path))
+                    key_id = config.getUInt64(key_id_path);
+            }
+            else
+                continue;
+
+            if (key_id)
+            {
+                if (!out_keys_by_id.contains(*key_id))
+                    out_keys_by_id[*key_id] = key;
+                else
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Multiple keys specified for same ID {}", *key_id);
+            }
+            else
+                out_keys_without_id.push_back(key);
+        }
+
+        if (out_keys_by_id.empty() && out_keys_without_id.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "No encryption keys found");
+
+        if (out_keys_by_id.empty() && (out_keys_without_id.size() == 1))
+        {
+            out_keys_by_id[0] = out_keys_without_id.front();
+            out_keys_without_id.clear();
+        }
+    }
+
+    /// Reads the current encryption key from the configuration.
+    String getCurrentKeyFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix,
+                                   const std::map<UInt64, String> & keys_by_id, const Strings & keys_without_id)
+    {
+        String key_path = config_prefix + ".current_key";
+        String key_hex_path = config_prefix + ".current_key_hex";
+        String key_id_path = config_prefix + ".current_key_id";
+
+        if (config.has(key_path) + config.has(key_hex_path) + config.has(key_id_path) > 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The current key is specified multiple times");
+
+        auto check_current_key_found = [&](const String & current_key_)
+        {
+            for (const auto & [_, key] : keys_by_id)
+            {
+                if (key == current_key_)
+                    return;
+            }
+            for (const auto & key : keys_without_id)
+            {
+                if (key == current_key_)
+                    return;
+            }
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The current key is not found in keys");
+        };
+
+        if (config.has(key_path))
+        {
+            String current_key = config.getString(key_path);
+            check_current_key_found(current_key);
+            return current_key;
+        }
+        else if (config.has(key_hex_path))
+        {
+            String current_key = unhexKey(config.getString(key_hex_path));
+            check_current_key_found(current_key);
+            return current_key;
+        }
+        else if (config.has(key_id_path))
+        {
+            UInt64 current_key_id = config.getUInt64(key_id_path);
+            auto it = keys_by_id.find(current_key_id);
+            if (it == keys_by_id.end())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not found a key with the current ID {}", current_key_id);
+            return it->second;
+        }
+        else if (keys_by_id.size() == 1 && keys_without_id.empty() && keys_by_id.begin()->first == 0)
+        {
+            /// There is only a single key defined with id=0, so we can choose it as current.
+            return keys_by_id.begin()->second;
+        }
+        else
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The current key is not specified");
+        }
+    }
+
+    /// Reads the current encryption algorithm from the configuration.
+    Algorithm getCurrentAlgorithmFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+    {
+        String path = config_prefix + ".algorithm";
+        if (!config.has(path))
+            return DEFAULT_ENCRYPTION_ALGORITHM;
+        return parseAlgorithmFromString(config.getString(path));
+    }
+
+    /// Reads the name of a wrapped disk & the path on the wrapped disk and then finds that disk in a disk map.
+    void getDiskAndPathFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const DisksMap & map,
+                                  DiskPtr & out_disk, String & out_path)
+    {
+        String disk_name = config.getString(config_prefix + ".disk", "");
+        if (disk_name.empty())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS, "Name of the wrapped disk must not be empty. Encrypted disk is a wrapper over another disk");
+
+        auto disk_it = map.find(disk_name);
+        if (disk_it == map.end())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS, "The wrapped disk must have been announced earlier. No disk with name {}", disk_name);
+
+        out_disk = disk_it->second;
+
+        out_path = config.getString(config_prefix + ".path", "");
+        if (!out_path.empty() && (out_path.back() != '/'))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Disk path must ends with '/', but '{}' doesn't.", quoteString(out_path));
+    }
+
+    /// Parses the settings of an encrypted disk from the configuration.
     std::unique_ptr<const DiskEncryptedSettings> parseDiskEncryptedSettings(
-        const String & name, const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const DisksMap & map)
+        const String & disk_name,
+        const Poco::Util::AbstractConfiguration & config,
+        const String & config_prefix,
+        const DisksMap & disk_map)
     {
         try
         {
             auto res = std::make_unique<DiskEncryptedSettings>();
-            res->current_algorithm = DEFAULT_ENCRYPTION_ALGORITHM;
-            if (config.has(config_prefix + ".algorithm"))
-                parseFromString(res->current_algorithm, config.getString(config_prefix + ".algorithm"));
 
-            Strings config_keys;
-            config.keys(config_prefix, config_keys);
-            for (const std::string & config_key : config_keys)
+            std::map<UInt64, String> keys_by_id;
+            Strings keys_without_id;
+            getKeysFromConfig(config, config_prefix, keys_by_id, keys_without_id);
+
+            for (const auto & [key_id, key] : keys_by_id)
             {
-                String key;
-                UInt64 key_id;
+                auto fingerprint = calculateKeyFingerprint(key);
+                res->all_keys[fingerprint] = key;
 
-                if ((config_key == "key") || config_key.starts_with("key["))
-                {
-                    key = config.getString(config_prefix + "." + config_key, "");
-                    key_id = config.getUInt64(config_prefix + "." + config_key + "[@id]", 0);
-                }
-                else if ((config_key == "key_hex") || config_key.starts_with("key_hex["))
-                {
-                    key = unhexKey(config.getString(config_prefix + "." + config_key, ""));
-                    key_id = config.getUInt64(config_prefix + "." + config_key + "[@id]", 0);
-                }
-                else
-                    continue;
-
-                if (res->keys.contains(key_id))
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Multiple keys have the same ID {}", key_id);
-                res->keys[key_id] = key;
+                /// Version 1 used key fingerprints based on the key id.
+                /// We have to add such fingerprints to the map too to support reading files encrypted by version 1.
+                auto v1_fingerprint = calculateV1KeyFingerprint(key, key_id);
+                res->all_keys[v1_fingerprint] = key;
             }
 
-            if (res->keys.empty())
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "No keys, an encrypted disk needs keys to work");
-
-            if (!config.has(config_prefix + ".current_key_id"))
+            for (const auto & key : keys_without_id)
             {
-                /// In case of multiple keys, current_key_id is mandatory
-                if (res->keys.size() > 1)
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
-
-                /// If there is only one key with non zero ID, curren_key_id should be defined.
-                if (res->keys.size() == 1 && !res->keys.contains(0))
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+                auto fingerprint = calculateKeyFingerprint(key);
+                res->all_keys[fingerprint] = key;
             }
 
-            res->current_key_id = config.getUInt64(config_prefix + ".current_key_id", 0);
-            if (!res->keys.contains(res->current_key_id))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not found a key with the current ID {}", res->current_key_id);
-            FileEncryption::checkKeySize(res->current_algorithm, res->keys[res->current_key_id].size());
+            String current_key = getCurrentKeyFromConfig(config, config_prefix, keys_by_id, keys_without_id);
+            res->current_key = current_key;
+            res->current_key_fingerprint = calculateKeyFingerprint(current_key);
 
-            String wrapped_disk_name = config.getString(config_prefix + ".disk", "");
-            if (wrapped_disk_name.empty())
-                throw Exception(
-                    ErrorCodes::BAD_ARGUMENTS,
-                    "Name of the wrapped disk must not be empty. Encrypted disk is a wrapper over another disk");
+            res->current_algorithm = getCurrentAlgorithmFromConfig(config, config_prefix);
 
-            auto wrapped_disk_it = map.find(wrapped_disk_name);
-            if (wrapped_disk_it == map.end())
-                throw Exception(
-                    ErrorCodes::BAD_ARGUMENTS,
-                    "The wrapped disk must have been announced earlier. No disk with name {}",
-                    wrapped_disk_name);
-            res->wrapped_disk = wrapped_disk_it->second;
+            FileEncryption::checkKeySize(res->current_key.size(), res->current_algorithm);
 
-            res->disk_path = config.getString(config_prefix + ".path", "");
-            if (!res->disk_path.empty() && (res->disk_path.back() != '/'))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Disk path must ends with '/', but '{}' doesn't.", quoteString(res->disk_path));
+            DiskPtr wrapped_disk;
+            String disk_path;
+            getDiskAndPathFromConfig(config, config_prefix, disk_map, wrapped_disk, disk_path);
+            res->wrapped_disk = wrapped_disk;
+            res->disk_path = disk_path;
 
             return res;
         }
         catch (Exception & e)
         {
-            e.addMessage("Disk " + name);
+            e.addMessage("Disk " + disk_name);
             throw;
         }
     }
 
+    /// Reads the header of an encrypted file.
     FileEncryption::Header readHeader(ReadBufferFromFileBase & read_buffer)
     {
         try
@@ -136,24 +249,6 @@ namespace
             e.addMessage("While reading the header of encrypted file " + quoteString(read_buffer.getFileName()));
             throw;
         }
-    }
-
-    String getKey(const String & path, const FileEncryption::Header & header, const DiskEncryptedSettings & settings)
-    {
-        auto it = settings.keys.find(header.key_id);
-        if (it == settings.keys.end())
-            throw Exception(
-                ErrorCodes::DATA_ENCRYPTION_ERROR,
-                "Not found a key with ID {} required to decipher file {}",
-                header.key_id,
-                quoteString(path));
-
-        String key = it->second;
-        if (calculateKeyHash(key) != header.key_hash)
-            throw Exception(
-                ErrorCodes::DATA_ENCRYPTION_ERROR, "Wrong key with ID {}, could not decipher file {}", header.key_id, quoteString(path));
-
-        return key;
     }
 
     bool inline isSameDiskType(const IDisk & one, const IDisk & another)
@@ -239,7 +334,7 @@ void DiskEncrypted::copyDirectoryContent(const String & from_dir, const std::sha
         {
             auto from_settings = current_settings.get();
             auto to_settings = to_disk_enc->current_settings.get();
-            if (from_settings->keys == to_settings->keys)
+            if (from_settings->all_keys == to_settings->all_keys)
             {
                 /// Keys are the same so we can simply copy the encrypted file.
                 auto wrapped_from_path = wrappedPath(from_dir);
@@ -271,7 +366,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskEncrypted::readFile(
     }
     auto encryption_settings = current_settings.get();
     FileEncryption::Header header = readHeader(*buffer);
-    String key = getKey(path, header, *encryption_settings);
+    String key = encryption_settings->findKeyByFingerprint(header.key_fingerprint, path);
     return std::make_unique<ReadBufferFromEncryptedFile>(settings.local_fs_buffer_size, std::move(buffer), key, header);
 }
 

--- a/src/Disks/DiskEncryptedTransaction.cpp
+++ b/src/Disks/DiskEncryptedTransaction.cpp
@@ -1,6 +1,5 @@
 #include <Disks/DiskEncryptedTransaction.h>
 
-
 #if USE_SSL
 #include <IO/FileEncryptionCommon.h>
 #include <Common/Exception.h>
@@ -38,37 +37,19 @@ FileEncryption::Header readHeader(ReadBufferFromFileBase & read_buffer)
     }
 }
 
-String getCurrentKey(const String & path, const DiskEncryptedSettings & settings)
+}
+
+String DiskEncryptedSettings::findKeyByFingerprint(UInt128 key_fingerprint, const String & path_for_logs) const
 {
-    auto it = settings.keys.find(settings.current_key_id);
-    if (it == settings.keys.end())
+    auto it = all_keys.find(key_fingerprint);
+    if (it == all_keys.end())
+    {
         throw Exception(
             ErrorCodes::DATA_ENCRYPTION_ERROR,
-            "Not found a key with the current ID {} required to cipher file {}",
-            settings.current_key_id,
-            quoteString(path));
-
+            "Not found an encryption key required to decipher file {}",
+            quoteString(path_for_logs));
+    }
     return it->second;
-}
-
-String getKey(const String & path, const FileEncryption::Header & header, const DiskEncryptedSettings & settings)
-{
-    auto it = settings.keys.find(header.key_id);
-    if (it == settings.keys.end())
-        throw Exception(
-            ErrorCodes::DATA_ENCRYPTION_ERROR,
-            "Not found a key with ID {} required to decipher file {}",
-            header.key_id,
-            quoteString(path));
-
-    String key = it->second;
-    if (FileEncryption::calculateKeyHash(key) != header.key_hash)
-        throw Exception(
-            ErrorCodes::DATA_ENCRYPTION_ERROR, "Wrong key with ID {}, could not decipher file {}", header.key_id, quoteString(path));
-
-    return key;
-}
-
 }
 
 void DiskEncryptedTransaction::copyFile(const std::string & from_file_path, const std::string & to_file_path, const ReadSettings & read_settings, const WriteSettings & write_settings)
@@ -98,16 +79,15 @@ std::unique_ptr<WriteBufferFromFileBase> DiskEncryptedTransaction::writeFile( //
             /// Append mode: we continue to use the same header.
             auto read_buffer = delegate_disk->readFile(wrapped_path, ReadSettings().adjustBufferSize(FileEncryption::Header::kSize));
             header = readHeader(*read_buffer);
-            key = getKey(path, header, current_settings);
+            key = current_settings.findKeyByFingerprint(header.key_fingerprint, path);
         }
     }
     if (!old_file_size)
     {
         /// Rewrite mode: we generate a new header.
-        key = getCurrentKey(path, current_settings);
         header.algorithm = current_settings.current_algorithm;
-        header.key_id = current_settings.current_key_id;
-        header.key_hash = FileEncryption::calculateKeyHash(key);
+        key = current_settings.current_key;
+        header.key_fingerprint = current_settings.current_key_fingerprint;
         header.init_vector = FileEncryption::InitVector::random();
     }
     auto buffer = delegate_transaction->writeFile(wrapped_path, buf_size, mode, settings, autocommit);

--- a/src/Disks/DiskEncryptedTransaction.h
+++ b/src/Disks/DiskEncryptedTransaction.h
@@ -18,9 +18,13 @@ struct DiskEncryptedSettings
 {
     DiskPtr wrapped_disk;
     String disk_path;
-    std::unordered_map<UInt64, String> keys;
-    UInt64 current_key_id;
+    String current_key;
+    UInt128 current_key_fingerprint;
     FileEncryption::Algorithm current_algorithm;
+    std::unordered_map<UInt128 /* fingerprint */, String /* key */> all_keys;
+
+    /// Returns an encryption key found by its fingerprint.
+    String findKeyByFingerprint(UInt128 key_fingerprint, const String & path_for_logs) const;
 };
 
 

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -37,8 +37,10 @@ protected:
         auto settings = std::make_unique<DiskEncryptedSettings>();
         settings->wrapped_disk = local_disk;
         settings->current_algorithm = algorithm;
-        settings->keys[0] = key;
-        settings->current_key_id = 0;
+        auto fingerprint = FileEncryption::calculateKeyFingerprint(key);
+        settings->all_keys[fingerprint] = key;
+        settings->current_key = key;
+        settings->current_key_fingerprint = fingerprint;
         settings->disk_path = path;
         encrypted_disk = std::make_shared<DiskEncrypted>("encrypted_disk", std::move(settings));
     }
@@ -251,7 +253,7 @@ TEST_F(DiskEncryptedTest, RandomIV)
 
     String bina = getBinaryRepresentation(getDirectory() + "a.txt");
     String binb = getBinaryRepresentation(getDirectory() + "b.txt");
-    constexpr size_t iv_offset = 16;
+    constexpr size_t iv_offset = 23; /// See the description of the format in the comment for FileEncryption::Header.
     constexpr size_t iv_size = FileEncryption::InitVector::kSize;
     EXPECT_EQ(bina.substr(0, iv_offset), binb.substr(0, iv_offset)); /// Part of the header before IV is the same.
     EXPECT_NE(bina.substr(iv_offset, iv_size), binb.substr(iv_offset, iv_size)); /// IV differs.

--- a/src/IO/FileEncryptionCommon.cpp
+++ b/src/IO/FileEncryptionCommon.cpp
@@ -35,6 +35,7 @@ namespace
             case Algorithm::AES_128_CTR: return EVP_aes_128_ctr();
             case Algorithm::AES_192_CTR: return EVP_aes_192_ctr();
             case Algorithm::AES_256_CTR: return EVP_aes_256_ctr();
+            case Algorithm::MAX: break;
         }
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
@@ -195,10 +196,14 @@ namespace
         return plaintext_size;
     }
 
-    constexpr const char kHeaderSignature[] = "ENC";
-    constexpr const UInt16 kHeaderCurrentVersion = 1;
-}
+    constexpr const std::string_view kHeaderSignature = "ENC";
 
+    UInt128 calculateV1KeyFingerprint(UInt8 small_key_hash, UInt64 key_id)
+    {
+        /// In the version 1 we stored {key_id, very_small_hash(key)} instead of a fingerprint.
+        return static_cast<UInt128>(key_id) | (static_cast<UInt128>(small_key_hash) << 64);
+    }
+}
 
 String toString(Algorithm algorithm)
 {
@@ -207,6 +212,7 @@ String toString(Algorithm algorithm)
         case Algorithm::AES_128_CTR: return "aes_128_ctr";
         case Algorithm::AES_192_CTR: return "aes_192_ctr";
         case Algorithm::AES_256_CTR: return "aes_256_ctr";
+        case Algorithm::MAX: break;
     }
     throw Exception(
         ErrorCodes::BAD_ARGUMENTS,
@@ -214,22 +220,21 @@ String toString(Algorithm algorithm)
         static_cast<int>(algorithm));
 }
 
-void parseFromString(Algorithm & algorithm, const String & str)
+Algorithm parseAlgorithmFromString(const String & str)
 {
     if (boost::iequals(str, "aes_128_ctr"))
-        algorithm = Algorithm::AES_128_CTR;
-    else if (boost::iequals(str, "aes_192_ctr"))
-        algorithm = Algorithm::AES_192_CTR;
-    else if (boost::iequals(str, "aes_256_ctr"))
-        algorithm = Algorithm::AES_256_CTR;
-    else
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Encryption algorithm '{}' is not supported, specify one of the following: aes_128_ctr, aes_192_ctr, aes_256_ctr",
-            str);
+        return Algorithm::AES_128_CTR;
+    if (boost::iequals(str, "aes_192_ctr"))
+        return Algorithm::AES_192_CTR;
+    if (boost::iequals(str, "aes_256_ctr"))
+        return Algorithm::AES_256_CTR;
+    throw Exception(
+        ErrorCodes::BAD_ARGUMENTS,
+        "Encryption algorithm '{}' is not supported, specify one of the following: aes_128_ctr, aes_192_ctr, aes_256_ctr",
+        str);
 }
 
-void checkKeySize(Algorithm algorithm, size_t key_size) { checkKeySize(getCipher(algorithm), key_size); }
+void checkKeySize(size_t key_size, Algorithm algorithm) { checkKeySize(getCipher(algorithm), key_size); }
 
 
 String InitVector::toString() const
@@ -372,54 +377,92 @@ void Encryptor::decrypt(const char * data, size_t size, char * out)
 
 void Header::read(ReadBuffer & in)
 {
-    constexpr size_t header_signature_size = std::size(kHeaderSignature) - 1;
-    char signature[std::size(kHeaderSignature)] = {};
-    in.readStrict(signature, header_signature_size);
-    if (strcmp(signature, kHeaderSignature) != 0)
+    char signature[kHeaderSignature.length()];
+    in.readStrict(signature, kHeaderSignature.length());
+    if (memcmp(signature, kHeaderSignature.data(), kHeaderSignature.length()) != 0)
         throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Wrong signature, this is not an encrypted file");
 
-    UInt16 version;
-    readPODBinary(version, in);
-    if (version != kHeaderCurrentVersion)
+    /// The endianness of how the header is written.
+    /// Starting from version 2 the header is always in little endian.
+    std::endian endian = std::endian::little;
+
+    readBinaryLittleEndian(version, in);
+
+    if (version == 0x0100ULL)
+    {
+        /// Version 1 could write the header of an encrypted file in either little-endian or big-endian.
+        /// So now if we read the version as little-endian and it's 256 that means two things: the version is actually 1 and the whole header is in big endian.
+        endian = std::endian::big;
+        version = 1;
+    }
+
+    if (version < 1 || version > kCurrentVersion)
         throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Version {} of the header is not supported", version);
 
     UInt16 algorithm_u16;
     readPODBinary(algorithm_u16, in);
+    if (std::endian::native != endian)
+        algorithm_u16 = std::byteswap(algorithm_u16);
+    if (algorithm_u16 >= static_cast<UInt16>(Algorithm::MAX))
+        throw Exception(ErrorCodes::DATA_ENCRYPTION_ERROR, "Algorithm {} is not supported", algorithm_u16);
     algorithm = static_cast<Algorithm>(algorithm_u16);
 
-    readPODBinary(key_id, in);
-    readPODBinary(key_hash, in);
+    size_t bytes_to_skip = kSize - kHeaderSignature.length() - sizeof(version) - sizeof(algorithm_u16) - InitVector::kSize;
+
+    if (version < 2)
+    {
+        UInt64 key_id;
+        UInt8 small_key_hash;
+        readPODBinary(key_id, in);
+        readPODBinary(small_key_hash, in);
+        bytes_to_skip -= sizeof(key_id) + sizeof(small_key_hash);
+        if (std::endian::native != endian)
+            key_id = std::byteswap(key_id);
+        key_fingerprint = calculateV1KeyFingerprint(small_key_hash, key_id);
+    }
+    else
+    {
+        readBinaryLittleEndian(key_fingerprint, in);
+        bytes_to_skip -= sizeof(key_fingerprint);
+    }
+
     init_vector.read(in);
 
-    constexpr size_t reserved_size = kSize - header_signature_size - sizeof(version) - sizeof(algorithm_u16) - sizeof(key_id) - sizeof(key_hash) - InitVector::kSize;
-    static_assert(reserved_size < kSize);
-    in.ignore(reserved_size);
+    chassert(bytes_to_skip < kSize);
+    in.ignore(bytes_to_skip);
 }
 
 void Header::write(WriteBuffer & out) const
 {
-    constexpr size_t header_signature_size = std::size(kHeaderSignature) - 1;
-    out.write(kHeaderSignature, header_signature_size);
+    writeString(kHeaderSignature, out);
 
-    UInt16 version = kHeaderCurrentVersion;
-    writePODBinary(version, out);
+    writeBinaryLittleEndian(version, out);
 
     UInt16 algorithm_u16 = static_cast<UInt16>(algorithm);
-    writePODBinary(algorithm_u16, out);
+    writeBinaryLittleEndian(algorithm_u16, out);
 
-    writePODBinary(key_id, out);
-    writePODBinary(key_hash, out);
+    writeBinaryLittleEndian(key_fingerprint, out);
+
     init_vector.write(out);
 
-    constexpr size_t reserved_size = kSize - header_signature_size - sizeof(version) - sizeof(algorithm_u16) - sizeof(key_id) - sizeof(key_hash) - InitVector::kSize;
+    constexpr size_t reserved_size = kSize - kHeaderSignature.length() - sizeof(version) - sizeof(algorithm_u16) - sizeof(key_fingerprint) - InitVector::kSize;
     static_assert(reserved_size < kSize);
-    char reserved_zero_bytes[reserved_size] = {};
-    out.write(reserved_zero_bytes, reserved_size);
+    char zero_bytes[reserved_size] = {};
+    out.write(zero_bytes, reserved_size);
 }
 
-UInt8 calculateKeyHash(const String & key)
+UInt128 calculateKeyFingerprint(const String & key)
 {
-    return static_cast<UInt8>(sipHash64(key.data(), key.size())) & 0x0F;
+    const UInt64 seed0 = 0x4368456E63727970ULL; // ChEncryp
+    const UInt64 seed1 = 0x7465644469736B46ULL; // tedDiskF
+    return sipHash128Keyed(seed0, seed1, key.data(), key.size());
+}
+
+UInt128 calculateV1KeyFingerprint(const String & key, UInt64 key_id)
+{
+    /// In the version 1 we stored {key_id, very_small_hash(key)} instead of a fingerprint.
+    UInt8 small_key_hash = sipHash64(key.data(), key.size()) & 0x0F;
+    return calculateV1KeyFingerprint(small_key_hash, key_id);
 }
 
 }

--- a/src/IO/FileEncryptionCommon.h
+++ b/src/IO/FileEncryptionCommon.h
@@ -23,13 +23,14 @@ enum class Algorithm
     AES_128_CTR, /// Size of key is 16 bytes.
     AES_192_CTR, /// Size of key is 24 bytes.
     AES_256_CTR, /// Size of key is 32 bytes.
+    MAX
 };
 
 String toString(Algorithm algorithm);
-void parseFromString(Algorithm & algorithm, const String & str);
+Algorithm parseAlgorithmFromString(const String & str);
 
 /// Throws an exception if a specified key size doesn't correspond a specified encryption algorithm.
-void checkKeySize(Algorithm algorithm, size_t key_size);
+void checkKeySize(size_t key_size, Algorithm algorithm);
 
 
 /// Initialization vector. Its size is always 16 bytes.
@@ -80,6 +81,7 @@ public:
     /// the initialization vector is increased by an index of the current block
     /// and the index of the current block is calculated from this offset.
     void setOffset(size_t offset_) { offset = offset_; }
+    size_t getOffset() const { return offset; }
 
     /// Encrypts some data.
     /// Also the function moves `offset` by `size` (for successive encryptions).
@@ -102,15 +104,34 @@ private:
 
 
 /// File header which is stored at the beginning of encrypted files.
+///
+/// The format of that header is following:
+/// +--------+------+--------------------------------------------------------------------------+
+/// | offset | size | description                                                              |
+/// +--------+------+--------------------------------------------------------------------------+
+/// |      0 |    3 | 'E', 'N', 'C' (file's signature)                                         |
+/// |      3 |    2 | version of this header (1..2)                                            |
+/// |      5 |    2 | encryption algorithm (0..2, 0=AES_128_CTR, 1=AES_192_CTR, 2=AES_256_CTR) |
+/// |      7 |   16 | fingerprint of encryption key (SipHash)                                  |
+/// |     23 |   16 | initialization vector (randomly generated)                               |
+/// |     39 |   25 | reserved for future use                                                  |
+/// +--------+------+--------------------------------------------------------------------------+
+///
 struct Header
 {
+    /// Versions:
+    /// 1 - Initial version
+    /// 2 - The header of an encrypted file contains the fingerprint of a used encryption key instead of a pair {key_id, very_small_hash(key)}.
+    ///     The header is always stored in little endian.
+    static constexpr const UInt16 kCurrentVersion = 2;
+
+    UInt16 version = kCurrentVersion;
+
+    /// Encryption algorithm.
     Algorithm algorithm = Algorithm::AES_128_CTR;
 
-    /// Identifier of the key to encrypt or decrypt this file.
-    UInt64 key_id = 0;
-
-    /// Hash of the key to encrypt or decrypt this file.
-    UInt8 key_hash = 0;
+    /// Fingerprint of a key.
+    UInt128 key_fingerprint = 0;
 
     InitVector init_vector;
 
@@ -121,9 +142,11 @@ struct Header
     void write(WriteBuffer & out) const;
 };
 
-/// Calculates the hash of a passed key.
-/// 1 byte is enough because this hash is used only for the first check.
-UInt8 calculateKeyHash(const String & key);
+/// Calculates the fingerprint of a passed encryption key.
+UInt128 calculateKeyFingerprint(const String & key);
+
+/// Calculates kind of the fingerprint of a passed encryption key & key ID as it was implemented in version 1.
+UInt128 calculateV1KeyFingerprint(const String & key, UInt64 key_id);
 
 }
 }

--- a/src/IO/ReadBufferFromEncryptedFile.cpp
+++ b/src/IO/ReadBufferFromEncryptedFile.cpp
@@ -21,7 +21,6 @@ ReadBufferFromEncryptedFile::ReadBufferFromEncryptedFile(
     , encryptor(header_.algorithm, key_, header_.init_vector)
 {
     offset = offset_;
-    encryptor.setOffset(offset_);
     need_seek = true;
 }
 
@@ -60,9 +59,6 @@ off_t ReadBufferFromEncryptedFile::seek(off_t off, int whence)
         assert(!hasPendingData());
     }
 
-    /// The encryptor always needs to know what the current offset is.
-    encryptor.setOffset(new_pos);
-
     return new_pos;
 }
 
@@ -94,8 +90,13 @@ bool ReadBufferFromEncryptedFile::nextImpl()
     /// The used cipher algorithms generate the same number of bytes in output as it were in input,
     /// so after deciphering the numbers of bytes will be still `bytes_read`.
     working_buffer.resize(bytes_read);
+
+    /// The decryptor needs to know what the current offset is (because it's used in the decryption algorithm).
+    encryptor.setOffset(offset);
+
     encryptor.decrypt(encrypted_buffer.data(), bytes_read, working_buffer.begin());
 
+    offset += bytes_read;
     pos = working_buffer.begin();
     return true;
 }

--- a/src/IO/ReadBufferFromEncryptedFile.h
+++ b/src/IO/ReadBufferFromEncryptedFile.h
@@ -38,7 +38,6 @@ private:
     std::unique_ptr<ReadBufferFromFileBase> in;
 
     off_t offset = 0;
-
     bool need_seek = false;
 
     Memory<> encrypted_buffer;

--- a/src/IO/tests/gtest_file_encryption.cpp
+++ b/src/IO/tests/gtest_file_encryption.cpp
@@ -4,6 +4,13 @@
 #include <gtest/gtest.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/FileEncryptionCommon.h>
+#include <IO/WriteBufferFromFile.h>
+#include <IO/WriteBufferFromEncryptedFile.h>
+#include <IO/ReadBufferFromEncryptedFile.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadHelpers.h>
+#include <Common/getRandomASCIIString.h>
+#include <filesystem>
 
 
 using namespace DB;
@@ -209,5 +216,48 @@ INSTANTIATE_TEST_SUITE_P(All,
           },
     })
 );
+
+TEST(FileEncryptionPositionUpdateTest, Decryption)
+{
+    String tmp_path = std::filesystem::current_path() / "test_offset_update";
+    if (std::filesystem::exists(tmp_path))
+        std::filesystem::remove(tmp_path);
+
+    String key = "1234567812345678";
+    FileEncryption::Header header;
+    header.algorithm = Algorithm::AES_128_CTR;
+    header.key_fingerprint = calculateKeyFingerprint(key);
+    header.init_vector = InitVector::random();
+
+    auto lwb = std::make_unique<WriteBufferFromFile>(tmp_path);
+    WriteBufferFromEncryptedFile wb(10, std::move(lwb), key, header);
+    auto data = getRandomASCIIString(20);
+    wb.write(data.data(), data.size());
+    wb.finalize();
+
+    auto lrb = std::make_unique<ReadBufferFromFile>(tmp_path);
+    ReadBufferFromEncryptedFile rb(10, std::move(lrb), key, header);
+    rb.ignore(5);
+    rb.ignore(5);
+    rb.ignore(5);
+    ASSERT_EQ(rb.getPosition(), 15);
+
+    String res;
+    readStringUntilEOF(res, rb);
+    ASSERT_EQ(res, data.substr(15));
+    res.clear();
+
+    rb.seek(0, SEEK_SET);
+    ASSERT_EQ(rb.getPosition(), 0);
+    res.resize(5);
+    ASSERT_EQ(rb.read(res.data(), res.size()), 5);
+    ASSERT_EQ(res, data.substr(0, 5));
+    res.clear();
+
+    rb.seek(1, SEEK_CUR);
+    ASSERT_EQ(rb.getPosition(), 6);
+    readStringUntilEOF(res, rb);
+    ASSERT_EQ(res, data.substr(6));
+}
 
 #endif

--- a/src/Parsers/ASTCreateNamedCollectionQuery.h
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.h
@@ -27,4 +27,6 @@ public:
     std::string getCollectionName() const;
 };
 
+using ASTCreateNamedCollectionQueryPtr = std::shared_ptr<ASTCreateNamedCollectionQuery>;
+
 }

--- a/src/Storages/NamedCollectionsHelpers.cpp
+++ b/src/Storages/NamedCollectionsHelpers.cpp
@@ -1,7 +1,8 @@
-#include "NamedCollectionsHelpers.h"
+#include <Storages/NamedCollectionsHelpers.h>
 #include <Access/ContextAccess.h>
 #include <Core/Settings.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/Context.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>

--- a/src/Storages/NamedCollectionsHelpers.h
+++ b/src/Storages/NamedCollectionsHelpers.h
@@ -1,16 +1,19 @@
 #pragma once
 #include <Parsers/IAST_fwd.h>
 #include <IO/HTTPHeaderEntries.h>
+#include <Interpreters/Context_fwd.h>
 #include <Common/NamedCollections/NamedCollections.h>
 #include <Common/quoteString.h>
 #include <Common/re2.h>
 #include <unordered_set>
 #include <string_view>
+
 #include <fmt/format.h>
 
 
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -4,12 +4,13 @@
 #if USE_MYSQL
 
 #include <Core/Settings.h>
+#include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/Context.h>
 #include <DataTypes/DataTypeString.h>
 #include <Databases/MySQL/FetchTablesColumnsList.h>
 #include <Formats/FormatFactory.h>
 #include <IO/Operators.h>
 #include <IO/WriteHelpers.h>
-#include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Processors/Formats/IOutputFormat.h>

--- a/src/Storages/System/StorageSystemNamedCollections.cpp
+++ b/src/Storages/System/StorageSystemNamedCollections.cpp
@@ -1,4 +1,4 @@
-#include "StorageSystemNamedCollections.h"
+#include <Storages/System/StorageSystemNamedCollections.h>
 
 #include <Common/FieldVisitorToString.h>
 #include <DataTypes/DataTypeString.h>
@@ -7,6 +7,7 @@
 #include <Interpreters/ProfileEventsExt.h>
 #include <Access/Common/AccessType.h>
 #include <Access/Common/AccessFlags.h>
+#include <Access/ContextAccess.h>
 #include <Columns/ColumnMap.h>
 #include <Common/NamedCollections/NamedCollectionsFactory.h>
 
@@ -19,6 +20,8 @@ NamesAndTypesList StorageSystemNamedCollections::getNamesAndTypes()
     return {
         {"name", std::make_shared<DataTypeString>()},
         {"collection", std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>())},
+        {"source", std::make_shared<DataTypeString>()},
+        {"create_query", std::make_shared<DataTypeString>()},
     };
 }
 
@@ -44,16 +47,23 @@ void StorageSystemNamedCollections::fillData(MutableColumns & res_columns, Conte
         auto & tuple_column = column_map->getNestedData();
         auto & key_column = tuple_column.getColumn(0);
         auto & value_column = tuple_column.getColumn(1);
+        bool access_secrets = access->isGranted(AccessType::SHOW_NAMED_COLLECTIONS_SECRETS);
 
         size_t size = 0;
         for (const auto & key : collection->getKeys())
         {
             key_column.insertData(key.data(), key.size());
-            value_column.insert(collection->get<String>(key));
+            if (access_secrets)
+                value_column.insert(collection->get<String>(key));
+            else
+                value_column.insert("[HIDDEN]");
             size++;
         }
 
         offsets.push_back(offsets.back() + size);
+
+        res_columns[2]->insert(magic_enum::enum_name(collection->getSourceId()));
+        res_columns[3]->insert(collection->getCreateStatement(access_secrets));
     }
 }
 


### PR DESCRIPTION
* clickhouse/clickhouse#78582: Add create_query, source columns to system.named_collections

* clickhouse/clickhouse#68615: Add storage encryption for named collections

* clickhouse/clickhouse#66288: Ignore ON CLUSTER clause in queries for management of replicated named collections

* clickhouse/clickhouse#66599: Fix dropping named collection in local storage

* clickhouse/clickhouse#49882: Use fingerprints instead of key IDs in encrypted disks

* clickhouse/clickhouse#36493: Fix offset update ReadBufferFromEncryptedFile

* clickhouse/clickhouse#39687: Fix seeking while reading from encrypted disk

* clickhouse/clickhouse#71308: Added missing unescaping in named collections names

* clickhouse/clickhouse#75333 part - NamedCollections headers
