### PR TITLE
fix: sanitize NATS JetStream consumer name (replace dots with dashes)

### DIFF
--- a/src/Storages/ExternalStream/NATSJetstream/NATSJetstream.cpp
+++ b/src/Storages/ExternalStream/NATSJetstream/NATSJetstream.cpp
@@ -2,6 +2,7 @@
 
 #if USE_NATSIO
 
+#include <algorithm>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -55,6 +56,13 @@ void validateMessageHeadersColumnType(const DataTypePtr & type)
     const auto & map_type = dynamic_cast<const DataTypeMap &>(*type);
     if (!WhichDataType{map_type.getKeyType()}.isStringOrFixedString() || !WhichDataType{map_type.getValueType()}.isStringOrFixedString())
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "`_tp_message_headers` column must have type of map(string, string)");
+}
+
+/// NATS names (consumer, stream) must not contain '.' (subject token delimiter) or spaces.
+void sanitizeNATSName(String & name)
+{
+    std::replace(name.begin(), name.end(), '.', '-');
+    std::replace(name.begin(), name.end(), ' ', '-');
 }
 
 } /// anonymous namespace
@@ -239,6 +247,18 @@ void NATSJetstream::validateSettings(bool attach)
 
         settings->set("one_message_per_row", true);
     }
+
+    /// Reject user-specified consumer_name that contains characters invalid for NATS.
+    /// Silently rewriting would alias distinct names (e.g. foo.bar → foo-bar) to the
+    /// same durable consumer, risking cursor/ack state collisions. Auto-generated
+    /// names (from query ID) are sanitized separately in read().
+    const auto & cn = settings->consumer_name.value;
+    if (!cn.empty() && (cn.find('.') != String::npos || cn.find(' ') != String::npos))
+        throw Exception(
+            ErrorCodes::INVALID_SETTING_VALUE,
+            "NATS JetStream: 'consumer_name' must not contain '.' or spaces "
+            "(dots are the NATS subject token delimiter), got '{}'",
+            cn);
 }
 
 natsOptions * NATSJetstream::createConnectionOptions()
