### PR TITLE
CMake: improve Windows configure path (avoid uname, AMD64 mapping, skip polluted-env check)

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -15,36 +15,38 @@ if (NOT DEFINED ENV{XCODE_IDE})
     endif ()
 endif()
 
-# Check if environment is polluted.
-if (NOT "$ENV{CFLAGS}" STREQUAL ""
-    OR NOT "$ENV{CXXFLAGS}" STREQUAL ""
-    OR NOT "$ENV{LDFLAGS}" STREQUAL ""
-    OR CMAKE_C_FLAGS OR CMAKE_CXX_FLAGS OR CMAKE_EXE_LINKER_FLAGS OR CMAKE_MODULE_LINKER_FLAGS
-    OR CMAKE_C_FLAGS_INIT OR CMAKE_CXX_FLAGS_INIT OR CMAKE_EXE_LINKER_FLAGS_INIT OR CMAKE_MODULE_LINKER_FLAGS_INIT)
+# Check if environment is polluted (skip on Windows where MSVC sets default flags).
+if (NOT WIN32)
+    if (NOT "$ENV{CFLAGS}" STREQUAL ""
+        OR NOT "$ENV{CXXFLAGS}" STREQUAL ""
+        OR NOT "$ENV{LDFLAGS}" STREQUAL ""
+        OR CMAKE_C_FLAGS OR CMAKE_CXX_FLAGS OR CMAKE_EXE_LINKER_FLAGS OR CMAKE_MODULE_LINKER_FLAGS
+        OR CMAKE_C_FLAGS_INIT OR CMAKE_CXX_FLAGS_INIT OR CMAKE_EXE_LINKER_FLAGS_INIT OR CMAKE_MODULE_LINKER_FLAGS_INIT)
 
-    # if $ENV
-    message("CFLAGS: $ENV{CFLAGS}")
-    message("CXXFLAGS: $ENV{CXXFLAGS}")
-    message("LDFLAGS: $ENV{LDFLAGS}")
-    # if *_FLAGS
-    message("CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
-    message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-    message("CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
-    message("CMAKE_MODULE_LINKER_FLAGS: ${CMAKE_MODULE_LINKER_FLAGS}")
-    # if *_FLAGS_INIT
-    message("CMAKE_C_FLAGS_INIT: ${CMAKE_C_FLAGS_INIT}")
-    message("CMAKE_CXX_FLAGS_INIT: ${CMAKE_CXX_FLAGS_INIT}")
-    message("CMAKE_EXE_LINKER_FLAGS_INIT: ${CMAKE_EXE_LINKER_FLAGS_INIT}")
-    message("CMAKE_MODULE_LINKER_FLAGS_INIT: ${CMAKE_MODULE_LINKER_FLAGS_INIT}")
+        # if $ENV
+        message("CFLAGS: $ENV{CFLAGS}")
+        message("CXXFLAGS: $ENV{CXXFLAGS}")
+        message("LDFLAGS: $ENV{LDFLAGS}")
+        # if *_FLAGS
+        message("CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
+        message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+        message("CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
+        message("CMAKE_MODULE_LINKER_FLAGS: ${CMAKE_MODULE_LINKER_FLAGS}")
+        # if *_FLAGS_INIT
+        message("CMAKE_C_FLAGS_INIT: ${CMAKE_C_FLAGS_INIT}")
+        message("CMAKE_CXX_FLAGS_INIT: ${CMAKE_CXX_FLAGS_INIT}")
+        message("CMAKE_EXE_LINKER_FLAGS_INIT: ${CMAKE_EXE_LINKER_FLAGS_INIT}")
+        message("CMAKE_MODULE_LINKER_FLAGS_INIT: ${CMAKE_MODULE_LINKER_FLAGS_INIT}")
 
-    message(FATAL_ERROR "
-        Some of the variables like CFLAGS, CXXFLAGS, LDFLAGS are not empty.
-        It is not possible to build proton with custom flags.
-        These variables can be set up by previous invocation of some other build tools.
-        You should cleanup these variables and start over again.
-        Run the `env` command to check the details.
-        You will also need to remove the contents of the build directory.
-        Note: if you don't like this behavior, you can manually edit the cmake files, but please don't complain to developers.")
+        message(FATAL_ERROR "
+            Some of the variables like CFLAGS, CXXFLAGS, LDFLAGS are not empty.
+            It is not possible to build proton with custom flags.
+            These variables can be set up by previous invocation of some other build tools.
+            You should cleanup these variables and start over again.
+            Run the `env` command to check the details.
+            You will also need to remove the contents of the build directory.
+            Note: if you don't like this behavior, you can manually edit the cmake files, but please don't complain to developers.")
+    endif()
 endif()
 
 # Default toolchain - this is needed to avoid dependency on OS files.

--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -48,14 +48,19 @@ if (NOT "$ENV{CFLAGS}" STREQUAL ""
 endif()
 
 # Default toolchain - this is needed to avoid dependency on OS files.
-execute_process(COMMAND uname -s
-    OUTPUT_VARIABLE OS
-    COMMAND_ERROR_IS_FATAL ANY
-)
-execute_process(COMMAND uname -m
-    OUTPUT_VARIABLE ARCH
-    COMMAND_ERROR_IS_FATAL ANY
-)
+if (NOT WIN32)
+    execute_process(COMMAND uname -s
+        OUTPUT_VARIABLE OS
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    execute_process(COMMAND uname -m
+        OUTPUT_VARIABLE ARCH
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+else()
+    set(OS "${CMAKE_SYSTEM_NAME}")
+    set(ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
 
 # By default, prefer clang on Linux
 # But note, that you still may change the compiler with -DCMAKE_C_COMPILER/-DCMAKE_CXX_COMPILER.

--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
     if (CMAKE_LIBRARY_ARCHITECTURE MATCHES "i386")
         message (FATAL_ERROR "32bit platforms are not supported")
     endif ()


### PR DESCRIPTION
﻿Fixes #1096

### What changed
- Avoid calling uname on Windows in PreLoad.cmake (use CMAKE_SYSTEM_* instead)
- Treat AMD64 as x86_64 in arch detection
- Skip polluted-env flags check on Windows (MSVC sets defaults)

### Proof (Windows)
Generator: Visual Studio 17 2022 (x64)

Command:
cmake -S . -B build -G "Visual Studio 17 2022" -A x64

Result:
Configure proceeds until it hits the existing guard:
Platform Windows is not supported (cmake/target.cmake:19).

This PR does not attempt to enable Windows support; it only removes earlier configure blockers on Windows.
