### PR TITLE
 port ch remove object update

### DIFF
--- a/base/base/BorrowedObjectPool.h
+++ b/base/base/BorrowedObjectPool.h
@@ -10,7 +10,7 @@
 #include <base/MoveOrCopyIfThrow.h>
 
 /** Pool for limited size objects that cannot be used from different threads simultaneously.
-  * The main use case is to have fixed size of objects that can be reused in difference threads during their lifetime
+  * The main use case is to have fixed size of objects that can be reused in different threads during their lifetime
   * and have to be initialized on demand.
   * Two main properties of pool are allocated objects size and borrowed objects size.
   * Allocated objects size is size of objects that are currently allocated by the pool.

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -1,4 +1,5 @@
 #include <Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h>
+#include <Common/Exception.h>
 
 #if USE_AZURE_BLOB_STORAGE
 
@@ -254,36 +255,22 @@ std::unique_ptr<WriteBufferFromFileBase> AzureObjectStorage::writeObject( /// NO
         settings.get());
 }
 
-/// Remove file. Throws exception if file doesn't exists or it's a directory.
-void AzureObjectStorage::removeObject(const StoredObject & object)
-{
-    const auto & path = object.remote_path;
-    LOG_TEST(log, "Removing single object: {}", path);
-    auto client_ptr = client.get();
-    auto delete_info = client_ptr->DeleteBlob(path);
-    if (!delete_info.Value.Deleted)
-        throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Failed to delete file in AzureBlob Storage: {}", path);
-}
-
-void AzureObjectStorage::removeObjects(const StoredObjects & objects)
-{
-    auto client_ptr = client.get();
-    for (const auto & object : objects)
-    {
-        LOG_TEST(log, "Removing object: {} (total: {})", object.remote_path, objects.size());
-        auto delete_info = client_ptr->DeleteBlob(object.remote_path);
-        if (!delete_info.Value.Deleted)
-            throw Exception(
-                ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Failed to delete file (path: {}) in AzureBlob Storage, reason: {}",
-                object.remote_path, delete_info.RawResponse ? delete_info.RawResponse->GetReasonPhrase() : "Unknown");
-    }
-}
-
 void AzureObjectStorage::removeObjectIfExists(const StoredObject & object)
 {
     auto client_ptr = client.get();
-    LOG_TEST(log, "Removing single object: {}", object.remote_path);
-    auto delete_info = client_ptr->DeleteBlob(object.remote_path);
+    try
+    {
+        LOG_TEST(log, "Removing single object: {}", object.absolute_path);
+        auto delete_info = client_ptr->DeleteBlob(object.absolute_path);
+    }
+    catch (const Azure::Storage::StorageException & e)
+    {
+        /// If object doesn't exist...
+        if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
+            return;
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        throw;
+    }
 }
 
 void AzureObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
@@ -291,11 +278,21 @@ void AzureObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
     auto client_ptr = client.get();
     for (const auto & object : objects)
     {
-        removeObjectIfExists(object);
+        try
+        {
+            auto delete_info = client_ptr->DeleteBlob(object.absolute_path);
+        }
+        catch (const Azure::Storage::StorageException & e)
+        {
+            /// If object doesn't exist...
+            if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
+                return;
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+            throw;
+        }
     }
 
 }
-
 
 ObjectMetadata AzureObjectStorage::getObjectMetadata(const std::string & path) const
 {

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -120,11 +120,6 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    /// Remove file. Throws exception if file doesn't exists or it's a directory.
-    void removeObject(const StoredObject & object) override;
-
-    void removeObjects(const StoredObjects & objects) override;
-
     void removeObjectIfExists(const StoredObject & object) override;
 
     void removeObjectsIfExist(const StoredObjects & objects) override;

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -106,7 +106,6 @@ std::unique_ptr<WriteBufferFromFileBase> CachedObjectStorage::writeObject( /// N
     if (cache_on_write)
     {
         auto key = getCacheKey(object.remote_path);
-
         return std::make_unique<CachedOnDiskWriteBufferFromFile>(
             std::move(implementation_buffer),
             cache,
@@ -126,19 +125,6 @@ void CachedObjectStorage::removeCacheIfExists(const std::string & path_key_for_c
 
     /// Add try catch?
     cache->removeKeyIfExists(getCacheKey(path_key_for_cache));
-}
-
-void CachedObjectStorage::removeObject(const StoredObject & object)
-{
-    object_storage->removeObject(object);
-}
-
-void CachedObjectStorage::removeObjects(const StoredObjects & objects)
-{
-    for (const auto & object : objects)
-        removeCacheIfExists(object.remote_path);
-
-    object_storage->removeObjects(objects);
 }
 
 void CachedObjectStorage::removeObjectIfExists(const StoredObject & object)

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -51,10 +51,6 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void removeObject(const StoredObject & object) override;
-
-    void removeObjects(const StoredObjects & objects) override;
-
     void removeObjectIfExists(const StoredObject & object) override;
 
     void removeObjectsIfExist(const StoredObjects & objects) override;

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -1,5 +1,6 @@
 #include <Disks/ObjectStorages/DiskObjectStorageTransaction.h>
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
+#include <Disks/ObjectStorages/StoredObject.h>
 #include <Disks/IO/WriteBufferWithFinalizeCallback.h>
 #include <Interpreters/Context.h>
 #include <Common/checkStackSize.h>
@@ -84,7 +85,7 @@ struct PureMetadataObjectStorageOperation final : public IDiskObjectStorageOpera
     {
     }
 
-    void finalize() override
+    void finalize(StoredObjects & /*to_remove*/) override
     {
     }
 
