### PR TITLE
Moved cached UDF loading into the MetaStore constructor so it happens…

### DIFF
--- a/src/Cluster/MetaStore/MetaStore_Bootstrap.cpp
+++ b/src/Cluster/MetaStore/MetaStore_Bootstrap.cpp
@@ -29,6 +29,9 @@ MetaStore::MetaStore(StoreConfigPtr config_, std::shared_ptr<MetaDB> meta_db_)
 {
     /// Always node ID 1
     node_identity = 1;
+
+    /// Load cached UDF names early to avoid races after readiness
+    loadUserDefinedFunctions();
 }
 
 MetaStore::~MetaStore() noexcept
@@ -145,9 +148,6 @@ void MetaStore::init()
 
     /// Mark as ready
     setReady();
-
-    /// Load cached UDF names so UDF lookups work after restart
-    loadUserDefinedFunctions();
 
     LOG_DEBUG(logger, "MetaStore initialization complete");
 }


### PR DESCRIPTION
… before readiness is signaled, eliminating the startup race; removed the post-ready call in init().

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix #1052 