### PR TITLE
Fix SIGSEGV in QueryThreadLog flush

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -515,7 +515,7 @@ std::shared_ptr<const ContextAccess> AccessControl::getContextAccess(
     params.allow_introspection = settings.allow_introspection_functions;
     params.interface = client_info.interface;
     params.http_method = client_info.http_method;
-    params.address = client_info.current_address.host();
+    params.address = client_info.current_address->host();
     params.quota_key = client_info.quota_key;
 
     /// Extract the last entry from comma separated list of X-Forwarded-For addresses.

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -18,6 +18,12 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+ClientInfo::ClientInfo()
+{
+    current_address = std::make_shared<Poco::Net::SocketAddress>();
+    initial_address = std::make_shared<Poco::Net::SocketAddress>();
+}
+
 
 void ClientInfo::write(WriteBuffer & out, const UInt64 /*server_protocol_revision*/) const
 {
@@ -30,7 +36,7 @@ void ClientInfo::write(WriteBuffer & out, const UInt64 /*server_protocol_revisio
 
     writeBinary(initial_user, out);
     writeBinary(initial_query_id, out);
-    writeBinary(initial_address.toString(), out);
+    writeBinary(initial_address->toString(), out);
 
     /// if (server_protocol_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME)
     writeBinary(initial_query_start_time_microseconds, out);
@@ -115,7 +121,9 @@ void ClientInfo::read(ReadBuffer & in, const UInt64 /*client_protocol_revision*/
 
     String initial_address_string;
     readBinary(initial_address_string, in);
-    initial_address = Poco::Net::SocketAddress(initial_address_string);
+    /// Allocate a fresh address object to avoid mutating a shared instance
+    /// (ClientInfo is frequently copied; shared_ptr fields can be aliased).
+    initial_address = std::make_shared<Poco::Net::SocketAddress>(initial_address_string);
 
     /// if (client_protocol_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME)
     {

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -5,6 +5,8 @@
 #include <base/types.h>
 #include <Common/OpenTelemetryTraceContext.h>
 
+#include <memory>
+
 namespace DB
 {
 
@@ -21,6 +23,8 @@ class ReadBuffer;
 class ClientInfo
 {
 public:
+    ClientInfo();
+
     enum class Interface : uint8_t
     {
         TCP = 1,
@@ -56,12 +60,12 @@ public:
     String current_user;
     String current_user_password;
     String current_query_id;
-    Poco::Net::SocketAddress current_address;
+    std::shared_ptr<Poco::Net::SocketAddress> current_address;
 
     /// When query_kind == INITIAL_QUERY, these values are equal to current.
     String initial_user;
     String initial_query_id;
-    Poco::Net::SocketAddress initial_address;
+    std::shared_ptr<Poco::Net::SocketAddress> initial_address;
     time_t initial_query_start_time{};
     Decimal64 initial_query_start_time_microseconds{};
 

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -270,13 +270,13 @@ void QueryLogElement::appendClientInfo(const ClientInfo & client_info, MutableCo
 
     columns[i++]->insert(client_info.current_user);
     columns[i++]->insert(client_info.current_query_id);
-    columns[i++]->insertData(IPv6ToBinary(client_info.current_address.host()).data(), 16);
-    columns[i++]->insert(client_info.current_address.port());
+    columns[i++]->insertData(IPv6ToBinary(client_info.current_address->host()).data(), 16);
+    columns[i++]->insert(client_info.current_address->port());
 
     columns[i++]->insert(client_info.initial_user);
     columns[i++]->insert(client_info.initial_query_id);
-    columns[i++]->insertData(IPv6ToBinary(client_info.initial_address.host()).data(), 16);
-    columns[i++]->insert(client_info.initial_address.port());
+    columns[i++]->insertData(IPv6ToBinary(client_info.initial_address->host()).data(), 16);
+    columns[i++]->insert(client_info.initial_address->port());
     columns[i++]->insert(client_info.initial_query_start_time);
     columns[i++]->insert(client_info.initial_query_start_time_microseconds);
 

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -338,7 +338,7 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
     }
 
     prepared_client_info->current_user = credentials_.getUserName();
-    prepared_client_info->current_address = address;
+    prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);
 
     /// proton : starts
     if (const auto * basic_cred = typeid_cast<const BasicCredentials *>(&credentials_))
@@ -355,7 +355,7 @@ void Session::onAuthenticationFailure(const std::optional<String> & user_name, c
     {
         /// Add source address to the log
         auto info_for_log = *prepared_client_info;
-        info_for_log.current_address = address_;
+        info_for_log.current_address = std::make_shared<Poco::Net::SocketAddress>(address_);
         session_log->addLoginFailure(auth_id, info_for_log, user_name, e);
     }
 }
@@ -496,7 +496,9 @@ ContextMutablePtr Session::makeQueryContextImpl(const ClientInfo * client_info_t
     if (prepared_client_info && !prepared_client_info->current_user.empty())
     {
         res_client_info.current_user = prepared_client_info->current_user;
-        res_client_info.current_address = prepared_client_info->current_address;
+        /// Do not share the same address instance between contexts.
+        /// Upstream uses Context::setCurrentAddress(), which deep-copies into a fresh shared_ptr.
+        res_client_info.current_address = std::make_shared<Poco::Net::SocketAddress>(*prepared_client_info->current_address);
     }
 
     /// Set parameters of initial query.
@@ -506,7 +508,10 @@ ContextMutablePtr Session::makeQueryContextImpl(const ClientInfo * client_info_t
     if (res_client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY)
     {
         res_client_info.initial_user = res_client_info.current_user;
-        res_client_info.initial_address = res_client_info.current_address;
+        /// Do not alias `initial_address` with `current_address`:
+        /// `current_address` can be updated later (e.g. for nested/secondary contexts),
+        /// while "initial" must remain a snapshot of the original client address.
+        res_client_info.initial_address = std::make_shared<Poco::Net::SocketAddress>(*res_client_info.current_address);
     }
 
     /// Sets that row policies of the initial user should be used too.
@@ -548,4 +553,3 @@ void Session::releaseSessionID()
 }
 
 }
-

--- a/src/Interpreters/SessionLog.cpp
+++ b/src/Interpreters/SessionLog.cpp
@@ -179,8 +179,8 @@ void SessionLogElement::appendToBlock(MutableColumns & columns) const
         offsets.push_back(settings_tuple_col.size());
     }
 
-    columns[i++]->insertData(IPv6ToBinary(client_info.current_address.host()).data(), 16);
-    columns[i++]->insert(client_info.current_address.port());
+    columns[i++]->insertData(IPv6ToBinary(client_info.current_address->host()).data(), 16);
+    columns[i++]->insert(client_info.current_address->port());
 
     columns[i++]->insert(client_info.interface);
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -174,7 +174,7 @@ static void logQuery(const String & query, ContextPtr context, bool internal, Qu
             transaction_info = fmt::format(" (TID: {}, TIDH: {})", txn->tid, txn->tid.getHash());
 
         LOG_DEBUG(getLogger("executeQuery"), "(from {}{}{}){}{} {} (stage: {})",
-            client_info.current_address.toString(),
+            client_info.current_address->toString(),
             (current_user != "default" ? ", user: " + current_user : ""),
             (!initial_query_id.empty() && current_query_id != initial_query_id ? ", initial_query_id: " + initial_query_id : std::string()),
             transaction_info,
@@ -225,14 +225,14 @@ static void logException(ContextPtr context, QueryLogElement & elem)
 
     if (elem.stack_trace.empty())
         message.text = fmt::format("{} (from {}){} (in query: {})", elem.exception,
-                        context->getClientInfo().current_address.toString(),
+                        context->getClientInfo().current_address->toString(),
                         comment,
                         toOneLineQuery(elem.query));
     else
         message.text = fmt::format(
             "{} (from {}){} (in query: {}), Stack trace (when copying this message, always include the lines below):\n\n{}",
             elem.exception,
-            context->getClientInfo().current_address.toString(),
+            context->getClientInfo().current_address->toString(),
             comment,
             toOneLineQuery(elem.query),
             elem.stack_trace);

--- a/src/Interpreters/tests/gtest_client_info.cpp
+++ b/src/Interpreters/tests/gtest_client_info.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include <Interpreters/ClientInfo.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+
+using namespace DB;
+
+TEST(ClientInfo, DefaultConstructedHasAddresses)
+{
+    ClientInfo client_info;
+
+    ASSERT_TRUE(client_info.current_address);
+    ASSERT_TRUE(client_info.initial_address);
+
+    EXPECT_NO_THROW(client_info.current_address->host());
+    EXPECT_NO_THROW(client_info.current_address->port());
+    EXPECT_NO_THROW(client_info.initial_address->host());
+    EXPECT_NO_THROW(client_info.initial_address->port());
+}
+
+TEST(ClientInfo, SerializationPreservesInitialAddress)
+{
+    ClientInfo client_info;
+    client_info.query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
+    client_info.initial_user = "test_user";
+    client_info.initial_query_id = "test_query_id";
+    *client_info.initial_address = Poco::Net::SocketAddress{"127.0.0.1", 9000};
+    client_info.initial_query_start_time_microseconds = Decimal64{1234567};
+    client_info.interface = ClientInfo::Interface::TCP;
+
+    String serialized;
+    WriteBufferFromString out(serialized);
+    client_info.write(out, /*server_protocol_revision=*/0);
+    out.finalize();
+
+    ClientInfo roundtrip;
+    ReadBufferFromString in(serialized);
+    roundtrip.read(in, /*client_protocol_revision=*/0);
+
+    ASSERT_TRUE(roundtrip.initial_address);
+    EXPECT_EQ(roundtrip.initial_address->toString(), client_info.initial_address->toString());
+    EXPECT_EQ(roundtrip.initial_user, client_info.initial_user);
+    EXPECT_EQ(roundtrip.initial_query_id, client_info.initial_query_id);
+}
+

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1442,7 +1442,7 @@ void TCPHandler::receiveQuery()
         else
         {
             LOG_DEBUG(log, "User (initial, interserver mode): {}", client_info.initial_user);
-            session->authenticate(AlwaysAllowCredentials{client_info.initial_user}, client_info.initial_address);
+            session->authenticate(AlwaysAllowCredentials{client_info.initial_user}, *client_info.initial_address);
         }
 #else
         auto exception = Exception(ErrorCodes::AUTHENTICATION_FAILED,

--- a/src/Storages/System/StorageSystemProcesses.cpp
+++ b/src/Storages/System/StorageSystemProcesses.cpp
@@ -88,13 +88,13 @@ void StorageSystemProcesses::fillData(MutableColumns & res_columns, ContextPtr c
 
         res_columns[i++]->insert(process.client_info.current_user);
         res_columns[i++]->insert(process.client_info.current_query_id);
-        res_columns[i++]->insertData(IPv6ToBinary(process.client_info.current_address.host()).data(), 16);
-        res_columns[i++]->insert(process.client_info.current_address.port());
+        res_columns[i++]->insertData(IPv6ToBinary(process.client_info.current_address->host()).data(), 16);
+        res_columns[i++]->insert(process.client_info.current_address->port());
 
         res_columns[i++]->insert(process.client_info.initial_user);
         res_columns[i++]->insert(process.client_info.initial_query_id);
-        res_columns[i++]->insertData(IPv6ToBinary(process.client_info.initial_address.host()).data(), 16);
-        res_columns[i++]->insert(process.client_info.initial_address.port());
+        res_columns[i++]->insertData(IPv6ToBinary(process.client_info.initial_address->host()).data(), 16);
+        res_columns[i++]->insert(process.client_info.initial_address->port());
 
         res_columns[i++]->insert(UInt64(process.client_info.interface));
 


### PR DESCRIPTION
ClientInfo stored Poco::Net::SocketAddress by value; we observed a crash in SystemLogFlush while calling SocketAddress::host() during QueryThreadLog flush. Align with upstream ClickHouse by storing current/initial addresses as std::shared_ptr and initializing them in ClientInfo ctor.

Upstream: https://github.com/ClickHouse/ClickHouse/pull/75148 (commits 956b5fe90775, 94b092ebf7ad)

Tests: ClientInfo gtest for default init + serialization roundtrip.

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