@@ -165,7 +166,7 @@ struct RemoveObjectStorageOperation final : public IDiskObjectStorageOperation
 
     }
 
-    void finalize() override
+    void finalize(StoredObjects & to_remove) override
     {
         /// The client for an object storage may do retries internally
         /// and there could be a situation when a query succeeded, but the response is lost
@@ -175,7 +176,7 @@ struct RemoveObjectStorageOperation final : public IDiskObjectStorageOperation
         if (!delete_metadata_only && !objects_to_remove.objects.empty()
             && objects_to_remove.unlink_outcome->num_hardlinks == 0)
         {
-            object_storage.removeObjectsIfExist(objects_to_remove.objects);
+            to_remove.append_range(std::move(objects_to_remove.objects));
         }
     }
 };
@@ -257,7 +258,7 @@ struct RemoveManyObjectStorageOperation final : public IDiskObjectStorageOperati
     {
     }
 
-    void finalize() override
+    void finalize(StoredObjects & to_remove) override
     {
         StoredObjects remove_from_remote;
         for (auto && [objects, unlink_outcome] : objects_to_remove)
@@ -269,7 +270,7 @@ struct RemoveManyObjectStorageOperation final : public IDiskObjectStorageOperati
         /// Read comment inside RemoveObjectStorageOperation class
         /// TL;DR Don't pay any attention to 404 status code
         if (!remove_from_remote.empty())
-            object_storage.removeObjectsIfExist(remove_from_remote);
+            to_remove.append_range(std::move(remove_from_remote));
     }
 };
 
@@ -349,10 +350,9 @@ struct RemoveRecursiveObjectStorageOperation final : public IDiskObjectStorageOp
 
     void undo() override
     {
-
     }
 
-    void finalize() override
+    void finalize(StoredObjects & to_remove) override
     {
         if (!keep_all_batch_data)
         {
@@ -365,7 +365,10 @@ struct RemoveRecursiveObjectStorageOperation final : public IDiskObjectStorageOp
                         std::move(objects_to_remove.objects.begin(), objects_to_remove.objects.end(), std::back_inserter(remove_from_remote));
                 }
             }
