### PR TITLE
split block by max size

### DIFF
--- a/src/Processors/Executors/MessageQueueFormatExecutor.cpp
+++ b/src/Processors/Executors/MessageQueueFormatExecutor.cpp
@@ -3,6 +3,7 @@
 #include <Formats/FormatFactory.h>
 #include <Processors/Formats/IRowOutputFormat.h>
 #include <Processors/ProcessorID.h>
+#include <Processors/Streaming/SizedChunkSplitter.h>
 
 namespace DB
 {
@@ -78,11 +79,16 @@ void MessageQueueFormatExecutor::execute(const Block & block, MessageCallback me
     }
     else
     {
-        format->write(block);
-        format->finalize();
-        message_callback(buffer->str(), rows_in_block);
-        format->resetFormatter();
-        buffer->restart();
+        Streaming::SizedChunkSplitter splitter{max_rows_per_message, max_message_size};
+        auto blocks = splitter.splitBlockForSingleShard(block, 0);
+        for (const auto & block_with_shard : blocks)
+        {
+            format->write(block_with_shard.block);
+            format->finalize();
+            message_callback(buffer->str(), block_with_shard.block.rows());
+            format->resetFormatter();
+            buffer->restart();
+        }
     }
 }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
For HTTP databricks sample, insert fails when more than one row in chunk; even for max_insert_block_size is explicitly set
https://docs.timeplus.com/databricks-external
```
CREATE EXTERNAL STREAM http_databricks_t1 (product string, quantity int)
SETTINGS
type = 'http',
http_header_Authorization='Bearer $TOKEN',
url = 'https://$HOST.cloud.databricks.com/api/2.0/sql/statements/',
data_format = 'Template',
format_template_resultset_format='{"warehouse_id":"$WAREHOUSE_ID","statement": "INSERT INTO sales (product, quantity) VALUES (:product, :quantity)", "parameters": [${data}]}',
format_template_row_format='{ "name": "product", "value": ${product:JSON}, "type": "STRING" },{ "name": "quantity", "value": ${quantity:JSON}, "type": "INT" }',
format_template_rows_between_delimiter=''

INSERT INTO http_databricks_t1(product, quantity) VALUES('test',95)('test2', 96);
```