### PR TITLE
Perf: limit backfill max threads

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1136,6 +1136,7 @@ Possible values: non-negative numbers. Note that if the value is too small or to
     M(Bool, emit_during_backfill, false, "Enable emit intermediate aggr result during backfill historical data", 0) \
     M(Bool, force_backfill_in_order, false, "Requires backfill data in order", 0) \
     M(Bool, include_internal_streams, false, "Show internal streams on SHOW streams query.", 0) \
+    M(UInt64, backfill_max_threads, 0, "Max threads used to backfill historical data per shard. 0 means system defaults", 0) \
     M(UInt64, join_max_buffered_bytes, 524288000, "Max buffered bytes for stream to stream join", 0) \
     M(UInt64, join_buffered_data_block_size, 0, "For streaming join, when buffered data in memory, the data block size directs to merge small data blocks to form bigger ones to improve memory efficiency. 0 means disable merging small data blocks.", 0) \
     M(Int64, join_quiesce_threshold_ms, 0, "For streaming join, when left or right stream is in quiesce, the maximum time to wait before the join.", 0) \

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -409,7 +409,9 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
                 input_streams.emplace_back(plan->getCurrentDataStream());
 
             query_plan.unitePlans(
-                std::make_unique<Streaming::ConcatStep>(std::move(input_streams), /*disable_concat_callback=*/true), std::move(plans));
+                std::make_unique<Streaming::ConcatStep>(
+                    std::move(input_streams), /*disable_concat_callback_=*/true, settings.backfill_max_threads.value),
+                std::move(plans));
         }
         else
         {

--- a/src/Processors/QueryPlan/Streaming/ConcatStep.cpp
+++ b/src/Processors/QueryPlan/Streaming/ConcatStep.cpp
@@ -27,8 +27,8 @@ static Block checkHeaders(const DataStreams & input_streams)
     return res;
 }
 
-ConcatStep::ConcatStep(DataStreams input_streams_, bool disable_concat_callback_)
-    : header(checkHeaders(input_streams_)), disable_concat_callback(disable_concat_callback_)
+ConcatStep::ConcatStep(DataStreams input_streams_, bool disable_concat_callback_, UInt64 backfill_max_threads_)
+    : header(checkHeaders(input_streams_)), disable_concat_callback(disable_concat_callback_), backfill_max_threads(backfill_max_threads_)
 {
     input_streams = std::move(input_streams_);
     output_stream = DataStream{.header = header, .is_streaming = true};
@@ -72,7 +72,7 @@ QueryPipelineBuilderPtr ConcatStep::updatePipeline(QueryPipelineBuilders pipelin
     /// Concat historical pipeline and streaming pipeline via Streaming::ConcatProcessor, which will pulls all data from historical inputs,
     /// then get max_sn from historical inputs to reset streaming source, and then read all data from streaming inputs.
     return QueryPipelineBuilder::concatPipelines(
-        std::move(historical_pipeline), std::move(streaming_pipeline), std::move(concat_callback), &processors);
+        std::move(historical_pipeline), std::move(streaming_pipeline), std::move(concat_callback), &processors, backfill_max_threads);
 }
 
 void ConcatStep::describePipeline(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/Streaming/ConcatStep.h
+++ b/src/Processors/QueryPlan/Streaming/ConcatStep.h
@@ -9,7 +9,7 @@ namespace DB::Streaming
 class ConcatStep : public IQueryPlanStep
 {
 public:
-    explicit ConcatStep(DataStreams input_streams_, bool disable_concat_callback_);
+    explicit ConcatStep(DataStreams input_streams_, bool disable_concat_callback_, UInt64 backfill_max_threads_);
 
     String getName() const override { return "Concat"; }
 
@@ -20,6 +20,7 @@ public:
 private:
     Block header;
     bool disable_concat_callback;
+    UInt64 backfill_max_threads;
 };
 
 }

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -923,11 +923,14 @@ std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesStreami
     return left;
 }
 
