### PR TITLE
check data format for kafka schema registry cases

### DIFF
--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -302,7 +302,6 @@ bool ProtobufConfluentRowInputFormat::readRow(MutableColumns & columns, RowReadE
 
     auto schema_id = KafkaSchemaRegistry::readSchemaId(*in);
 
-
     Int64 indexes_count = 0;
     readVarInt(indexes_count, *in);
 

--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -257,6 +257,20 @@ void Kafka::validateSettings(bool attach)
                 ErrorCodes::INVALID_SETTING_VALUE, "Setting `message_key` is deprecated, define the _tp_message_key column instead");
     }
 
+    if (hasSchemaRegistryUrl())
+    {
+        const auto & format = settings->data_format.value;
+        const bool format_supported = format == "ProtobufSingle" || format == "Avro";
+        if (!format_supported)
+        {
+            LOG_ERROR(logger, "Kafka external stream with schema registry only supports 'ProtobufSingle' or 'Avro' data formats: actual='{}'", format);
+            if (!attach)
+                throw Exception(
+                    ErrorCodes::INVALID_SETTING_VALUE,
+                    "Kafka external stream with schema registry only supports 'ProtobufSingle' or 'Avro' data formats");
+        }
+    }
+
     const auto & columns = getInMemoryMetadataPtr()->getColumns();
     if (columns.has(ProtonConsts::RESERVED_EVENT_TIME) || columns.has(ProtonConsts::RESERVED_MESSAGE_KEY)
         || columns.has(ProtonConsts::RESERVED_MESSAGE_HEADERS))
@@ -572,6 +586,9 @@ Pipe Kafka::read(
 
 SinkToStoragePtr Kafka::write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr context)
 {
+    if (hasSchemaRegistryUrl() && data_format == "ProtobufSingle")
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Write Protobuf data with schema registry is not supported");
+
     auto producer = client->getProducer(topicName());
 
     auto sink = std::make_shared<KafkaSink>(

--- a/src/Storages/ExternalStream/Kafka/Kafka.h
+++ b/src/Storages/ExternalStream/Kafka/Kafka.h
@@ -94,7 +94,6 @@ private:
         size_t /*max_block_size*/,
         size_t /*num_streams*/) override;
 
-private:
     ASTs engine_args;
     ExternalStreamCounterPtr external_stream_counter;
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
a couple things can be improved:
    Report error when a user tries to write to a kafaka external stream which is configured with schema registry.
    Report error when a data format other than "Avro" and "ProtobufSingle" is used with schema registry.
