### PR TITLE
Disable pushdown non deterministic predicate exp

### DIFF
--- a/src/Cluster/LocalLog/Log/Loglet.cpp
+++ b/src/Cluster/LocalLog/Log/Loglet.cpp
@@ -505,8 +505,6 @@ FileLogEntriesPtr Loglet::doFetch(
 
 CallResult<std::optional<int64_t>> Loglet::sequenceForTimestamp(int64_t ts, bool /*append_time*/) const
 {
-    assert(ts > 0);
-
     auto ts_sn = event_ts_sn_index->leftLowerBoundSequenceForTimestamp(ts);
     if (ts_sn.hasError())
         return CallResult{std::optional<int64_t>{}, ts_sn.error_code};

--- a/src/Functions/Streaming/StreamingNow.cpp
+++ b/src/Functions/Streaming/StreamingNow.cpp
@@ -78,6 +78,8 @@ public:
 
     bool isDeterministic() const override { return false; }
 
+    bool isDeterministicInScopeOfQuery() const override { return false; }
+
     bool isVariadic() const override { return true; }
 
     size_t getNumberOfArguments() const override { return 0; }

--- a/src/Functions/Streaming/StreamingNow64.cpp
+++ b/src/Functions/Streaming/StreamingNow64.cpp
@@ -84,6 +84,8 @@ public:
 
     bool isDeterministic() const override { return false; }
 
+    bool isDeterministicInScopeOfQuery() const override { return false; }
+
     bool isVariadic() const override { return true; }
 
     size_t getNumberOfArguments() const override { return 0; }

--- a/src/Functions/Streaming/earliestTimestamp.cpp
+++ b/src/Functions/Streaming/earliestTimestamp.cpp
@@ -27,10 +27,6 @@ public:
 
     String getName() const override { return name; }
 
-    bool isDeterministic() const override { return false; }
-
-    bool isDeterministicInScopeOfQuery() const override { return false; }
-
     bool isVariadic() const override { return true; }
 
     size_t getNumberOfArguments() const override { return 0; }
@@ -58,10 +54,6 @@ public:
     static constexpr auto name = "earliest_timestamp";
 
     String getName() const override { return name; }
-
-    bool isDeterministic() const override { return false; }
-
-    bool isDeterministicInScopeOfQuery() const override { return false; }
 
     bool isVariadic() const override { return true; }
 

--- a/src/Functions/Streaming/earliestTimestamp.cpp
+++ b/src/Functions/Streaming/earliestTimestamp.cpp
@@ -29,6 +29,8 @@ public:
 
     bool isDeterministic() const override { return false; }
 
+    bool isDeterministicInScopeOfQuery() const override { return false; }
+
     bool isVariadic() const override { return true; }
 
     size_t getNumberOfArguments() const override { return 0; }
@@ -58,6 +60,8 @@ public:
     String getName() const override { return name; }
 
     bool isDeterministic() const override { return false; }
+
+    bool isDeterministicInScopeOfQuery() const override { return false; }
 
     bool isVariadic() const override { return true; }
 

--- a/tests/queries_ported/0_stateless/99081_non_deterministic_funcs_bug.reference
+++ b/tests/queries_ported/0_stateless/99081_non_deterministic_funcs_bug.reference
@@ -1,0 +1,5 @@
+======== non-deterministic predicate expressions should not be pushed down ========
+1
+1
+1
+1

--- a/tests/queries_ported/0_stateless/99081_non_deterministic_funcs_bug.sql
+++ b/tests/queries_ported/0_stateless/99081_non_deterministic_funcs_bug.sql
@@ -1,0 +1,14 @@
+DROP STREAM IF EXISTS 99081_kv;
+
+CREATE MUTABLE STREAM 99081_kv(i int, v string) primary key i;
+
+select ts, ts2, v from (select now() as ts, i, v from 99081_kv) as kv1 join (select now64(3) as ts2, i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0; -- { serverError UNSUPPORTED }
+select ts, ts2, v from (select now() as ts, i, v from 99081_kv) as kv1 join (select now64(3) as ts2, i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0 settings query_mode='table';
+
+--- `now() as ts` and `now64(3) as ts2` are not used
+select i, v from (select now() as ts, i, v from 99081_kv) as kv1 join (select now64(3) as ts2, i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0;
+
+select now() as ts, now64(3) as ts2, v, _tp_delta from (select i, v from 99081_kv) as kv1 join (select i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0 emit changelog;
+select now() as ts, now64(3) as ts2, v from (select i, v from 99081_kv) as kv1 join (select i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0;
+
+DROP STREAM IF EXISTS 99081_kv;

--- a/tests/queries_ported/0_stateless/99081_non_deterministic_funcs_bug.sql
+++ b/tests/queries_ported/0_stateless/99081_non_deterministic_funcs_bug.sql
@@ -1,6 +1,6 @@
 DROP STREAM IF EXISTS 99081_kv;
 
-CREATE MUTABLE STREAM 99081_kv(i int, v string) primary key i;
+CREATE STREAM 99081_kv(i int, v string) primary key i settings mode='versioned_kv';
 
 select ts, ts2, v from (select now() as ts, i, v from 99081_kv) as kv1 join (select now64(3) as ts2, i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0; -- { serverError UNSUPPORTED }
 select ts, ts2, v from (select now() as ts, i, v from 99081_kv) as kv1 join (select now64(3) as ts2, i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0 settings query_mode='table';
@@ -10,5 +10,48 @@ select i, v from (select now() as ts, i, v from 99081_kv) as kv1 join (select no
 
 select now() as ts, now64(3) as ts2, v, _tp_delta from (select i, v from 99081_kv) as kv1 join (select i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0 emit changelog;
 select now() as ts, now64(3) as ts2, v from (select i, v from 99081_kv) as kv1 join (select i from 99081_kv) as kv2 on kv1.i = kv2.i limit 0;
+
+--- https://github.com/timeplus-io/proton-enterprise/issues/11122: streaming now() predicate should not be pushed down
+SELECT '======== non-deterministic predicate expressions should not be pushed down ========';
+
+--- Case-1: subquery
+SELECT
+    sum(explain ILIKE '%Filter%') AS filter_count
+FROM (
+    EXPLAIN PLAN
+    SELECT v
+    FROM (SELECT * FROM 99081_kv) AS s
+    WHERE now() > to_datetime('1970-01-01 00:00:01') --- now()
+);
+
+SELECT
+    sum(explain ILIKE '%Filter%') AS filter_count
+FROM (
+    EXPLAIN PLAN
+    SELECT v
+    FROM (SELECT * FROM 99081_kv) AS s
+    WHERE now64(3) > to_datetime64('1970-01-01 00:00:01.000', 3) --- now64(3)
+);
+
+--- Case-2: join
+SELECT
+    sum(explain ILIKE '%Filter%') AS filter_count
+FROM (
+    EXPLAIN PLAN
+    SELECT kv1.v
+    FROM 99081_kv AS kv1
+    JOIN (SELECT i FROM 99081_kv) AS kv2 ON kv1.i = kv2.i
+    WHERE now() > to_datetime('1970-01-01 00:00:01') --- now()
+);
+
+SELECT
+    sum(explain ILIKE '%Filter%') AS filter_count
+FROM (
+    EXPLAIN PLAN
+    SELECT kv1.v
+    FROM 99081_kv AS kv1
+    JOIN (SELECT i FROM 99081_kv) AS kv2 ON kv1.i = kv2.i
+    WHERE now64(3) > to_datetime64('1970-01-01 00:00:01.000', 3) --- now64(3)
+);
 
 DROP STREAM IF EXISTS 99081_kv;


### PR DESCRIPTION


Please write user-readable short description of the changes:

Current logic will skip pushdown non deterministic function in scope of query,
https://github.com/timeplus-io/proton/blob/959b8dc634313dd5295e04357d75806af9a7f572/src/Interpreters/ExtractExpressionInfoVisitor.cpp#L93-L94

but these streaming functions's isDeterministicInScopeOfQuery() are not overrided

