### PR TITLE
bugfix: load cached UDF names during MetaStore initialization

### DIFF
--- a/programs/server/embedded.xml
+++ b/programs/server/embedded.xml
@@ -69,7 +69,7 @@
       <collect_interval_milliseconds>5000</collect_interval_milliseconds>
   </stream_metric_log>
 
-  <stream_state_log>
+  <introspection_state_log>
    <engine>
         engine Stream(1, weak_hash32(node_id))
         primary key (database, name, state_name, dimension, node_id)
@@ -78,10 +78,10 @@
         settings mode = 'versioned_kv', logstore_codec='zstd'
    </engine>
       <database>system</database>
-      <table>stream_state_log</table>
+      <table>introspection_state_log</table>
       <flush_interval_milliseconds>5000</flush_interval_milliseconds>
       <collect_interval_milliseconds>5000</collect_interval_milliseconds>
-  </stream_state_log>
+  </introspection_state_log>
 
   <mat_view_dlq>
    <engine>

--- a/src/Cluster/LocalLog/Log/LogManager.cpp
+++ b/src/Cluster/LocalLog/Log/LogManager.cpp
@@ -315,7 +315,7 @@ LogPtr LogManager::getOrCreateLog(const StreamShard & stream_shard, LogConfigPtr
     {
         LOG_INFO(
             logger,
-            "getOrCreateLog: Found existing log for stream_shard={}, log_ptr={}, next_sn={}",
+            "Found existing log for stream_shard={}, log_ptr={}, next_sn={}",
             stream_shard.string(),
             static_cast<const void *>(log.get()),
             log->nextLogSequence());

--- a/src/Cluster/MetaStore/MetaStore_Bootstrap.cpp
+++ b/src/Cluster/MetaStore/MetaStore_Bootstrap.cpp
@@ -146,6 +146,9 @@ void MetaStore::init()
     /// Mark as ready
     setReady();
 
+    /// Load cached UDF names so UDF lookups work after restart
+    loadUserDefinedFunctions();
+
     LOG_DEBUG(logger, "MetaStore initialization complete");
 }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix #1049