-            object_storage.removeObjects(remove_from_remote);
+
+            /// Read comment inside RemoveObjectStorageOperation class
+            /// TL;DR Don't pay any attention to 404 status code
+            to_remove.append_range(std::move(remove_from_remote));
         }
     }
 };
@@ -408,10 +411,12 @@ struct ReplaceFileObjectStorageOperation final : public IDiskObjectStorageOperat
 
     }
 
-    void finalize() override
+    void finalize(StoredObjects & to_remove) override
     {
+        /// Read comment inside RemoveObjectStorageOperation class
+        /// TL;DR Don't pay any attention to 404 status code
         if (!objects_to_remove.empty())
-            object_storage.removeObjects(objects_to_remove);
+            to_remove.append_range(std::move(objects_to_remove));
     }
 };
 
@@ -446,11 +451,10 @@ struct WriteFileObjectStorageOperation final : public IDiskObjectStorageOperatio
 
     void undo() override
     {
-        if (object_storage.exists(object))
-            object_storage.removeObject(object);
+        object_storage.removeObjectIfExists(object);
     }
 
-    void finalize() override
+    void finalize(StoredObjects & /*to_remove*/) override
     {
     }
 };
@@ -509,11 +513,10 @@ struct CopyFileObjectStorageOperation final : public IDiskObjectStorageOperation
 
     void undo() override
     {
-        for (const auto & object : created_objects)
-            destination_object_storage.removeObject(object);
+        destination_object_storage.removeObjectsIfExist(created_objects);
     }
 
-    void finalize() override
+    void finalize(StoredObjects & /*to_remove*/) override
     {
     }
 };
@@ -896,8 +899,10 @@ void DiskObjectStorageTransaction::commit()
         throw;
     }
 
+    StoredObjects objects_to_remove;
     for (const auto & operation : operations_to_execute)
-        operation->finalize();
+        operation->finalize(objects_to_remove);
+    object_storage.removeObjectsIfExist(objects_to_remove);
 }
 
 void DiskObjectStorageTransaction::undo()

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.h
@@ -24,11 +24,14 @@ public:
     /// Execute operation and something to metadata transaction
     virtual void execute(MetadataTransactionPtr transaction) = 0;
     /// Revert operation if possible
+    /// It is called if something went wrong before commit of metadata transaction
+    /// It is called in reverse order of execution of operations for all operations
+    /// even if they were not executed at all
     virtual void undo() = 0;
     /// Action to execute after metadata transaction successfully committed.
     /// Useful when it's impossible to revert operation
     /// like removal of blobs. Such implementation can lead to garbage.
-    virtual void finalize() = 0;
+    virtual void finalize(StoredObjects & to_remove) = 0;
     virtual ~IDiskObjectStorageOperation() = default;
 
     virtual std::string getInfoForLog() const = 0;

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -148,13 +148,6 @@ public:
 
     virtual bool isRemote() const = 0;
 
-    /// Remove object. Throws exception if object doesn't exists.
-    virtual void removeObject(const StoredObject & object) = 0;
-
-    /// Remove multiple objects. Some object storages can do batch remove in a more
-    /// optimal way.
-    virtual void removeObjects(const StoredObjects & objects) = 0;
-
     /// Remove object on path if exists
     virtual void removeObjectIfExists(const StoredObject & object) = 0;
 

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -135,7 +135,7 @@ std::unique_ptr<WriteBufferFromFileBase> LocalObjectStorage::writeObject( /// NO
     return std::make_unique<WriteBufferFromFile>(object.remote_path, buf_size);
 }
 
-void LocalObjectStorage::removeObject(const StoredObject & object)
+void LocalObjectStorage::removeObject(const StoredObject & object) const
 {
     /// For local object storage files are actually removed when "metadata" is removed.
     if (!exists(object))
@@ -145,7 +145,7 @@ void LocalObjectStorage::removeObject(const StoredObject & object)
         throwFromErrnoWithPath("Cannot unlink file " + object.remote_path, object.remote_path, ErrorCodes::CANNOT_UNLINK);
 }
 
