### PR TITLE
fix lambda argument in function

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1400,13 +1400,32 @@ public:
             pushOperand(std::move(elements.back()));
             elements.pop_back();
         }
-        /// 3. Put all elements in a single tuple
+        /// proton: starts. Fix lambda parsing when lambda is not the first function argument (#9688)
+        /// Collect a contiguous suffix of identifiers from the elements list as lambda parameters,
+        /// leave everything before them as function arguments.
+        /// e.g., `f('uint64', x -> x + 1)`: suffix = [x], remaining = ['uint64']
+        /// e.g., `array_map(x, y -> x + y, ...)`: suffix = [x, y], remaining = []
+        /// e.g., `f('a', x, y -> expr)`: suffix = [x, y], remaining = ['a']
         else
         {
-            auto function = makeASTFunction("tuple_cast", std::move(elements));
-            elements.clear();
+            /// Scan from the end to find the contiguous suffix of identifiers
+            size_t first_lambda_param = elements.size();
+            while (first_lambda_param > 0 && typeid_cast<ASTIdentifier *>(elements[first_lambda_param - 1].get()))
+            {
+                --first_lambda_param;
+            }
+
+            /// Explicitly fail if we have elements but no lambda parameters (e.g., f(1 -> 2))
+            if (first_lambda_param == elements.size())
+                return false;
+
+            ASTs lambda_params(std::make_move_iterator(elements.begin() + first_lambda_param), std::make_move_iterator(elements.end()));
+            elements.resize(first_lambda_param);
+
+            auto function = makeASTFunction("tuple_cast", std::move(lambda_params));
             pushOperand(function);
         }
+        /// proton: ends.
 
         /// We must check that tuple arguments are identifiers
         auto * func_ptr = operands.back()->as<ASTFunction>();

--- a/tests/queries_ported/0_stateless/99125_lambda_in_function_args.reference
+++ b/tests/queries_ported/0_stateless/99125_lambda_in_function_args.reference
@@ -1,0 +1,22 @@
+Test 1: Lambda as second argument without parentheses
+uint64
+Test 2: Lambda as third argument without parentheses
+uint64
+Test 3: Lambda with parentheses (still supported)
+uint64
+Test 4: Single-param lambda as first arg
+[2,3,4]
+Test 5: Lambda in nested function call
+[4,6,8]
+Test 6: Lambda with complex expression
+uint32
+Test 7: Multi-param lambda without parentheses
+[11,22,33]
+Test 8: Multi-param lambda with parentheses
+[11,22,33]
+Test 9: Multi-param lambda with parentheses after non-identifier arg
+5
+Test 10: Lambda as second arg in array_sort
+[3,2,1]
+Test 11: Chained higher-order functions
+[4,6]

--- a/tests/queries_ported/0_stateless/99125_lambda_in_function_args.sql
+++ b/tests/queries_ported/0_stateless/99125_lambda_in_function_args.sql
@@ -1,0 +1,42 @@
+-- Test lambda expressions as function arguments (issue #9688)
+-- Lambda expressions should work with or without parentheses after the fix
+
+-- Single-param lambda after non-identifier argument (the original bug)
+SELECT 'Test 1: Lambda as second argument without parentheses';
+SELECT to_type_name(random_in_type('uint64', x -> x + 1));
+
+SELECT 'Test 2: Lambda as third argument without parentheses';
+SELECT to_type_name(random_in_type('uint64', 10, x -> x + 1));
+
+SELECT 'Test 3: Lambda with parentheses (still supported)';
+SELECT to_type_name(random_in_type('uint64', (x -> x + 1)));
+
+-- Single-param lambda as first argument (baseline, must not regress)
+SELECT 'Test 4: Single-param lambda as first arg';
+SELECT array_map(x -> x + 1, [1, 2, 3]);
+
+SELECT 'Test 5: Lambda in nested function call';
+SELECT array_map(x -> x * 2, array_map(y -> y + 1, [1, 2, 3]));
+
+SELECT 'Test 6: Lambda with complex expression';
+SELECT to_type_name(random_in_type('uint32', x -> to_uint32(x + 10)));
+
+-- Multi-param lambda without parentheses (x, y are both lambda params)
+SELECT 'Test 7: Multi-param lambda without parentheses';
+SELECT array_map(x, y -> x + y, [1, 2, 3], [10, 20, 30]);
+
+-- Multi-param lambda with parentheses
+SELECT 'Test 8: Multi-param lambda with parentheses';
+SELECT array_map((x, y) -> x + y, [1, 2, 3], [10, 20, 30]);
+
+-- Multi-param lambda with parentheses after non-identifier arg
+SELECT 'Test 9: Multi-param lambda with parentheses after non-identifier arg';
+SELECT array_first((x, y) -> x > y, [1, 5, 3], [2, 4, 6]);
+
+-- array_sort with lambda as second arg (lambda after array, a non-identifier)
+SELECT 'Test 10: Lambda as second arg in array_sort';
+SELECT array_sort(x -> -x, [3, 1, 2]);
+
+-- Chained higher-order functions
+SELECT 'Test 11: Chained higher-order functions';
+SELECT array_filter(x -> x > 3, array_map(y -> y * 2, [1, 2, 3]));


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
SELECT random_in_type('uint64', 10, x -> x + 1); syntax error 

