### PR TITLE
Flush memtables for hybrid hash table before checkpoint

### DIFF
--- a/src/Common/HybridHashTable/HybridHashTable.h
+++ b/src/Common/HybridHashTable/HybridHashTable.h
@@ -993,6 +993,11 @@ public:
         /// After flushing, always expects rocks instance here
         if (!persistentPartInited())
             initRocks();
+
+        /// Flush all memtables to disk
+        rocksdb::FlushOptions flush_opts;
+        flush_opts.wait = true;
+        cf_handler->db->Flush(flush_opts, cf_handler->cf_handle);
     }
 
     void reload(const HybridHashTableConfig::ValueDeserializer & old_value_deserializer = {})


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
Need flush rocks before taking checkpoint, otherwise in-memory memtable won't be in ckpt