### PR TITLE
honor incremental ckpt

### DIFF
--- a/src/Checkpoint/CheckpointCoordinator_Checkpoint.cpp
+++ b/src/Checkpoint/CheckpointCoordinator_Checkpoint.cpp
@@ -1,6 +1,7 @@
 #include <Checkpoint/CheckpointCoordinator.h>
 #include <Checkpoint/FileCheckpoint.h>
 #include <Checkpoint/LocalFileSystemCheckpointStorage.h>
+#include <Checkpoint/LogStoreCheckpointContext.h>
 
 
 #include <Common/Stopwatch.h>
@@ -19,8 +20,27 @@ extern const int RECOVER_CHECKPOINT_FAILED;
 
 void CheckpointCoordinator::preCheckpoint(DB::CheckpointContextPtr ckpt_ctx)
 {
-    /// Always use local storage directly
-    ckpt_ctx->storage.preCheckpoint(ckpt_ctx);
+    if (!ckpt_ctx->request_ctx)
+    {
+        ckpt_ctx->storage.preCheckpoint(ckpt_ctx);
+        return;
+    }
+
+    const auto & settings = ckpt_ctx->request_ctx->settings;
+    /// If the checkpoint is async, pre-checkpoint the storage locally first.
+    if (settings->isAsync() && !ckpt_ctx->storage.isLocal())
+    {
+        /// Always checkpoints to local storage so that we can recover from local disk fastly
+        local_ckpt_storage->preCheckpoint(ckpt_ctx);
+
+        /// Metadata needs to be checkpointed to the target storage directly
+        if (ckpt_ctx->epoch.empty())
+            ckpt_ctx->storage.preCheckpoint(ckpt_ctx);
+    }
+    else
+    {
+        ckpt_ctx->storage.preCheckpoint(ckpt_ctx);
+    }
 }
 
 void CheckpointCoordinator::checkpoint(
@@ -48,7 +68,59 @@ void CheckpointCoordinator::checkpoint(UInt32 node_id, CheckpointPtr ckpt, Check
 
 void CheckpointCoordinator::checkpoint(const String & key, CheckpointPtr ckpt, CheckpointContextPtr ckpt_ctx)
 {
-    ckpt_ctx->storage.checkpoint(key, std::move(ckpt), ckpt_ctx);
+    if (!ckpt_ctx->request_ctx)
+    {
+        ckpt_ctx->storage.checkpoint(key, std::move(ckpt), ckpt_ctx);
+        return;
+    }
+
+    const auto & settings = ckpt_ctx->request_ctx->settings;
+
+    bool incremental = settings->isIncremental() && ckpt->supportsIncremental() && ckpt_ctx->epoch.epoch > 1;
+    if (auto logstore_ckpt_ctx = ckpt_ctx->tryGetExtra<LogStoreCheckpointContext>();
+        logstore_ckpt_ctx && logstore_ckpt_ctx->force_request_full_ckpt)
+        incremental = false;
+
+    /// If the checkpoint is async, we need to checkpoint to local storage first.
+    if (settings->isAsync() && !ckpt_ctx->storage.isLocal())
+    {
+        if (incremental)
+        {
+            auto prev_ckpt_ctx = ckpt_ctx->cloneWithEpoch(ckpt_ctx->request_ctx->last_epoch);
+            CheckpointPtr prev_ckpt;
+            if (local_ckpt_storage->exists(key, prev_ckpt_ctx))
+                prev_ckpt = local_ckpt_storage->recover(key, prev_ckpt_ctx);
+            else if (ckpt_ctx->storage.exists(key, prev_ckpt_ctx))
+                prev_ckpt = ckpt_ctx->storage.recover(key, prev_ckpt_ctx);
+
+            if (prev_ckpt)
+                ckpt->enableIncremental(std::move(prev_ckpt));
+        }
+
+        /// Always checkpoints to local storage so that we can recover from local disk fastly
+        local_ckpt_storage->checkpoint(key, std::move(ckpt), ckpt_ctx);
+
+        /// Metadata needs to be checkpointed to the target storage directly
+        if (ckpt_ctx->epoch.empty())
+        {
+            auto local_ckpt = local_ckpt_storage->recover(key, ckpt_ctx);
+            ckpt_ctx->storage.checkpoint(key, std::move(local_ckpt), ckpt_ctx);
+        }
+    }
+    else
+    {
+        if (incremental)
+        {
+            auto prev_ckpt_ctx = ckpt_ctx->cloneWithEpoch(ckpt_ctx->request_ctx->last_epoch);
+            if (ckpt_ctx->storage.exists(key, prev_ckpt_ctx))
+            {
+                auto prev_ckpt = ckpt_ctx->storage.recover(key, std::move(prev_ckpt_ctx));
+                ckpt->enableIncremental(std::move(prev_ckpt));
+            }
+        }
+
+        ckpt_ctx->storage.checkpoint(key, std::move(ckpt), ckpt_ctx);
+    }
 }
 
 void CheckpointCoordinator::checkpointed(VersionType /*version*/, UInt32 node_id, CheckpointContextPtr ckpt_ctx)
@@ -64,7 +136,30 @@ void CheckpointCoordinator::checkpointed(VersionType /*version*/, UInt32 node_id
             /// Unregistered
             return;
 
-        chassert(ckpt_ctx->epoch == iter->second->current_epoch);
+        if (ckpt_ctx->epoch != iter->second->current_epoch)
+        {
+            if (!iter->second->ack_nodes_readonly.contains(node_id))
+            {
+                LOG_WARNING(
+                    logger,
+                    "Ignored checkpoint ack from non-ack node: node_id={} ack_epoch={} current_epoch={} query_id={} ack_nodes_count={}",
+                    node_id,
+                    ckpt_ctx->epoch,
+                    iter->second->current_epoch,
+                    ckpt_ctx->qid,
+                    iter->second->ack_nodes.size());
+                return;
+            }
+
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Checkpoint ack epoch mismatch: node_id={} ack_epoch={} current_epoch={} query_id={} ack_nodes_count={}",
+                node_id,
+                ckpt_ctx->epoch,
+                iter->second->current_epoch,
+                ckpt_ctx->qid,
+                iter->second->ack_nodes.size());
+        }
         chassert(ckpt_ctx->request_ctx);
 
         if (iter->second->ack(node_id))

--- a/src/Checkpoint/CheckpointSettings.cpp
+++ b/src/Checkpoint/CheckpointSettings.cpp
@@ -16,7 +16,6 @@ extern const int INVALID_SETTING_VALUE;
 
 namespace
 {
-#if 0
 bool parseBoolTextWord(const std::string & str, std::string_view setting_name)
 {
     if (str.empty())
@@ -39,7 +38,6 @@ bool parseBoolTextWord(const std::string & str, std::string_view setting_name)
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Invalid setting '{}': {}", setting_name, e.what());
     }
 }
-#endif
 }
 
 void CheckpointSettings::serialize(VersionType, WriteBuffer & wb) const
@@ -68,7 +66,13 @@ void CheckpointSettings::deserialize(VersionType version, ReadBuffer & rb)
 
         /// Repair raw settings
         std::string replication_type_str = "local_file_system"; // Always local
-        raw_settings = fmt::format("type={};replication_type={};interval={};", "file", replication_type_str, interval);
+        raw_settings = fmt::format(
+            "type={};replication_type={};interval={};async={};incremental={}",
+            "file",
+            replication_type_str,
+            interval,
+            isAsync(),
+            isIncremental());
     }
 }
 
