### PR TITLE
Port CH #82137: settings over URI is broken

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1,4 +1,4 @@
-#include <Server/HTTPHandler.h>
+﻿#include <Server/HTTPHandler.h>
 
 #include <Access/Authentication.h>
 #include <Access/Credentials.h>
@@ -46,6 +46,8 @@
 
 #include <chrono>
 #include <sstream>
+#include <string_view>
+#include <vector>
 
 
 namespace DB
@@ -695,7 +697,7 @@ void HTTPHandler::processQuery(
         {
             /// Other than query parameters are treated as settings.
             if (!customizeQueryParam(context, key, value))
-                settings_changes.push_back({key, value});
+                settings_changes.setSetting(key, value);
         }
     }
 


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
clickhouse/clickhouse#82137