### PR TITLE
fix: correct NATS cmake flag in Docker packager

### DIFF
--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -243,7 +243,7 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, image_typ
         cmake_flags.append('-DENABLE_LIBPQXX=ON')
         cmake_flags.append('-DUSE_MONGODB=ON')
         cmake_flags.append('-DENABLE_ULID=ON')
-        cmake_flags.append('-DENABLE_NATSIO=ON')
+        cmake_flags.append('-DENABLE_NATS=ON')
 
 
     # krb5: Disabled in environments other than Linux and native Darwin.


### PR DESCRIPTION
## Summary
- The Docker packager passed `-DENABLE_NATSIO=ON` but the CMake option defined in `contrib/nats-io-cmake/CMakeLists.txt` is `ENABLE_NATS`
- CMake silently ignored the unknown variable, so the nats-io C library was never built and `USE_NATSIO` was never set — the NATS JetStream connector (`#if USE_NATSIO` guards) was compiled out of all Docker images
- Fix: rename the flag from `ENABLE_NATSIO` to `ENABLE_NATS` in `docker/packager/packager`

## Context
Introduced in d28c60427b ("add nats-io submodule") which was part of PR #1117. The JetStream connector itself (PR #1111) is correct — only the packager flag name was wrong.

## Test plan
- [ ] CI rebuilds Docker image with this fix
- [ ] Verify `CREATE EXTERNAL STREAM ... SETTINGS type='nats_jetstream'` no longer returns `NOT_IMPLEMENTED` in the new image
- [ ] Run NATS JetStream test harness (docker-compose + SQL tests)


Made with [Cursor](https://cursor.com)