### PR TITLE
add schema-id in snapshot

### DIFF
--- a/src/Storages/ExternalStream/Iceberg/IcebergSink.cpp
+++ b/src/Storages/ExternalStream/Iceberg/IcebergSink.cpp
@@ -297,6 +297,7 @@ void IcebergSink::commit()
             .total_position_deletes = std::to_string(total_position_deletes),
             .total_equality_deletes = std::to_string(total_equality_deletes),
         },
+        .schema_id = metadata.getCurrentSchemaID(),
     };
 
     Apache::Iceberg::Updates updates;

--- a/src/Storages/Iceberg/ICatalog.cpp
+++ b/src/Storages/Iceberg/ICatalog.cpp
@@ -113,6 +113,22 @@ const std::string & TableMetadata::getSchemaJSON() const
     return iceberg_schema;
 }
 
+void TableMetadata::setCurrentSchemaID(int64_t current_schema_id_)
+{
+    if (!with_schema)
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Data schema was not requested");
+
+    current_schema_id = current_schema_id_;
+}
+
+int64_t TableMetadata::getCurrentSchemaID() const
+{
+    if (!with_schema)
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Data schema was not requested");
+
+    return current_schema_id;
+}
+
 void TableMetadata::setStorageCredentials(std::shared_ptr<IStorageCredentials> credentials_)
 {
     if (!with_storage_credentials)

--- a/src/Storages/Iceberg/ICatalog.h
+++ b/src/Storages/Iceberg/ICatalog.h
@@ -154,6 +154,9 @@ public:
     void setSchemaJSON(const std::string & schema_json_);
     const std::string & getSchemaJSON() const;
 
+    void setCurrentSchemaID(int64_t current_schema_id_);
+    int64_t getCurrentSchemaID() const;
+
     void setStorageCredentials(std::shared_ptr<IStorageCredentials> credentials_);
     std::shared_ptr<IStorageCredentials> getStorageCredentials() const;
 
@@ -188,6 +191,7 @@ private:
     std::string path;
     DB::NamesAndTypesList schema;
     std::string iceberg_schema;
+    int64_t current_schema_id{0};
 
     int64_t snapshot_id{0};
     uint64_t sequence_number{0};

--- a/src/Storages/Iceberg/RestCatalog.cpp
+++ b/src/Storages/Iceberg/RestCatalog.cpp
@@ -649,6 +649,7 @@ void extractTableMetadata(const std::string & json_str, TableMetadata & result, 
                 snapshot.sequence_number = snapshot_obj->getValue<uint64_t>("sequence-number");
                 snapshot.timestamp_ms = snapshot_obj->getValue<int64_t>("timestamp-ms");
                 snapshot.manifest_list = snapshot_obj->getValue<std::string>("manifest-list");
+                snapshot.schema_id = snapshot_obj->optValue<int64_t>("schema-id", 0);
 
                 auto summary_obj = snapshot_obj->get("summary").extract<Poco::JSON::Object::Ptr>();
                 snapshot.summary.operation = summary_obj->getValue<std::string>("operation");
@@ -697,6 +698,7 @@ void extractTableMetadata(const std::string & json_str, TableMetadata & result, 
         auto schema = schema_processor.getTimeplusTableSchemaById(id);
         result.setSchema(*schema);
         result.setSchemaJSON(iceberg_schema_json);
+        result.setCurrentSchemaID(id);
     }
 
     if (result.requiresCredentials() && object->has("config"))

--- a/src/Storages/Iceberg/Update.cpp
+++ b/src/Storages/Iceberg/Update.cpp
@@ -27,6 +27,7 @@ void AddSnopshotUpdate::apply(Poco::JSON::Array & updates) const
     snapshot_obj.set("timestamp-ms", snapshot.timestamp_ms);
     snapshot_obj.set("manifest-list", snapshot.manifest_list);
     snapshot_obj.set("summary", summary_obj);
+    snapshot_obj.set("schema-id", snapshot.schema_id);
 
     Poco::JSON::Object obj;
     obj.set("action", action);

--- a/src/Storages/Iceberg/Update.h
+++ b/src/Storages/Iceberg/Update.h
@@ -52,6 +52,7 @@ struct Snapshot
     int64_t timestamp_ms{0};
     std::string manifest_list;
     Summary summary;
+    int64_t schema_id{0};
 
     bool isValid() const { return snapshot_id > 0; }
 };


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
Fix #1035 

Add schema-id field to table metadata snapshots

CH can now read the table without an exception.

Athena does not return schema id null error any more but still fails in reading parquet data file (#1038)