### PR TITLE
set s3 max upload idle seconds default to 1s

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -117,7 +117,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(Bool, enable_s3_requests_logging, false, "Enable very explicit logging of S3 requests. Makes sense for debug only.", 0) \
     /* proton: starts */ \
     M(UInt64, s3_min_upload_file_size, 500*1024*1024, "The minimum size of file to upload to S3, i.e. once the file reaches this size, the multipart upload will finish, or the file will be uploaded via single part upload if this size is smaller than s3_max_single_part_upload_size.", 0) \
-    M(UInt64, s3_max_upload_idle_seconds, 0, "The maximum idle time (in seconds) to wait for new data before complete a upload to S3, 0 means no limits.", 0) \
+    M(UInt64, s3_max_upload_idle_seconds, 1, "The maximum idle time (in seconds) to wait for new data before complete a upload to S3, 0 means no limits.", 0) \
     /* proton: ends */ \
     M(UInt64, hdfs_replication, 0, "The actual number of replications can be specified when the hdfs file is created.", 0) \
     M(Bool, hdfs_truncate_on_insert, false, "Enables or disables truncate before insert in s3 engine tables", 0) \

--- a/src/Storages/ExternalTable/S3/StorageS3.cpp
+++ b/src/Storages/ExternalTable/S3/StorageS3.cpp
@@ -806,12 +806,15 @@ public:
             timer_pool.scheduleOrThrowOnError([this, max_upload_idle_seconds]() {
                 while (true)
                 {
+                    uint64_t sleep_time_sec = max_upload_idle_seconds;
+
                     {
                         std::lock_guard lock(cancel_mutex);
                         if (stopped)
                             break;
 
-                        if (upload_idle_timer.elapsedSeconds() >= max_upload_idle_seconds)
+                        auto elapsed_seconds = static_cast<uint64_t>(upload_idle_timer.elapsedSeconds());
+                        if (elapsed_seconds >= max_upload_idle_seconds)
                         {
                             try
                             {
@@ -823,8 +826,13 @@ public:
                                 release();
                             }
                         }
+                        else
+                        {
+                            sleep_time_sec = max_upload_idle_seconds - elapsed_seconds;
+                        }
                     }
-                    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+                    sleepForSeconds(sleep_time_sec);
                 }
             });
     }
@@ -854,7 +862,7 @@ public:
         if (cancelled)
             return;
 
-        if (current_total_size >= min_upload_file_size)
+        if (current_total_size >= min_upload_file_size && current_total_size > 0)
             /// Properly finalize the format writer and complete the current upload.
             finalize();
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
change s3 external table sink flush. set default s3_max_upload_idle_seconds from 0 (no flush) to 1 second. This avoids file not uploaded to s3 for long time when no new data is coming.