@@ -152,6 +156,12 @@ void CheckpointSettings::parseImpl()
 
     if (auto iter = settings_map.find("interval"); iter != settings_map.end())
         interval = std::stoul(iter->second);
+
+    if (auto iter = settings_map.find("async"); iter != settings_map.end())
+        strategy.async = parseBoolTextWord(iter->second, "async");
+
+    if (auto iter = settings_map.find("incremental"); iter != settings_map.end())
+        strategy.incremental = parseBoolTextWord(iter->second, "incremental");
 
     /// Other unknown settings are ignored
 }


### PR DESCRIPTION

Please write user-readable short description of the changes:
fix #1079

```
  -- Source streams
  DROP STREAM IF EXISTS orders;
  DROP STREAM IF EXISTS products;

  CREATE STREAM orders(order_id int32, product_id int32, quantity int32);
  CREATE STREAM products(product_id int32, name string)
      PRIMARY KEY product_id SETTINGS mode='versioned_kv';

  -- Target stream
  DROP STREAM IF EXISTS enriched_orders;
  CREATE STREAM enriched_orders(order_id int32, product_name string, quantity int32);

  -- MV with join using hybrid hash join and incremental checkpoint
  DROP VIEW IF EXISTS mv_join_incr_ckpt;

  CREATE MATERIALIZED VIEW mv_join_incr_ckpt
  INTO enriched_orders
  AS
  SELECT
      o.order_id,
      p.name AS product_name,
      o.quantity
  FROM orders AS o
  INNER JOIN products AS p ON o.product_id = p.product_id
  SETTINGS
      seek_to = 'earliest',
      checkpoint_interval = 2,
      default_hash_join = 'hybrid',
      checkpoint_settings = 'type=auto;incremental=true';

  -- Insert product data
  INSERT INTO products(product_id, name) VALUES (1, 'Widget'), (2, 'Gadget');

  -- Insert orders
  INSERT INTO orders(order_id, product_id, quantity) VALUES (100, 1, 5), (101, 2, 3);

  -- Wait for epoch 1 checkpoint
  SELECT sleep(3) FORMAT Null;

  -- Insert more data to trigger activity for epoch 2
  INSERT INTO orders(order_id, product_id, quantity) VALUES (102, 1, 10);

  -- Wait for epoch 2 checkpoint (incremental should kick in here)
  SELECT sleep(3) FORMAT Null;

  -- Insert more data for epoch 3
  INSERT INTO orders(order_id, product_id, quantity) VALUES (103, 2, 7);

  -- Wait for epoch 3 checkpoint
  SELECT sleep(3) FORMAT Null;


```