-void LocalObjectStorage::removeObjects(const StoredObjects & objects)
+void LocalObjectStorage::removeObjects(const StoredObjects & objects) const
 {
     for (const auto & object : objects)
         removeObject(object);

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
@@ -4,6 +4,7 @@
 
 #include <Disks/ObjectStorages/IObjectStorage.h>
 
+
 namespace Poco
 {
 class Logger;
@@ -48,10 +49,6 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void removeObject(const StoredObject & object) override;
-
-    void removeObjects(const StoredObjects &  objects) override;
-
     void removeObjectIfExists(const StoredObject & object) override;
 
     void removeObjectsIfExist(const StoredObjects & objects) override;
@@ -93,6 +90,9 @@ public:
     ReadSettings patchSettings(const ReadSettings & read_settings) const override;
 
 private:
+    void removeObject(const StoredObject & object) const;
+    void removeObjects(const StoredObjects &  objects) const;
+
     String key_prefix;
     LoggerPtr log;
     std::string description;

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -130,7 +130,7 @@ void MetadataStorageFromPlainObjectStorageTransaction::unlinkFile(const std::str
 {
     auto object_key = metadata_storage.object_storage->generateObjectKeyForPath(path);
     auto object = StoredObject(object_key.serialize());
-    metadata_storage.object_storage->removeObject(object);
+    metadata_storage.object_storage->removeObjectIfExists(object);
 }
 
 void MetadataStorageFromPlainObjectStorageTransaction::removeDirectory(const std::string & path)
@@ -138,7 +138,7 @@ void MetadataStorageFromPlainObjectStorageTransaction::removeDirectory(const std
     if (metadata_storage.object_storage->isWriteOnce())
     {
         for (auto it = metadata_storage.iterateDirectory(path); it->isValid(); it->next())
-            metadata_storage.object_storage->removeObject(StoredObject(it->path()));
+            metadata_storage.object_storage->removeObjectIfExists(StoredObject(it->path()));
     }
     else
     {

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -65,7 +65,7 @@ void MetadataStorageFromPlainObjectStorageCreateDirectoryOperation::undo(std::un
     if (write_finalized)
     {
         path_map.erase(path);
-        object_storage->removeObject(StoredObject(object_key.serialize(), path / PREFIX_PATH_FILE_NAME));
+        object_storage->removeObjectIfExists(StoredObject(object_key.serialize(), path / PREFIX_PATH_FILE_NAME));
     }
     else if (write_created)
         object_storage->removeObjectIfExists(StoredObject(object_key.serialize(), path / PREFIX_PATH_FILE_NAME));
@@ -164,7 +164,7 @@ void MetadataStorageFromPlainObjectStorageRemoveDirectoryOperation::execute(std:
     key_prefix = path_it->second;
     auto object_key = ObjectStorageKey::createAsRelative(key_prefix, PREFIX_PATH_FILE_NAME);
     auto object = StoredObject(object_key.serialize(), path / PREFIX_PATH_FILE_NAME);
-    object_storage->removeObject(object);
+    object_storage->removeObjectIfExists(object);
     path_map.erase(path_it);
 }
 

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -331,19 +331,9 @@ void S3ObjectStorage::removeObjectsImpl(const StoredObjects & objects, bool if_e
                       ProfileEvents::DiskS3DeleteObjects);
 }
 
-void S3ObjectStorage::removeObject(const StoredObject & object)
-{
-    removeObjectImpl(object, false);
-}
-
 void S3ObjectStorage::removeObjectIfExists(const StoredObject & object)
 {
     removeObjectImpl(object, true);
-}
-
-void S3ObjectStorage::removeObjects(const StoredObjects & objects)
-{
-    removeObjectsImpl(objects, false);
 }
 
 void S3ObjectStorage::removeObjectsIfExist(const StoredObjects & objects)

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -100,13 +100,6 @@ public:
     ObjectStorageIteratorPtr iterate(const std::string & path_prefix) const override;
 
     /// Uses `DeleteObjectRequest`.
-    void removeObject(const StoredObject & object) override;
-
-    /// Uses `DeleteObjectsRequest` if it is allowed by `s3_capabilities`, otherwise `DeleteObjectRequest`.
-    /// `DeleteObjectsRequest` is not supported on GCS, see https://issuetracker.google.com/issues/162653700 .
-    void removeObjects(const StoredObjects & objects) override;
-
-    /// Uses `DeleteObjectRequest`.
     void removeObjectIfExists(const StoredObject & object) override;
 
     /// Uses `DeleteObjectsRequest` if it is allowed by `s3_capabilities`, otherwise `DeleteObjectRequest`.

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -238,16 +238,6 @@ std::unique_ptr<WriteBufferFromFileBase> WebObjectStorage::writeObject( /// NOLI
     throwNotAllowed();
 }
 
-void WebObjectStorage::removeObject(const StoredObject &)
-{
-    throwNotAllowed();
-}
-
-void WebObjectStorage::removeObjects(const StoredObjects &)
-{
-    throwNotAllowed();
-}
-
 void WebObjectStorage::removeObjectIfExists(const StoredObject &)
 {
     throwNotAllowed();

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.h
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.h
@@ -51,10 +51,6 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void removeObject(const StoredObject & object) override;
-
-    void removeObjects(const StoredObjects &  objects) override;
-
     void removeObjectIfExists(const StoredObject & object) override;
 
     void removeObjectsIfExist(const StoredObjects & objects) override;

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -7,11 +7,11 @@
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
 
-#include <QueryPipeline/Pipe.h>
-#include <Processors/ISimpleTransform.h>
-#include <Processors/Formats/IOutputFormat.h>
-#include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Interpreters/Context.h>
+#include <Processors/Executors/CompletedPipelineExecutor.h>
+#include <Processors/Formats/IOutputFormat.h>
+#include <Processors/ISimpleTransform.h>
+#include <QueryPipeline/Pipe.h>
 
 /// proton: starts
 #include <Processors/Formats/IRowInputFormat.h>
@@ -25,10 +25,10 @@ namespace ErrorCodes
 {
     extern const int UNSUPPORTED_METHOD;
     extern const int TIMEOUT_EXCEEDED;
-    extern const int CANNOT_FCNTL;
     extern const int CANNOT_READ_FROM_FILE_DESCRIPTOR;
-    extern const int CANNOT_POLL;
     extern const int CANNOT_WRITE_TO_FILE_DESCRIPTOR;
+    extern const int CANNOT_FCNTL;
+    extern const int CANNOT_POLL;
 }
 
 static bool tryMakeFdNonBlocking(int fd)
@@ -75,28 +75,22 @@ static bool pollFd(int fd, size_t timeout_milliseconds, int events)
     pfd.events = events;
     pfd.revents = 0;
 
-    Stopwatch watch;
-
     int res;
 
     while (true)
     {
+        Stopwatch watch;
         res = poll(&pfd, 1, static_cast<int>(timeout_milliseconds));
 
         if (res < 0)
         {
-            if (errno == EINTR)
-            {
-                watch.stop();
-                timeout_milliseconds -= watch.elapsedMilliseconds();
-                watch.start();
-
-                continue;
-            }
-            else
-            {
+            if (errno != EINTR)
                 throwFromErrno("Cannot poll", ErrorCodes::CANNOT_POLL);
-            }
+
+            const auto elapsed = watch.elapsedMilliseconds();
+            if (timeout_milliseconds <= elapsed)
+                break;
+            timeout_milliseconds -= elapsed;
         }
         else
         {


### PR DESCRIPTION
- [ ] clickhouse/clickhouse#44690: Fix flaky tests
- [ ] clickhouse/clickhouse#71529: use removeObjectIfExists instead of removeObject
- [ ] clickhouse/clickhouse#85316: Batch removed objects from different disk transaction operations

* fix

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
