### PR TITLE
fix session window arugment size validation

### DIFF
--- a/src/Interpreters/Streaming/WindowCommon.cpp
+++ b/src/Interpreters/Streaming/WindowCommon.cpp
@@ -332,7 +332,7 @@ ASTs checkAndExtractSessionArguments(const ASTFunction * func_ast)
     if (args.size() < 2)
         throw Exception::createRuntime(ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION, SESSION_HELP_MESSAGE);
 
-    if (args.size() > 5)
+    if (args.size() > 6)
         throw Exception::createRuntime(ErrorCodes::TOO_MANY_ARGUMENTS_FOR_FUNCTION, SESSION_HELP_MESSAGE);
 
     ASTs asts;


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
```
CREATE STREAM default.devices
(
  `device` string,
  `phase` int8,
  `status` int8
);

SELECT
  window_start, window_end, device, count()
FROM
  session(default.devices, _tp_time, 10m, 30m, status = 1, status = 2)
GROUP BY
  device, window_start, window_end;

DB::Exception: Function 'session' requires at least 2 parameters: <name of the stream>, [timestamp column], <timeout interval>, [max session time], [session range comparision] | [start_prediction, end_prediction]. (TOO_MANY_ARGUMENTS_FOR_FUNCTION)
```