old:
```
2026.01.07 04:44:27.708451 [ 220 ] {.mv-047c9b6a-1fa9-4ac1-8e32-0dc7a987929b} <Information> RocksCheckpoint: Took 13 ms to materialized rocks ckpt to 
.mv-047c9b6a-1fa9-4ac1-8e32-0dc7a987929b/3_01KEBCAFJQN2GNX0430PCBDPM2/1.rckpt on disk local_fs_ckpt_storage (/var/lib/proton/checkpoint/), materialized_bytes=2
2026.01.07 04:44:27.708507 [ 220 ] {.mv-047c9b6a-1fa9-4ac1-8e32-0dc7a987929b} <Information> LocalFileSystemCheckpointStorage: Committed checkpoint 
epoch=3_01KEBCAFJQN2GNX0430PCBDPM2 for query=.mv-047c9b6a-1fa9-4ac1-8e32-0dc7a987929b

```

new:
```
2026.01.07 04:42:04.211291 [ 5826 ] {.mv-8e9f4216-34cc-4547-b601-fcf461ffb70e} <Information> RocksCheckpoint: Took 12 ms to materialized incremental rocks ckpt to 
.mv-8e9f4216-34cc-4547-b601-fcf461ffb70e/3_01KEBC63H429WKM6YEXZSM1Z09/1.rckpt on disk local_fs_ckpt_storage (./proton-data/checkpoint/), materialized_bytes=2
2026.01.07 04:42:04.211340 [ 5826 ] {.mv-8e9f4216-34cc-4547-b601-fcf461ffb70e} <Information> LocalFileSystemCheckpointStorage: Committed checkpoint 
epoch=3_01KEBC63H429WKM6YEXZSM1Z09 for query=.mv-8e9f4216-34cc-4547-b601-fcf461ffb70e

```


  | Epoch | Old Version             | New Version                             |
  |-------|-------------------------|-----------------------------------------|
  | 1     | materialized rocks ckpt | materialized rocks ckpt                 |
  | 2     | materialized rocks ckpt | materialized **incremental** rocks ckpt |
  | 3     | materialized rocks ckpt | materialized **incremental** rocks ckpt |

  The difference is the word "incremental" in the log message:

  Old (broken):
  RocksCheckpoint: Took 12 ms to materialized rocks ckpt to ...

  New (fixed):
  RocksCheckpoint: Took 10 ms to materialized incremental rocks ckpt to ...

  The old version was ignoring the incremental=true setting and always doing full checkpoints. Now correctly enables incremental checkpointing for epoch 2+.
