### PR TITLE
Enable parsing of numbers as strings in JSON input formats and add regression tests

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -935,7 +935,7 @@ Possible values: non-negative numbers. Note that if the value is too small or to
     M(Bool, input_format_json_read_bools_as_strings, true, "Allow to parse bools as strings in JSON input formats", 0) \
     M(Bool, input_format_json_try_infer_numbers_from_strings, false, "Try to infer numbers from string fields while schema inference", 0) \
     M(Bool, input_format_json_validate_types_from_metadata, true, "For JSON/JSONCompact/JSONColumnsWithMetadata input formats this controls whether format parser should check if data types from input metadata match data types of the corresponding columns from the table", 0) \
-    M(Bool, input_format_json_read_numbers_as_strings, false, "Allow to parse numbers as strings in JSON input formats", 0) \
+    M(Bool, input_format_json_read_numbers_as_strings, true, "Allow to parse numbers as strings in JSON input formats", 0) \
     M(Bool, input_format_json_read_objects_as_strings, true, "Allow to parse JSON objects as strings in JSON input formats", 0) \
     M(Bool, input_format_json_read_arrays_as_strings, true, "Allow to parse JSON arrays as strings in JSON input formats", 0) \
     M(Bool, input_format_json_try_infer_named_tuples_from_objects, true, "Try to infer named tuples from JSON objects in JSON input formats", 0) \

--- a/tests/queries_ported/0_stateless/99112_99071_json_numbers_as_strings_regression.sql
+++ b/tests/queries_ported/0_stateless/99112_99071_json_numbers_as_strings_regression.sql
@@ -1,0 +1,29 @@
+SET query_mode='table';
+-- Repro on MutableStream
+
+DROP STREAM IF EXISTS 99073_jsn_num_str_mut;
+CREATE STREAM 99073_jsn_num_str_mut (cl_ord_id string, v int) PRIMARY KEY cl_ord_id;
+
+DROP STREAM IF EXISTS 99072_jsn_num_str;
+CREATE STREAM 99072_jsn_num_str (cl_ord_id string);
+
+
+-- Default is on: numeric value for a String column should succeed
+INSERT INTO 99073_jsn_num_str_mut FORMAT JSONEachRow {"cl_ord_id": 12345, "v": 1};
+
+SELECT cl_ord_id, v FROM 99073_jsn_num_str_mut ORDER BY cl_ord_id;
+
+INSERT INTO 99072_jsn_num_str FORMAT JSONEachRow {"cl_ord_id": 12345};
+
+SELECT cl_ord_id FROM 99072_jsn_num_str ORDER BY cl_ord_id;
+
+-- Disable and verify failure
+SET input_format_json_read_numbers_as_strings = 0;
+INSERT INTO 99073_jsn_num_str_mut FORMAT JSONEachRow {"cl_ord_id": 67890, "v": 2}; -- { clientError CANNOT_PARSE_QUOTED_STRING }
+
+INSERT INTO 99072_jsn_num_str FORMAT JSONEachRow {"cl_ord_id": 67890}; -- { clientError CANNOT_PARSE_QUOTED_STRING }
+
+DROP STREAM 99072_jsn_num_str;
+
+
+DROP STREAM 99073_jsn_num_str_mut;


### PR DESCRIPTION

Please write user-readable short description of the changes:
cherry-pick one line harmless change from 
- [ ] https://github.com/ClickHouse/ClickHouse/pull/54427

```
DROP STREAM IF EXISTS t1;
CREATE STREAM t1 (cl_ord_id string);

-- expect failure (default off)
INSERT INTO t1 FORMAT JSONEachRow {"cl_ord_id": 12345};

-- enable, then works
SET input_format_json_read_numbers_as_strings = 1;
INSERT INTO t1 FORMAT JSONEachRow {"cl_ord_id": 12345};
SELECT cl_ord_id FROM table(t1);
```