### PR TITLE
fix sink block due to response queue is full

### DIFF
--- a/src/Storages/ExternalStream/Kafka/Kafka.cpp
+++ b/src/Storages/ExternalStream/Kafka/Kafka.cpp
@@ -623,7 +623,7 @@ SinkToStoragePtr Kafka::write(const ASTPtr & /*query*/, const StorageMetadataPtr
         getLogger(fmt::format("{}.{}", getLoggerName(), producer->name())),
         context);
 
-    producer->start(/*need_poll=*/context->isQueryFromMaterializedView());
+    producer->start(/*need_poll=*/true);
     return sink;
 }
 


### PR DESCRIPTION
 

Please write user-readable short description of the changes:
Kafka inserting message may block if response queue is full and will not be consumed.

Always start background thread to poll for Producer no matter query is from mv or not.