### PR TITLE
fix splunk related smoke test case fail

### DIFF
--- a/tests/cluster/deployment/docker-compose-p1k1.yaml
+++ b/tests/cluster/deployment/docker-compose-p1k1.yaml
@@ -137,7 +137,7 @@ services:
       restart_policy:
         condition: on-failure
   splunk:
-    image: splunk/splunk:9.4
+    image: splunk/splunk@sha256:54cecca15bb2a8f3bdf79ec01f0775c18b388748dda3f6246cd4fe364d7ce7a3
     container_name: ${CONTAINER_NAME_PREFIX}_splunk
     environment:
       - SPLUNK_START_ARGS=--accept-license

--- a/tests/cluster/deployment/docker-compose-p3k1.yaml
+++ b/tests/cluster/deployment/docker-compose-p3k1.yaml
@@ -174,7 +174,7 @@ services:
       restart_policy:
         condition: on-failure
   splunk:
-    image: splunk/splunk:9.4
+    image: splunk/splunk@sha256:54cecca15bb2a8f3bdf79ec01f0775c18b388748dda3f6246cd4fe364d7ce7a3
     container_name: ${CONTAINER_NAME_PREFIX}_splunk
     environment:
       - SPLUNK_START_ARGS=--accept-license


### PR DESCRIPTION

Please write user-readable short description of the changes:
splunk/splunk 9.4.7 (Nov 28), 9.4.6(Oct 31)
https://hub.docker.com/r/splunk/splunk/tags?name=9.4

https://github.com/timeplus-io/proton/actions/runs/19900032060
```
Some tests failed
Group 4, Suite http_external_stream: Failed after 3 retries
Failed cases: 00_ext_stream_http_splunk,01_ext_stream_http_splunk_exception
```