### PR TITLE
feat: separate prometheus listen host configuration

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2117,24 +2117,45 @@ void Server::createServers(
     port_name = "prometheus.port";
     if (config.has(port_name))
     {
-        for (const auto & listen_host : listen_hosts)
-        {
-            UInt16 port = config.getUInt(port_name);
-            /// Prometheus (if defined and not setup yet with http_port)
-            createServer(config, listen_host, port_name, port, listen_try, start_servers, servers, [&](UInt16 port_) -> ProtocolServerAdapter
-            {
+        const UInt16 port = config.getUInt(port_name);
+
+        /// proton: starts
+        /// Lambda to create Prometheus server for a given listen_host
+        auto createPrometheusServer = [&](const std::string & host) {
+            createServer(config, host, port_name, port, listen_try, start_servers, servers, [&](UInt16 port_) -> ProtocolServerAdapter {
                 Poco::Net::ServerSocket socket;
-                auto address = socketBindListen(socket, listen_host, port_);
+                auto address = socketBindListen(socket, host, port_);
                 socket.setReceiveTimeout(settings.http_receive_timeout);
                 socket.setSendTimeout(settings.http_send_timeout);
-                return ProtocolServerAdapter(
-                    listen_host,
+                return {
+                    host,
                     port_name,
                     "Prometheus: http://" + address.toString(),
                     std::make_unique<HTTPServer>(
-                        context(), createHandlerFactory(*this, async_metrics, "PrometheusHandler-factory"), server_pool, socket, http_params));
+                        context(),
+                        createHandlerFactory(*this, async_metrics, "PrometheusHandler-factory"),
+                        server_pool,
+                        socket,
+                        http_params)};
             });
+        };
+
+        /// Check for Prometheus-specific listen_host configuration
+        const std::string prometheus_listen_host = config.getString("prometheus.listen_host", "");
+        if (!prometheus_listen_host.empty())
+        {
+            /// Use Prometheus-specific listen_host
+            createPrometheusServer(prometheus_listen_host);
         }
+        else
+        {
+            /// Fall back to global listen_hosts if no Prometheus-specific listen_host is configured
+            for (const auto & listen_host : listen_hosts)
+            {
+                createPrometheusServer(listen_host);
+            }
+        }
+        /// proton: ends
     }
 }
 }

--- a/programs/server/config.yaml
+++ b/programs/server/config.yaml
@@ -551,6 +551,7 @@ access_control_improvements:
 #     asynchronous_metrics: false
 
 # Serve endpoint for Prometheus monitoring.
+# listen_host - host to bind Prometheus server. If not defined, uses node listen_host
 # endpoint - mertics path (relative to root, starting with "/")
 # port - port to setup server. If not defined or 0 than http_port used
 # metrics - send data from table system.metrics
@@ -559,6 +560,7 @@ access_control_improvements:
 # status_info - send data from different component from CH, ex: Dictionaries status
 
 prometheus:
+    # listen_host: 0.0.0.0
     endpoint: /metrics
     port: 9363
     metrics: true


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
For now, it shares the global listen_host as other public servers. User like to only opens up prometheus to outside and all of other servers are listening on localhost

```
prometheus:
  listen_host: ...     # <<<<<<<<<<<<< Add this config. If it is not there, fallback to the global one under `node:` section
  asynchronous_metrics: true
  cluster: true
  endpoint: /metrics
  events: true
  external_stream: true
  materialized_view: true
  metrics: true
  port: 9363
  query_info: true
  status_info: true
```