### PR TITLE
bugfix: fix streaming CTE/subquery + aggregation returning empty results

### DIFF
--- a/src/Processors/Transforms/Streaming/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/Streaming/AggregatingTransform.cpp
@@ -102,6 +102,18 @@ IProcessor::Status AggregatingTransform::prepare()
     /// Get chunk from input.
     if (input.isFinished() && !need_process)
     {
+        /// When a bounded input (e.g. CTE with LIMIT) finishes before any
+        /// periodic watermark fires, inject a synthetic watermark so the
+        /// aggregation can finalize its buffered state.
+        if (src_rows > 0 && !input_finished_finalized)
+        {
+            input_finished_finalized = true;
+            current_chunk = Chunk{getInputs().front().getHeader().getColumns(), 0};
+            current_chunk.setWatermark(TIMEOUT_WATERMARK);
+            read_current_chunk = true;
+            return Status::Ready;
+        }
+
         is_consume_finished = true;
         output.finish();
         return Status::Finished;

--- a/src/Processors/Transforms/Streaming/AggregatingTransform.h
+++ b/src/Processors/Transforms/Streaming/AggregatingTransform.h
@@ -160,6 +160,11 @@ protected:
     bool backfill_started = false;
     bool backfill_done = false;
 
+    /// When a bounded input (e.g. CTE with LIMIT) finishes before any periodic
+    /// watermark fires, we inject a synthetic watermark so the aggregation
+    /// finalizes its buffered state instead of silently dropping it.
+    bool input_finished_finalized = false;
+
     LoggerPtr logger;
 };
 

--- a/tests/queries_ported/0_stateless/98468_streaming_cte_limit_aggregation.reference
+++ b/tests/queries_ported/0_stateless/98468_streaming_cte_limit_aggregation.reference
@@ -1,0 +1,15 @@
+cte_count
+6
+cte_groupby
+1	15	2
+2	45	2
+3	45	2
+subquery_count
+6
+cte_passthrough
+1
+1
+2
+2
+3
+3

--- a/tests/queries_ported/0_stateless/98468_streaming_cte_limit_aggregation.sql
+++ b/tests/queries_ported/0_stateless/98468_streaming_cte_limit_aggregation.sql
@@ -1,0 +1,31 @@
+-- Regression test for #2817: CTE streaming query with LIMIT feeding into
+-- aggregation returned empty results because the stream finished before
+-- any periodic watermark could trigger finalization.
+
+DROP STREAM IF EXISTS 98468_cte_agg;
+
+CREATE STREAM 98468_cte_agg (cid uint32, val float64) SETTINGS shards = 1;
+
+SELECT sleep(2) FORMAT Null;
+
+INSERT INTO 98468_cte_agg (cid, val, _tp_time) VALUES (1, 10.0, '2025-01-01 00:00:01.000'), (1, 20.0, '2025-01-01 00:00:02.000'), (2, 30.0, '2025-01-01 00:00:03.000'), (3, 40.0, '2025-01-01 00:00:04.000'), (3, 50.0, '2025-01-01 00:00:05.000'), (2, 60.0, '2025-01-01 00:00:06.000');
+
+SELECT sleep(2) FORMAT Null;
+
+-- CTE streaming + simple count
+SELECT 'cte_count';
+WITH data AS (SELECT * FROM 98468_cte_agg WHERE _tp_time >= earliest_ts() LIMIT 6) SELECT count() FROM data SETTINGS max_execution_time=10, timeout_overflow_mode='break';
+
+-- CTE streaming + GROUP BY aggregation
+SELECT 'cte_groupby';
+WITH data AS (SELECT * FROM 98468_cte_agg WHERE _tp_time >= earliest_ts() LIMIT 6) SELECT cid, avg(val), count() FROM data GROUP BY cid ORDER BY cid SETTINGS max_execution_time=10, timeout_overflow_mode='break';
+
+-- Subquery streaming + count (same issue without CTE syntax)
+SELECT 'subquery_count';
+SELECT count() FROM (SELECT * FROM 98468_cte_agg WHERE _tp_time >= earliest_ts() LIMIT 6) SETTINGS max_execution_time=10, timeout_overflow_mode='break';
+
+-- CTE streaming non-aggregate should still work (regression guard)
+SELECT 'cte_passthrough';
+WITH data AS (SELECT * FROM 98468_cte_agg WHERE _tp_time >= earliest_ts() LIMIT 6) SELECT cid FROM data ORDER BY cid SETTINGS max_execution_time=10, timeout_overflow_mode='break';
+
+DROP STREAM IF EXISTS 98468_cte_agg;


### PR DESCRIPTION
## Summary
- When a bounded streaming input (e.g. CTE with LIMIT) finished before any periodic watermark fired, `AggregatingTransform::prepare()` would close the output without finalizing buffered aggregation state — resulting in silently empty results.
- Fix: inject a synthetic watermark when the input finishes with accumulated but un-finalized rows, triggering the existing finalization path.
- Added regression test `98468_streaming_cte_limit_aggregation` covering CTE streaming + `count()`, `GROUP BY`, subquery, and non-aggregate passthrough.