+/// \param left -> historical pipeline
+/// \param right -> streaming pipeline
 QueryPipelineBuilderPtr QueryPipelineBuilder::concatPipelines(
     QueryPipelineBuilderPtr left,
     QueryPipelineBuilderPtr right,
     std::function<void(Int64)> concat_callback,
-    Processors * collected_processors)
+    Processors * collected_processors,
+    size_t backfill_max_threads)
 {
     if (!(!left->isStreaming() && right->isStreaming()))
         throw Exception(
@@ -962,7 +965,13 @@ QueryPipelineBuilderPtr QueryPipelineBuilder::concatPipelines(
 
     left->pipe.processors->emplace_back(transform);
     left->pipe.processors->insert(left->pipe.processors->end(), streaming_pipe.processors->begin(), streaming_pipe.processors->end());
-    left->pipe.max_parallel_streams = std::max(left->pipe.max_parallel_streams, streaming_pipe.max_parallel_streams);
+
+    if (backfill_max_threads)
+        left->pipe.max_parallel_streams
+            = std::max(std::min(left->pipe.max_parallel_streams, backfill_max_threads), streaming_pipe.max_parallel_streams);
+    else
+        left->pipe.max_parallel_streams = std::max(left->pipe.max_parallel_streams, streaming_pipe.max_parallel_streams);
+
     return left;
 }
 

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -236,7 +236,8 @@ public:
         QueryPipelineBuilderPtr left,
         QueryPipelineBuilderPtr right,
         std::function<void(Int64)> concat_callback = {},
-        Processors * collected_processors = nullptr);
+        Processors * collected_processors = nullptr,
+        size_t backfill_max_threads = 0);
     /// proton: ends.
 
 private:

--- a/src/Storages/Stream/StorageStream.cpp
+++ b/src/Storages/Stream/StorageStream.cpp
@@ -271,6 +271,9 @@ void StorageStream::doRead(
     size_t streaming_shard_num_streams = std::max<size_t>(
         1ul, (context_->getSettingsRef().min_threads.value + shards_to_read.shards.size() - 1) / shards_to_read.shards.size());
     size_t shard_num_streams = std::max<size_t>(1ul, num_streams / shards_to_read.shards.size());
+    if (context_->getSettingsRef().backfill_max_threads.value > 0)
+        shard_num_streams = std::min<size_t>(shard_num_streams, context_->getSettingsRef().backfill_max_threads.value);
+
     /// Specially, we always read by single thread for keyed storage
     if (Streaming::isKeyedStorage(dataStreamSemantic()))
         shard_num_streams = 1;
@@ -782,7 +785,10 @@ void StorageStream::preRename(const StorageID & new_table_id)
 }
 
 void StorageStream::truncate(
-    const ASTPtr & query, [[maybe_unused]] const StorageMetadataPtr & metadata_snapshot, ContextPtr context_, [[maybe_unused]] TableExclusiveLockHolder & holder)
+    const ASTPtr & query,
+    [[maybe_unused]] const StorageMetadataPtr & metadata_snapshot,
+    ContextPtr context_,
+    [[maybe_unused]] TableExclusiveLockHolder & holder)
 {
     auto table_id = getStorageID();
     auto truncate_command = DB::queryToString(query);

--- a/src/Storages/Stream/StreamShardStore.cpp
+++ b/src/Storages/Stream/StreamShardStore.cpp
@@ -487,7 +487,12 @@ void StreamShardStore::readConcat(
     for (const auto & plan : plans)
         input_streams.emplace_back(plan->getCurrentDataStream());
 
-    query_plan.unitePlans(std::make_unique<Streaming::ConcatStep>(std::move(input_streams), /*disable_concat_callback=*/false), std::move(plans));
+    query_plan.unitePlans(
+        std::make_unique<Streaming::ConcatStep>(
+            std::move(input_streams),
+            /*disable_concat_callback_=*/false,
+            context->getSettingsRef().backfill_max_threads.value),
+        std::move(plans));
 }
 
 cluster::CallResultV<int64_t>


### PR DESCRIPTION


Please write user-readable short description of the changes:
Need have a way (settings) to limit the backfill threads and also the calculation of backfill threads may need revisited