### PR TITLE
Fix Windows CMake configure (no uname, AMD64 mapping, skip polluted env check)

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -15,36 +15,38 @@ if (NOT DEFINED ENV{XCODE_IDE})
     endif ()
 endif()
 
-# Check if environment is polluted.
-if (NOT "$ENV{CFLAGS}" STREQUAL ""
-    OR NOT "$ENV{CXXFLAGS}" STREQUAL ""
-    OR NOT "$ENV{LDFLAGS}" STREQUAL ""
-    OR CMAKE_C_FLAGS OR CMAKE_CXX_FLAGS OR CMAKE_EXE_LINKER_FLAGS OR CMAKE_MODULE_LINKER_FLAGS
-    OR CMAKE_C_FLAGS_INIT OR CMAKE_CXX_FLAGS_INIT OR CMAKE_EXE_LINKER_FLAGS_INIT OR CMAKE_MODULE_LINKER_FLAGS_INIT)
+# Check if environment is polluted (skip on Windows where MSVC sets default flags).
+if (NOT WIN32)
+    if (NOT "$ENV{CFLAGS}" STREQUAL ""
+        OR NOT "$ENV{CXXFLAGS}" STREQUAL ""
+        OR NOT "$ENV{LDFLAGS}" STREQUAL ""
+        OR CMAKE_C_FLAGS OR CMAKE_CXX_FLAGS OR CMAKE_EXE_LINKER_FLAGS OR CMAKE_MODULE_LINKER_FLAGS
+        OR CMAKE_C_FLAGS_INIT OR CMAKE_CXX_FLAGS_INIT OR CMAKE_EXE_LINKER_FLAGS_INIT OR CMAKE_MODULE_LINKER_FLAGS_INIT)
 
-    # if $ENV
-    message("CFLAGS: $ENV{CFLAGS}")
-    message("CXXFLAGS: $ENV{CXXFLAGS}")
-    message("LDFLAGS: $ENV{LDFLAGS}")
-    # if *_FLAGS
-    message("CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
-    message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-    message("CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
-    message("CMAKE_MODULE_LINKER_FLAGS: ${CMAKE_MODULE_LINKER_FLAGS}")
-    # if *_FLAGS_INIT
-    message("CMAKE_C_FLAGS_INIT: ${CMAKE_C_FLAGS_INIT}")
-    message("CMAKE_CXX_FLAGS_INIT: ${CMAKE_CXX_FLAGS_INIT}")
-    message("CMAKE_EXE_LINKER_FLAGS_INIT: ${CMAKE_EXE_LINKER_FLAGS_INIT}")
-    message("CMAKE_MODULE_LINKER_FLAGS_INIT: ${CMAKE_MODULE_LINKER_FLAGS_INIT}")
+        # if $ENV
+        message("CFLAGS: $ENV{CFLAGS}")
+        message("CXXFLAGS: $ENV{CXXFLAGS}")
+        message("LDFLAGS: $ENV{LDFLAGS}")
+        # if *_FLAGS
+        message("CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
+        message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+        message("CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
+        message("CMAKE_MODULE_LINKER_FLAGS: ${CMAKE_MODULE_LINKER_FLAGS}")
+        # if *_FLAGS_INIT
+        message("CMAKE_C_FLAGS_INIT: ${CMAKE_C_FLAGS_INIT}")
+        message("CMAKE_CXX_FLAGS_INIT: ${CMAKE_CXX_FLAGS_INIT}")
+        message("CMAKE_EXE_LINKER_FLAGS_INIT: ${CMAKE_EXE_LINKER_FLAGS_INIT}")
+        message("CMAKE_MODULE_LINKER_FLAGS_INIT: ${CMAKE_MODULE_LINKER_FLAGS_INIT}")
 
-    message(FATAL_ERROR "
-        Some of the variables like CFLAGS, CXXFLAGS, LDFLAGS are not empty.
-        It is not possible to build proton with custom flags.
-        These variables can be set up by previous invocation of some other build tools.
-        You should cleanup these variables and start over again.
-        Run the `env` command to check the details.
-        You will also need to remove the contents of the build directory.
-        Note: if you don't like this behavior, you can manually edit the cmake files, but please don't complain to developers.")
+        message(FATAL_ERROR "
+            Some of the variables like CFLAGS, CXXFLAGS, LDFLAGS are not empty.
+            It is not possible to build proton with custom flags.
+            These variables can be set up by previous invocation of some other build tools.
+            You should cleanup these variables and start over again.
+            Run the `env` command to check the details.
+            You will also need to remove the contents of the build directory.
+            Note: if you don't like this behavior, you can manually edit the cmake files, but please don't complain to developers.")
+    endif()
 endif()
 
 # Default toolchain - this is needed to avoid dependency on OS files.

--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -48,14 +48,19 @@ if (NOT "$ENV{CFLAGS}" STREQUAL ""
 endif()
 
 # Default toolchain - this is needed to avoid dependency on OS files.
-execute_process(COMMAND uname -s
-    OUTPUT_VARIABLE OS
-    COMMAND_ERROR_IS_FATAL ANY
-)
-execute_process(COMMAND uname -m
-    OUTPUT_VARIABLE ARCH
-    COMMAND_ERROR_IS_FATAL ANY
-)
+if (NOT WIN32)
+    execute_process(COMMAND uname -s
+        OUTPUT_VARIABLE OS
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(COMMAND uname -m
+        OUTPUT_VARIABLE ARCH
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+else()
+    set(OS "${CMAKE_SYSTEM_NAME}")
+    set(ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
 
 # By default, prefer clang on Linux
 # But note, that you still may change the compiler with -DCMAKE_C_COMPILER/-DCMAKE_CXX_COMPILER.

--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
     if (CMAKE_LIBRARY_ARCHITECTURE MATCHES "i386")
         message (FATAL_ERROR "32bit platforms are not supported")
     endif ()


### PR DESCRIPTION
/claim #535 
### Summary
This PR fixes Windows CMake configuration failures without refactoring or changing runtime logic.

### What was broken on Windows
- `PreLoad.cmake` tried to call `uname`, which is not available on Windows.
- CMake arch detection treated `AMD64` as unsupported.
- The “polluted environment flags” check always failed on Windows because MSVC sets default flags.

### Fix (minimal scope)
- Avoid calling `uname` on Windows; use `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_PROCESSOR`.
- Treat `AMD64` as `x86_64` in CMake arch detection.
- Skip the polluted-env fatal check on `WIN32` (MSVC defaults would otherwise abort configure).

### Build / Repro (WSL recommended)
```bash
git submodule sync --recursive
git submodule update --init --recursive
cmake -S . -B build -G Ninja
ninja -C build -j2

Note: `test_unit_tests_dbms` is long-running on my WSL setup. With `ctest --timeout 900` it times out after ~15 minutes while still making progress (log ends mid-suite, e.g. `StreamingHashJoin.SimpleJoinTests`, not a crash).
Previously on the same setup it completed in ~33 minutes with 11264/11265 passed and 1 failing gtest (`TimeWheel.Concurrency_Thread`).

