### PR TITLE
fix: Alerts name conflicts with stream names.

### DIFF
--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -132,6 +132,10 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
     /// proton: starts. Hide inner table names starts with '.inner.', e.g. `.inner.target...`
     if (!getContext()->getSettingsRef().include_internal_streams.value)
         rewritten_query << " AND NOT starts_with(name, '.inner.')";
+
+    /// Exclude Alerts
+    if (!query.dictionaries)
+        rewritten_query << " AND engine != 'StorageAlert'";
     /// proton: ends.
 
     if (!query.like.empty())


### PR DESCRIPTION


Please write user-readable short description of the changes:
Alerts are attached as Database table.

    Cannot create alert with the same name as existing streams. The error message is kind of misleading.
    When run 'show streams', the alerts are displayed in the list.
