### PR TITLE
fixes transfer consecutive data in ExpandResizeProcessor

### DIFF
--- a/src/Processors/Streaming/ResizeProcessor.cpp
+++ b/src/Processors/Streaming/ResizeProcessor.cpp
@@ -258,6 +258,10 @@ IProcessor::Status ExpandResizeProcessor::prepare(const PortNumbers & /*updated_
             {
                 ++num_finished_outputs;
                 output.status = OutputStatus::Finished;
+
+                // Clear exclusive_output if this port was exclusive
+                if (exclusive_output.has_value() && *exclusive_output == &output)
+                    exclusive_output.reset();
             }
 
             continue;
@@ -268,7 +272,16 @@ IProcessor::Status ExpandResizeProcessor::prepare(const PortNumbers & /*updated_
             if (output.status != OutputStatus::NeedData)
             {
                 output.status = OutputStatus::NeedData;
-                waiting_outputs.push_back(&output);
+                if (exclusive_output.has_value() && *exclusive_output == &output)
+                {
+                    /// Prioritize outputs that require consecutive data
+                    waiting_outputs.push_front(*exclusive_output);
+                    exclusive_output.reset();
+                }
+                else
+                {
+                    waiting_outputs.push_back(&output);
+                }
             }
         }
     }
@@ -311,7 +324,7 @@ IProcessor::Status ExpandResizeProcessor::prepare(const PortNumbers & /*updated_
     {
         input.setNeeded();
 
-        if (input.hasData())
+        if (input.hasData() && !exclusive_output.has_value())
         {
             auto data = input.pullData(/*set_not_needed*/ true);
             if (data.chunk.hasWatermark())
@@ -341,6 +354,11 @@ IProcessor::Status ExpandResizeProcessor::prepare(const PortNumbers & /*updated_
                 auto bytes = data.chunk.bytes();
                 auto rows = data.chunk.rows();
                 auto start_ns = MonotonicNanoseconds::now();
+
+                /// Received consecutive data, make this output exclusive
+                if (data.chunk.isConsecutiveData())
+                    exclusive_output = &waiting_output;
+
                 waiting_output.port->pushData(std::move(data));
                 metrics.processed_bytes += bytes;
                 metrics.processed_rows += rows;

--- a/src/Processors/Streaming/ResizeProcessor.h
+++ b/src/Processors/Streaming/ResizeProcessor.h
@@ -129,6 +129,12 @@ private:
     std::vector<OutputPortWithStatus> output_ports;
     std::list<OutputPortWithStatus *> waiting_outputs;
 
+    /// When an output receives a chunk marked as "consecutive",
+    /// switch that output into 'exclusive’ mode until the next chunk is read.
+    /// This guarantees that consecutive data is always delivered to the same output,
+    /// without affecting other outputs.
+    std::optional<OutputPortWithStatus *> exclusive_output;
+
     /// To propagate
     Chunk header_chunk;
     Int64 watermark = INVALID_WATERMARK;

--- a/src/Processors/Transforms/Streaming/JoinTransform.cpp
+++ b/src/Processors/Transforms/Streaming/JoinTransform.cpp
@@ -4,6 +4,7 @@
 #include <Interpreters/Streaming/HashJoin/joinKind.h>
 #include <Interpreters/TableJoin.h>
 #include <base/ClockUtils.h>
+#include <Common/logger_useful.h>
 
 namespace DB
 {
@@ -148,6 +149,8 @@ void JoinTransform::work()
 
                 if (input_chunk.hasWatermark())
                 {
+                    chassert(!required_update_processing_index && "Watermark should not be present when update processing is required");
+
                     auto input_chunk_watermark = input_chunk.getChunkContext()->getWatermark();
 
                     local_watermark = std::min(local_watermark, input_chunk_watermark);
@@ -155,6 +158,8 @@ void JoinTransform::work()
                 }
                 else if (input_chunk.requestCheckpoint())
                 {
+                    chassert(!required_update_processing_index && "Checkpoint request should not occur when update processing is required");
+
                     ++requested_checkpoint_num;
                     continue; /// keep in input_ports_with_data until all inputs checkpoint requested
                 }
@@ -170,12 +175,6 @@ void JoinTransform::work()
             }
         }
 
-        /// We propagate empty chunk with or without watermark.
-        /// Skip propagate if needs to processing next consecutive chunk
-        /// to avoid downstream aggregation to emit transitive results we don't want
-        if (!has_data && !required_update_processing_index)
-            output_chunks.emplace_back(output_header_chunk.clone());
-
         /// All inputs request checkpoint
         if (requested_checkpoint_num == input_ports_with_data.size())
         {
@@ -187,22 +186,25 @@ void JoinTransform::work()
     if (has_data)
         doJoin(std::move(chunks));
 
+    /// If no output was produced, emit a heartbeat chunk.
+    /// Skip the heartbeat when the next "consecutive" chunk must be processed,
+    /// to avoid downstream aggregation to emit transitive results we don't want
+    if (output_chunks.empty() && !required_update_processing_index)
+        output_chunks.emplace_back(output_header_chunk.clone());
+
     /// Piggy-back watermark
     /// We only do this piggy-back once for the last output chunk if there is
     if (has_watermark)
     {
-        if (!output_chunks.empty())
-            setupWatermark(output_chunks.back(), local_watermark);
-        else
-            /// If there is no join result or chunks don't have data but have watermark, we still need propagate the watermark
-            propagateWatermark(local_watermark);
+        chassert(!output_chunks.empty());
+        setupWatermark(output_chunks.back(), local_watermark);
     }
     else if (requested_ckpt)
     {
         checkpoint(requested_ckpt);
 
         /// Propagate request checkpoint
-        assert(!output_chunks.empty());
+        chassert(!output_chunks.empty());
         output_chunks.back().setCheckpointContext(std::move(requested_ckpt));
     }
 
@@ -215,13 +217,6 @@ void JoinTransform::work()
     metrics.processed_rows += in_rows;
     metrics.processed_bytes += in_bytes;
     metrics.processed_time_ns += MonotonicNanoseconds::now() - start_ns;
-}
-
-inline void JoinTransform::propagateWatermark(int64_t local_watermark)
-{
-    auto chunk = output_header_chunk.clone();
-    if (setupWatermark(chunk, local_watermark))
-        output_chunks.emplace_back(std::move(chunk));
 }
 
 inline bool JoinTransform::setupWatermark(Chunk & chunk, int64_t local_watermark)

--- a/src/Processors/Transforms/Streaming/JoinTransform.h
+++ b/src/Processors/Transforms/Streaming/JoinTransform.h
@@ -42,7 +42,6 @@ public:
 
 private:
     using Chunks = std::array<Chunk, 2>;
-    void propagateWatermark(int64_t local_watermark);
     bool setupWatermark(Chunk & chunk, int64_t local_watermark);
 
     void doJoin(Chunks chunks);


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
When running a query with concurrent hash join, got <Fatal> : Logical error: 'Pipeline stuck' 