### PR TITLE
fix iceberg namespace for rest catalog

### DIFF
--- a/src/Databases/ApacheIceberg/DatabaseIceberg.cpp
+++ b/src/Databases/ApacheIceberg/DatabaseIceberg.cpp
@@ -59,26 +59,28 @@ extern const int UNSUPPORTED;
 
 namespace
 {
-/// Parse a string, containing at least one dot, into a two substrings:
-/// A.B.C.D.E -> A.B.C.D and E, where
-/// `A.B.C.D` is a table "namespace".
-/// `E` is a table name.
-std::pair<std::string, std::string> parseTableName(const std::string & name)
-{
-    auto pos = name.rfind('.');
-    if (pos == std::string::npos)
-        return {"", name};
-
-    auto table_name = name.substr(pos + 1);
-    auto namespace_name = name.substr(0, name.size() - table_name.size() - 1);
-    return {std::move(namespace_name), std::move(table_name)};
-}
-
 auto & tableCache()
 {
     static LRUCache<std::string, IStorage> table_cache{/*max_size_=*/1000};
     return table_cache;
 }
+}
+
+std::pair<std::string, std::string> DatabaseApacheIceberg::getNamespaceAndTableName(const std::string & stream_name) const
+{
+    /// Return <namespace_name, table_name> pair for ICatalog function's parameters
+    /// Parse the full stream name (`database_name`.`stream_name`) into a two substrings:
+    /// `A`.`B.C.D.E` -> A.B.C.D and E, where
+    /// `A.B.C.D` is a table "namespace".
+    /// `E` is a table name.
+
+    auto pos = stream_name.rfind('.');
+    if (pos == std::string::npos)
+        return {getDatabaseName(), stream_name};
+
+    auto table_name = stream_name.substr(pos + 1);
+    auto namespace_name = fmt::format("{}.{}", getDatabaseName(), stream_name.substr(0, stream_name.size() - table_name.size() - 1));
+    return {std::move(namespace_name), std::move(table_name)};
 }
 
 DatabaseApacheIceberg::DatabaseApacheIceberg(
@@ -220,9 +222,8 @@ bool DatabaseApacheIceberg::empty() const
 
 bool DatabaseApacheIceberg::isTableExist(const String & name, ContextPtr /* context_ */) const
 {
-    const auto [namespace_name, table_name] = parseTableName(name);
-    return getCatalog()->existsTable(
-        namespace_name.empty() ? getDatabaseName() : fmt::format("{}.{}", getDatabaseName(), namespace_name), table_name);
+    const auto [namespace_name, table_name] = getNamespaceAndTableName(name);
+    return getCatalog()->existsTable(namespace_name, table_name);
 }
 
 StoragePtr DatabaseApacheIceberg::tryGetTable(const String & name [[maybe_unused]], ContextPtr context_ [[maybe_unused]]) const
@@ -234,9 +235,9 @@ StoragePtr DatabaseApacheIceberg::tryGetTable(const String & name [[maybe_unused
     if (with_vended_credentials)
         table_metadata = table_metadata.withStorageCredentials();
 
-    auto cache_key = fmt::format("{}.{}", getDatabaseName(), name);
-
-    if (!catalog->tryGetTableMetadata(getDatabaseName(), name, table_metadata))
+    const auto [namespace_name, table_name] = getNamespaceAndTableName(name);
+    auto cache_key = fmt::format("{}.{}", namespace_name, table_name);
+    if (!catalog->tryGetTableMetadata(namespace_name, table_name, table_metadata))
     {
         tableCache().remove(cache_key);
         return nullptr;
@@ -389,9 +390,10 @@ void DatabaseApacheIceberg::createTable(ContextPtr /*context*/, const String & n
     const auto & new_create_query = parseCreateQueryFromAST(origin_create_query, getDatabaseName(), name);
     table->setInMemoryCreateQuery(new_create_query);
 
+    const auto [namespace_name, table_name] = getNamespaceAndTableName(name);
     getCatalog()->createTable(
-        getDatabaseName(),
-        name,
+        namespace_name,
+        table_name,
         endpoint + (endpoint.ends_with('/') ? "" : "/") + name,
         table->getInMemoryMetadata().getColumns().getAllPhysical(),
         std::nullopt,
@@ -402,8 +404,9 @@ void DatabaseApacheIceberg::createTable(ContextPtr /*context*/, const String & n
 
 void DatabaseApacheIceberg::dropTable(ContextPtr /*context*/, const String & name, bool /*sync = false*/, const ASTPtr & /*query*/)
 {
-    getCatalog()->deleteTable(getDatabaseName(), name);
-    tableCache().remove(fmt::format("{}.{}", getDatabaseName(), name));
+    const auto [namespace_name, table_name] = getNamespaceAndTableName(name);
+    getCatalog()->deleteTable(namespace_name, table_name);
+    tableCache().remove(fmt::format("{}.{}", namespace_name, table_name));
 }
 
 ASTPtr DatabaseApacheIceberg::getCreateTableQueryImpl(const String & name, ContextPtr context_, bool throw_on_error) const
@@ -423,9 +426,8 @@ ASTPtr DatabaseApacheIceberg::generateCreateTableQuery(const String & name, [[ma
 {
     auto table_metadata = Apache::Iceberg::TableMetadata().withLocation().withSchema();
 
-    const auto [namespace_name, table_name] = parseTableName(name);
-    getCatalog()->getTableMetadata(
-        namespace_name.empty() ? getDatabaseName() : fmt::format("{}.{}", getDatabaseName(), namespace_name), table_name, table_metadata);
+    const auto [namespace_name, table_name] = getNamespaceAndTableName(name);
+    getCatalog()->getTableMetadata(namespace_name, table_name, table_metadata);
 
     auto create_table_query = std::make_shared<ASTCreateQuery>();
 

--- a/src/Databases/ApacheIceberg/DatabaseIceberg.h
+++ b/src/Databases/ApacheIceberg/DatabaseIceberg.h
@@ -51,6 +51,8 @@ protected:
 
     ASTPtr generateCreateTableQuery(const String & table_name, const StoragePtr & storage, bool throw_on_error) const;
 
+    std::pair<std::string, std::string> getNamespaceAndTableName(const std::string & stream_name) const;
+
 private:
     void validateSettings();
     void parseStorageCredentials();

--- a/src/Storages/Iceberg/RestCatalog.cpp
+++ b/src/Storages/Iceberg/RestCatalog.cpp
@@ -151,7 +151,7 @@ std::string encodeNamespaceName(const std::string & namespace_name)
         else
             /// 0x1F is a unit separator
             /// https://github.com/apache/iceberg/blob/70d87f1750627b14b3b25a0216a97db86a786992/open-api/rest-catalog-open-api.yaml#L264
-            result.push_back(static_cast<char>(0x1F));
+            result += "%1F";
     }
     return result;
 }
@@ -479,7 +479,7 @@ Poco::URI::QueryParameters RestCatalog::createParentNamespaceParams(const std::s
 
 DB::Names RestCatalog::getTablesImpl(const std::string & base_namespace, size_t limit) const
 {
-    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / base_namespace / "tables";
+    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / encodeNamespaceName(base_namespace) / "tables";
     auto buf = createReadBuffer(
         config.prefix / endpoint,
         Poco::Net::HTTPRequest::HTTP_GET,
@@ -632,8 +632,12 @@ void extractTableMetadata(const std::string & json_str, TableMetadata & result, 
     result.setSequenceNumber(metadata_object->getValue<uint64_t>("last-sequence-number"));
     result.setTableUUID(metadata_object->getValue<std::string>("table-uuid"));
 
-    auto snapshot_id = metadata_object->getValue<int64_t>("current-snapshot-id");
-    result.setSnapshotID(snapshot_id);
+    int64_t snapshot_id = 0;
+    if (metadata_object->has("current-snapshot-id"))
+    {
+        snapshot_id = metadata_object->getValue<int64_t>("current-snapshot-id");
+        result.setSnapshotID(snapshot_id);
+    }
 
     auto snapshots = metadata_object->get("snapshots");
     if (!snapshots.isEmpty() && snapshots.isArray())
@@ -817,7 +821,7 @@ bool RestCatalog::tryGetTableMetadata(const std::string & namespace_name, const 
 void RestCatalog::getTableMetadata(const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const
 {
     if (!getTableMetadataImpl(namespace_name, table_name, result))
-        throw DB::Exception(DB::ErrorCodes::ICEBERG_CATALOG_ERROR, "No response from iceberg catalog");
+        throw DB::Exception(DB::ErrorCodes::ICEBERG_CATALOG_ERROR, "Table not found from iceberg catalog: namespace={} table={}", namespace_name, table_name);
 }
 
 bool RestCatalog::getTableMetadataImpl(const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -140,7 +140,12 @@ ColumnPtr getFilteredTables(const ActionsDAG::Node * predicate, const ColumnPtr 
         {
             database_column->insert(table_it->name());
             if (engine_column)
-                engine_column->insert(table_it->table()->getName());
+            {
+                if (const auto & storage = table_it->table(); storage)
+                    engine_column->insert(table_it->table()->getName());
+                else
+                    engine_column->insert("Unknown");
+            }
         }
     }
 


### PR DESCRIPTION
Fix #1083 

Fix the inconsistency in mapping proton stream name to Iceberg namespace name. And the issue in encoding multipart namespace ('.' -> "%1F")

For example, Proton stream \`a\`.\`b.c.d\` is with namespace \`a.b.c\` and table name \`d\` in Iceberg.

It is a little strange namespace is part from database name and part from the prefix of stream name. In ClickHouse, it put all the namespace in table name prefix (\`a\`.\`b.c.d\` is to namespace \`b.c\` and table name \`d\`. database name \`a\` is just to identify catalog)
