### PR TITLE
fix: flush pending messages in Pulsar's batch buffer before waiting f…

### DIFF
--- a/src/Storages/ExternalStream/Pulsar/PulsarSink.cpp
+++ b/src/Storages/ExternalStream/Pulsar/PulsarSink.cpp
@@ -196,6 +196,10 @@ void PulsarSink::waitForAcks() const
 
 void PulsarSink::checkpoint(CheckpointContextPtr context)
 {
+    /// Flush any pending messages in Pulsar's internal batch buffer before waiting for acks.
+    /// Without this, messages may be stuck in the batch buffer waiting for the batch timer,
+    /// causing waitForAcks() to timeout even though messages haven't been sent yet.
+    producer.flush();
     waitForAcks();
 
     state.reset();


### PR DESCRIPTION
…or acks (#11120)

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
