### PR TITLE
unexpected parameterized view exception

### DIFF
--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -41,6 +41,9 @@
 #include <Parsers/ASTInterpolateElement.h>
 #include <Parsers/queryToString.h>
 #include <Parsers/ASTCreateQuery.h>
+/// proton: starts.
+#include <Parsers/QueryParameterVisitor.h>
+/// proton: ends.
 
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -80,6 +83,9 @@ namespace ErrorCodes
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int UNKNOWN_IDENTIFIER;
     extern const int BAD_QUERY_PARAMETER;
+    /// proton: starts.
+    extern const int UNKNOWN_QUERY_PARAMETER;
+    /// proton: ends.
 }
 
 namespace
@@ -380,7 +386,28 @@ void translateQualifiedNames(ASTPtr & query, const ASTSelectQuery & select_query
 
     /// This may happen after expansion of COLUMNS('regexp').
     if (select_query.select()->children.empty())
+    {
+        /// proton: starts.
+        /// If the query still contains unresolved parameters, surface a clearer error with names.
+        NameSet unresolved_params = analyzeReceiveQueryParams(query);
+        if (!unresolved_params.empty())
+        {
+            std::stringstream ss;
+            ss << "Query parameter(s) are not set: ";
+            bool first = true;
+            for (const auto & name : unresolved_params)
+            {
+                if (!first)
+                    ss << ", ";
+                first = false;
+                ss << backQuote(name);
+            }
+            throw Exception::createRuntime(ErrorCodes::UNKNOWN_QUERY_PARAMETER, ss.str());
+        }
+        /// proton: ends.
+
         throw Exception(ErrorCodes::EMPTY_LIST_OF_COLUMNS_QUERIED, "Empty list of columns in SELECT query");
+    }	
 }
 
 // Replaces one avg/sum/count function with an appropriate expression with

--- a/tests/queries_ported/0_stateless/99100_parameterized_view_throw_exception.sql
+++ b/tests/queries_ported/0_stateless/99100_parameterized_view_throw_exception.sql
@@ -1,0 +1,19 @@
+drop view if exists 99100_param_view;
+drop stream if exists 99100_github_events;
+
+create view 99100_param_view as select * from 99100_github_events limit {limit:int8};
+
+SET query_mode='table';
+
+select * from 99100_param_view(limit=2); -- { serverError UNKNOWN_STREAM }
+select * from 99100_param_view; -- { serverError UNKNOWN_STREAM }
+
+create stream 99100_github_events(id int);
+
+
+select * from 99100_param_view(limit=2);
+select * from 99100_param_view; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+
+drop view if exists 99100_param_view;
+drop stream if exists 99100_github_events;


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
fix 
> I created a parameterized view like this create view github_param_view as select * from github_events limit {limit:int8} I can query with select * from github_param_view(limit=2) but the error message if I don't set the param value is a bit confusing. It should show param(s) are not set
Code: 51. DB::Exception: Empty list of columns in SELECT query. (EMPTY_LIST_OF_COLUMNS_QUERIED)


before:
```
proton :) select * from github_param_view

SELECT
  *
FROM
  github_param_view

Query id: b7535caa-f40c-42b6-bc6d-fc29b97595d2


0 rows in set. Elapsed: 0.023 sec. 

Received exception from server (version 3.0.11):
Code: 51. DB::Exception: Received from localhost:8463. DB::Exception: Empty list of columns in SELECT query. (EMPTY_LIST_OF_COLUMNS_QUERIED)

proton :) 

```

after:
```
SELECT
  *
FROM
  `99100_param_view`

Query id: 62b96c6a-6d7d-4fda-a01d-8baed2ab504c


0 rows in set. Elapsed: 0.011 sec. 

Received exception from server (version 3.0.11):
Code: 456. DB::Exception: Received from localhost:8463. DB::Exception: Query parameter(s) are not set: `limit`. (UNKNOWN_QUERY_PARAMETER)

```