### PR TITLE
fix race for table_function_results

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1773,6 +1773,7 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
         }
 
         res = table_function_ptr->execute(table_expression, shared_from_this(), table_function_ptr->getName());
+        setTableFunctionResults(key, res);
 
         /// Since ITableFunction::parseArguments() may change table_expression, i.e.:
         ///

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1555,6 +1555,23 @@ static bool findIdentifier(const ASTFunction * function)
     return false;
 }
 
+/// proton: starts.
+StoragePtr Context::getTableFunctionResults(const String & key) const
+{
+    SharedLockGuard lock(mutex);
+    auto it = table_function_results.find(key);
+    if (it != table_function_results.end())
+        return it->second;
+    return nullptr;
+}
+
+void Context::setTableFunctionResults(const String & key, const StoragePtr & table_function_result)
+{
+    std::lock_guard lock(mutex);
+    table_function_results.emplace(key, table_function_result);
+}
+/// proton: ends.
+
 StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const ASTSelectQuery * select_query_hint)
 {
     ASTFunction * function = assert_cast<ASTFunction *>(table_expression.get());
@@ -1598,7 +1615,9 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
     }
     auto hash = table_expression->getTreeHash();
     String key = toString(hash.first) + '_' + toString(hash.second);
-    StoragePtr & res = table_function_results[key];
+    /// proton: starts.
+    auto res = getTableFunctionResults(key);
+    /// proton: ends.
     if (!res)
     {
         TableFunctionPtr table_function_ptr;
@@ -1763,7 +1782,9 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
         if (hash != new_hash)
         {
             key = toString(new_hash.first) + '_' + toString(new_hash.second);
-            table_function_results[key] = res;
+            /// proton: starts.
+            setTableFunctionResults(key, res);
+            /// proton: ends.
         }
     }
     return res;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -800,6 +800,8 @@ public:
     void addRequiredColumns(RequiredColumnTuple && column_tuple) { required_columns.insert(std::move(column_tuple)); }
     /// Get data stream semantic for subquery
     DataStreamSemanticCache & getDataStreamSemanticCache() const;
+    StoragePtr getTableFunctionResults(const String & key) const;
+    void setTableFunctionResults(const String & key, const StoragePtr & table);
     /// proton: ends
 
     /// Id of initiating query for distributed queries; or current query id if it's not a distributed query.


### PR DESCRIPTION
There is a race condition for std::map<String, StoragePtr>) table_function_results; in ContextData

Fatal stacktrace

(inlined by) std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::shared_ptr<DB::IStorage>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::shared_ptr<DB::IStorage>>>>::map[abi:ne180100](std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::shared_ptr<DB::IStorage>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::shared_ptr<DB::IStorage>>>> const&) at map:1078
 (inlined by) DB::ContextData::ContextData(DB::ContextData const&) at Context.cpp:788