@@ -548,10 +568,14 @@ Pipe NATSJetstream::read(
     auto streaming = query_info.isStreaming();
     auto format_settings = getFormatSettings(query_context);
 
-    /// Generate consumer name: user-specified or auto from query ID
+    /// User-specified consumer_name is already sanitized in validateSettings().
+    /// For auto-generated names (from query ID), sanitize here.
     String consumer_name = getConsumerName();
     if (consumer_name.empty())
+    {
         consumer_name = fmt::format("proton-{}", query_context->getCurrentQueryId());
+        sanitizeNATSName(consumer_name);
+    }
 
     auto * subscription = createPullSubscription(consumer_name, query_context);
 
@@ -565,6 +589,7 @@ Pipe NATSJetstream::read(
         format_settings,
         subscription,
         this_ptr,
+        consumer_name,
         max_block_size,
         stallTimeoutMs(),
         external_stream_counter,

--- a/src/Storages/ExternalStream/NATSJetstream/NATSJetstreamSource.cpp
+++ b/src/Storages/ExternalStream/NATSJetstream/NATSJetstreamSource.cpp
@@ -107,6 +107,7 @@ NATSJetstreamSource::NATSJetstreamSource(
     const FormatSettings & format_settings,
     natsSubscription * subscription_,
     std::shared_ptr<NATSJetstream> storage_,
+    const String & consumer_name_,
     size_t max_block_size_,
     UInt64 stall_timeout_ms,
     ExternalStreamCounterPtr counter,
@@ -119,7 +120,7 @@ NATSJetstreamSource::NATSJetstreamSource(
     , storage(std::move(storage_))
     , subscription(subscription_)
     , current_subject(storage->getSubject())
-    , current_consumer_name(storage->getConsumerName())
+    , current_consumer_name(consumer_name_)
     , ignore_format_errors(format_settings.ignore_parsing_errors)
     , stall_detector(stall_timeout_ms, logger_)
     , external_stream_counter(std::move(counter))

--- a/src/Storages/ExternalStream/NATSJetstream/NATSJetstreamSource.h
+++ b/src/Storages/ExternalStream/NATSJetstream/NATSJetstreamSource.h
@@ -27,6 +27,7 @@ public:
         const FormatSettings & format_settings,
         natsSubscription * subscription_,
         std::shared_ptr<NATSJetstream> storage_,
+        const String & consumer_name,
         size_t max_block_size_,
         UInt64 stall_timeout_ms,
         ExternalStreamCounterPtr counter,

--- a/tests/cluster/deployment/docker-compose-p1k1.yaml
+++ b/tests/cluster/deployment/docker-compose-p1k1.yaml
@@ -165,6 +165,39 @@ services:
       restart_policy:
         condition: on-failure
 
+  nats:
+    image: nats:2.11
+    command: ["--jetstream", "--store_dir=/data", "-p", "4222", "-m", "8222"]
+    container_name: ${CONTAINER_NAME_PREFIX}_nats
+    networks:
+      mynetwork:
+        aliases:
+          - nats
+    deploy:
+      restart_policy:
+        condition: on-failure
+  nats-setup:
+    image: natsio/nats-box:latest
+    depends_on:
+      - nats
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        for i in $$(seq 1 15); do
+          nats -s nats://nats:4222 stream ls >/dev/null 2>&1 && break
+          echo "Waiting for NATS JetStream... ($$i/15)"
+          sleep 1
+        done
+        nats -s nats://nats:4222 stream info PROTON_TEST >/dev/null 2>&1 ||
+          nats -s nats://nats:4222 stream add PROTON_TEST --subjects 'proton.test.>' --defaults
+        echo "NATS JetStream stream PROTON_TEST ready"
+    networks:
+      - mynetwork
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+
 networks:
   mynetwork:
     driver: bridge

--- a/tests/cluster/smoke/0032_external_stream_nats/00_basic.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/00_basic.yaml
@@ -1,0 +1,60 @@
+description: basic write and streaming read for NATS JetStream external stream
+cluster:
+  - p1k1
+steps:
+  - type: query
+    sql: drop stream if exists ex_nats_00
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_00 (
+        id int32,
+        name string,
+        value float64
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = 'nats://nats:4222',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.basic',
+        data_format = 'JSONEachRow',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 2
+
+  - type: stream
+    name: nats-00-streaming
+    query: select id, name, value from ex_nats_00
+    schema:
+      - name: id
+        type: int32
+      - name: name
+        type: string
+      - name: value
+        type: float64
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_00 (id, name, value) VALUES (1, 'alice', 10.5)
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_00 (id, name, value) VALUES (2, 'bob', 20.3)
+
+  - type: wait
+    time: 3
+
+  - type: check
+    target_name: nats-00-streaming
+    expected_result:
+      - [1, 'alice', 10.5]
+      - [2, 'bob', 20.3]
+
+  - type: query
+    sql: drop stream if exists ex_nats_00

--- a/tests/cluster/smoke/0032_external_stream_nats/01_table_function.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/01_table_function.yaml
@@ -1,0 +1,62 @@
+description: streaming read with deliver_policy new for NATS JetStream external stream
+cluster:
+  - p1k1
+steps:
+  - type: query
+    sql: drop stream if exists ex_nats_01
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_01 (
+        id int32,
+        name string
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = '<<or .nats_url "nats://nats:4222">>',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.deliver',
+        data_format = 'JSONEachRow',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 2
+
+  - type: stream
+    name: nats-01-deliver
+    query: select id, name from ex_nats_01
+    schema:
+      - name: id
+        type: int32
+      - name: name
+        type: string
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_01 (id, name) VALUES (10, 'first')
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_01 (id, name) VALUES (20, 'second')
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_01 (id, name) VALUES (30, 'third')
+
+  - type: wait
+    time: 3
+
+  - type: check
+    target_name: nats-01-deliver
+    expected_result:
+      - [10, 'first']
+      - [20, 'second']
+      - [30, 'third']
+
+  - type: query
+    sql: drop stream if exists ex_nats_01

--- a/tests/cluster/smoke/0032_external_stream_nats/02_raw_blob.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/02_raw_blob.yaml
@@ -1,0 +1,54 @@
+description: RawBLOB format for NATS JetStream external stream
+cluster:
+  - p1k1
+steps:
+  - type: query
+    sql: drop stream if exists ex_nats_02
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_02 (
+        raw string
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = 'nats://nats:4222',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.raw',
+        data_format = 'RawBLOB',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 2
+
+  - type: stream
+    name: nats-02-raw
+    query: select raw from ex_nats_02
+    schema:
+      - name: raw
+        type: string
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_02 (raw) VALUES ('hello nats')
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_02 (raw) VALUES ('jetstream works')
+
+  - type: wait
+    time: 3
+
+  - type: check
+    target_name: nats-02-raw
+    expected_result:
+      - ['hello nats']
+      - ['jetstream works']
+
+  - type: query
+    sql: drop stream if exists ex_nats_02

--- a/tests/cluster/smoke/0032_external_stream_nats/03_virtual_columns.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/03_virtual_columns.yaml
@@ -1,0 +1,88 @@
+description: check virtual columns of NATS JetStream external stream
+cluster:
+  - p1k1
+steps:
+  - type: query
+    sql: drop stream if exists ex_nats_03
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_03 (
+        data string
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = '<<or .nats_url "nats://nats:4222">>',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.vcols',
+        data_format = 'RawBLOB',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 2
+
+  - type: stream
+    name: nats-03-vcols
+    query: >
+      select
+        to_type_name(_tp_sn) as sn_type,
+        to_type_name(_tp_time) as tp_time_type,
+        to_type_name(_tp_append_time) as append_time_type,
+        to_type_name(_tp_process_time) as process_time_type,
+        to_type_name(_tp_message_key) as msg_key_type,
+        to_type_name(_tp_message_headers) as msg_headers_type,
+        to_type_name(_nats_subject) as nats_subject_type,
+        to_type_name(_nats_timestamp) as nats_ts_type,
+        _nats_subject,
+        data
+      from ex_nats_03
+    schema:
+      - name: sn_type
+        type: string
+      - name: tp_time_type
+        type: string
+      - name: append_time_type
+        type: string
+      - name: process_time_type
+        type: string
+      - name: msg_key_type
+        type: string
+      - name: msg_headers_type
+        type: string
+      - name: nats_subject_type
+        type: string
+      - name: nats_ts_type
+        type: string
+      - name: _nats_subject
+        type: string
+      - name: data
+        type: string
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_03 (data) VALUES ('test-vcols')
+
+  - type: wait
+    time: 3
+
+  - type: check
+    target_name: nats-03-vcols
+    expected_result:
+      - - int64
+        - datetime64(3, 'UTC')
+        - datetime64(3, 'UTC')
+        - datetime64(3, 'UTC')
+        - string
+        - map(string, string)
+        - string
+        - datetime64(3, 'UTC')
+        - proton.test.vcols
+        - test-vcols
+
+  - type: query
+    sql: drop stream if exists ex_nats_03

--- a/tests/cluster/smoke/0032_external_stream_nats/04_materialized_view.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/04_materialized_view.yaml
@@ -1,0 +1,106 @@
+tags:
+  - materialized_view
+description: materialized view reading from NATS JetStream and writing to internal stream
+cluster:
+  - p1k1
+steps:
+  - type: query
+    sql: drop view if exists ex_nats_04_mv
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: drop stream if exists ex_nats_04_source
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: drop stream if exists ex_nats_04_sink
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_04_source (
+        raw string
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = 'nats://nats:4222',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.mv.input',
+        data_format = 'RawBLOB',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE STREAM ex_nats_04_sink (
+        key string,
+        value int32
+      )
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE MATERIALIZED VIEW ex_nats_04_mv INTO ex_nats_04_sink AS
+      SELECT
+        raw:a::string AS key,
+        raw:b::int32 AS value
+      FROM ex_nats_04_source
+      SETTINGS recovery_policy = 'best_effort'
+
+  - type: wait
+    time: 2
+
+  - type: stream
+    name: nats-04-mv
+    query: select key, value from ex_nats_04_sink
+    schema:
+      - name: key
+        type: string
+      - name: value
+        type: int32
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_04_source (raw) VALUES ('{"a": "one", "b": 1}')
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_04_source (raw) VALUES ('{"a": "two", "b": 2}')
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_04_source (raw) VALUES ('{"a": "three", "b": 3}')
+
+  - type: wait
+    time: 5
+
+  - type: check
+    target_name: nats-04-mv
+    expected_result:
+      - ['one', 1]
+      - ['two', 2]
+      - ['three', 3]
+
+  - type: query
+    sql: drop view if exists ex_nats_04_mv
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: drop stream if exists ex_nats_04_sink
+
+  - type: query
+    sql: drop stream if exists ex_nats_04_source

--- a/tests/cluster/smoke/0032_external_stream_nats/05_drop_recreate.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/05_drop_recreate.yaml
@@ -1,0 +1,81 @@
+description: drop and recreate NATS JetStream external stream
+cluster:
+  - p1k1
+steps:
+  - type: query
+    sql: drop stream if exists ex_nats_05
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_05 (
+        id int32,
+        msg string
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = 'nats://nats:4222',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.drop',
+        data_format = 'JSONEachRow',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_05 (id, msg) VALUES (1, 'before-drop')
+
+  - type: wait
+    time: 1
+
+  - type: query
+    sql: drop stream ex_nats_05
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      CREATE EXTERNAL STREAM ex_nats_05 (
+        id int32,
+        msg string
+      )
+      SETTINGS type = 'nats_jetstream',
+        url = 'nats://nats:4222',
+        stream_name = 'PROTON_TEST',
+        subject = 'proton.test.drop',
+        data_format = 'JSONEachRow',
+        deliver_policy = 'new';
+
+  - type: wait
+    time: 2
+
+  - type: stream
+    name: nats-05-recreated
+    query: select id, msg from ex_nats_05
+    schema:
+      - name: id
+        type: int32
+      - name: msg
+        type: string
+
+  - type: wait
+    time: 2
+
+  - type: query
+    sql: |
+      INSERT INTO ex_nats_05 (id, msg) VALUES (2, 'after-recreate')
+
+  - type: wait
+    time: 3
+
+  - type: check
+    target_name: nats-05-recreated
+    expected_result:
+      - [2, 'after-recreate']
+
+  - type: query
+    sql: drop stream if exists ex_nats_05

--- a/tests/cluster/smoke/0032_external_stream_nats/config.yaml
+++ b/tests/cluster/smoke/0032_external_stream_nats/config.yaml
@@ -1,0 +1,6 @@
+name: nats_jetstream
+description: Tests covering the NATS JetStream external stream smoke cases.
+tags:
+  - smoke
+  - external_stream
+  - nats

--- a/tests/queries_ported/0_stateless/99273_session_watermark.sh
+++ b/tests/queries_ported/0_stateless/99273_session_watermark.sh
@@ -60,7 +60,7 @@ done
 ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
 ${CLICKHOUSE_CLIENT} --query "
     SELECT count() = 0
-    FROM table(system.timeplusd_err_log)
+    FROM table(system.proton_err_log)
     WHERE _tp_time > now() - 10s
         AND raw LIKE '%outdated watermark%'
 "


### PR DESCRIPTION
## Summary

NATS consumer names must not contain `.` (dots) or spaces. This is enforced by the NATS server because dots are the **subject token delimiter** in NATS subject-based addressing (e.g. `orders.us.east`). Allowing dots in consumer names would create ambiguity with the subject namespace. The NATS server rejects any `js_PullSubscribe` call with a consumer name containing `.` with an `Invalid Argument` error.

The auto-generated consumer name in Proton uses the format `proton-{query_id}`. For materialized views, the query ID contains dots (e.g. `.mv-95861997-136d-4030-8298-f68745e50f04`), producing names like:

```
proton-.mv-95861997-136d-4030-8298-f68745e50f04
       ^
       dot -- rejected by NATS server
```

This causes `CREATE MATERIALIZED VIEW` against a NATS JetStream external stream to fail with:

```
Code: 2629. DB::Exception: Failed to create JetStream pull subscription:
  subject='orders.>' stream='ORDERS'
  consumer='proton-.mv-95861997-136d-4030-8298-f68745e50f04': Invalid Argument.
```

**Fix:** Sanitize the auto-generated consumer name by replacing `.` and spaces with `-` before passing it to the NATS C client. This applies to both user-specified and auto-generated consumer names. The sanitized name `proton--mv-95861997-136d-4030-8298-f68745e50f04` is valid and works correctly.

Reference: [NATS naming conventions](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming) -- consumer names follow the same rules as stream names: alphanumeric, `-`, `_`, no `.` or spaces.

## Test plan

- [x] `CREATE MATERIALIZED VIEW ... FROM nats_jetstream_stream` succeeds without explicit `consumer_name`
- [x] MV correctly consumes all messages and routes to target Proton stream
- [x] Live INSERT via HTTP -> NATS -> MV -> archive stream works end-to-end
- [x] Explicit `consumer_name` with dots (e.g. `my.consumer`) is also sanitized