### PR TITLE
Chore/validate task creation

### DIFF
--- a/src/Interpreters/InterpreterCreateTaskQuery.cpp
+++ b/src/Interpreters/InterpreterCreateTaskQuery.cpp
@@ -8,7 +8,6 @@
 #include <Cluster/MetaStore/MetaStore.h>
 #include <Cluster/Protocol/ExistsOperation.h>
 #include <Cluster/Protocol/TaskDescriptor.h>
-<<<<<<< HEAD
 #include <Cluster/Requests/CreateTaskRequest.h>
 #include <Cluster/Requests/CreateTaskResponse.h>
 #include <Cluster/Requests/GetTaskRequest.h>

--- a/src/Interpreters/InterpreterCreateTaskQuery.cpp
+++ b/src/Interpreters/InterpreterCreateTaskQuery.cpp
@@ -8,12 +8,17 @@
 #include <Cluster/MetaStore/MetaStore.h>
 #include <Cluster/Protocol/ExistsOperation.h>
 #include <Cluster/Protocol/TaskDescriptor.h>
+<<<<<<< HEAD
 #include <Cluster/Requests/CreateTaskRequest.h>
 #include <Cluster/Requests/CreateTaskResponse.h>
 #include <Cluster/Requests/GetTaskRequest.h>
 #include <Cluster/Requests/GetTaskResponse.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
 #include <Parsers/ASTCreateTaskQuery.h>
+#include <Task/TaskExecutionResult.h>
+#include <Task/Utils.h>
+#include <Common/Exception.h>
 
 
 namespace DB
@@ -21,10 +26,11 @@ namespace DB
 
 namespace ErrorCodes
 {
+extern const int BAD_ARGUMENTS;
 extern const int CANNOT_CREATE_TASK;
 extern const int RESOURCE_ALREADY_EXISTS;
+extern const int SYNTAX_ERROR;
 extern const int UNKNOWN_DATABASE;
-extern const int UNKNOWN_FUNCTION;
 extern const int UNSUPPORTED;
 }
 
@@ -63,11 +69,12 @@ BlockIO InterpreterCreateTaskQuery::execute()
         database = current_context->getCurrentDatabase();
     }
 
-    auto task_name = create_task_query.getName();
+    /// Validate the task query and target stream before creating the task
+    Task::validateCreateTaskQuery(&create_task_query, current_context);
 
+    auto task_name = create_task_query.getName();
     UInt32 version{1};
     DB::UUID id;
-
     auto req = std::make_shared<cluster::GetTaskRequest>(
         database,
         task_name,

--- a/src/Parsers/ParserCreateTaskQuery.cpp
+++ b/src/Parsers/ParserCreateTaskQuery.cpp
@@ -115,11 +115,19 @@ bool ParserCreateTaskQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expecte
             return false;
 
         checkpoint_str = checkpoint->as<ASTLiteral>()->value.safeGet<String>();
-
         Poco::JSON::Parser parser;
-        auto obj = parser.parse(checkpoint_str).extract<Poco::JSON::Object::Ptr>();
+        Poco::JSON::Object::Ptr obj;
+        try
+        {
+            obj = parser.parse(checkpoint_str).extract<Poco::JSON::Object::Ptr>();
+        }
+        catch (...)
+        {
+            obj.reset();
+        }
         if (!obj)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "CHECKPOINT should be in JSON format: actual={}", checkpoint_str);
+
         auto keys = obj->getNames();
         for (auto & key : keys)
             checkpoint_columns.push_back(std::move(key));

--- a/src/Task/Utils.cpp
+++ b/src/Task/Utils.cpp
@@ -2,12 +2,28 @@
 
 #include <Bootstrap/Globals.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/InterpreterSelectWithUnionQuery.h>
+#include <Parsers/ASTCreateTaskQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ParserQuery.h>
+#include <Parsers/parseQuery.h>
+#include <Storages/IStorage.h>
 #include <Task/TaskScheduler.h>
 
 #include <ranges>
 
 
-namespace DB::Task
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+extern const int INCORRECT_QUERY;
+extern const int UNKNOWN_STREAM;
+}
+
+namespace Task
 {
 
 std::string getTaskQuery(const std::string & sql, const Checkpoint & checkpoint)
@@ -36,4 +52,109 @@ std::vector<TaskInfoPtr> getTaskInfos(const std::string & ns)
     return task_scheduler->getTasks(ns);
 }
 
+void validateCreateTaskQuery(const ASTCreateTaskQuery * create_task_query, const ContextPtr & context)
+{
+    const auto & settings = context->getSettingsRef();
+
+    /// Expand the SQL with checkpoint initial values
+    Task::Checkpoint checkpoint;
+    if (!create_task_query->checkpoint.empty())
+    {
+        auto maybe_checkpoint = Task::parseCheckpoint(create_task_query->checkpoint);
+        if (maybe_checkpoint.hasError())
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Failed to parse checkpoint initial values: {}",
+                maybe_checkpoint.err.string());
+        }
+        checkpoint = std::move(maybe_checkpoint.result);
+    }
+    const auto expanded_sql = Task::getTaskQuery(create_task_query->sql, checkpoint);
+
+    /// 1. Parse and validate the query syntax
+    ParserQuery parser(expanded_sql.data() + expanded_sql.size());
+    ASTPtr select_ast;
+    try
+    {
+        select_ast = parseQuery(parser, expanded_sql.data(), expanded_sql.data() + expanded_sql.size(), "", settings.max_query_size, settings.max_parser_depth);
+    }
+    catch (Exception & e)
+    {
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Task query is invalid: query='{}' error='{}'", expanded_sql, e.displayText());
+    }
+
+    if (select_ast->as<ASTSelectWithUnionQuery>() == nullptr)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Task query must be a SELECT query");
+
+    /// 2. Validate target stream exists and schema compatibility if INTO is specified
+    if (create_task_query->to_table_id)
+    {
+        String target_database;
+        if (!create_task_query->to_table_id.database_name.empty())
+            target_database = create_task_query->to_table_id.database_name;
+        else
+            target_database = context->getCurrentDatabase();
+
+        const String & target_table_name = create_task_query->to_table_id.table_name;
+        StorageID target_table_id{target_database, target_table_name};
+
+        auto target_table = DatabaseCatalog::instance().tryGetTable(target_table_id, context);
+        if (!target_table)
+            throw Exception(
+                ErrorCodes::UNKNOWN_STREAM, "Target stream {}.{} does not exist", target_database, target_table_name);
+
+        /// 3. Validate schema compatibility
+        Block source_header = InterpreterSelectWithUnionQuery::getSampleBlock(select_ast, context, false);
+        auto target_metadata_snapshot = target_table->getInMemoryMetadataPtr();
+        const auto & target_table_columns = target_metadata_snapshot->getColumns();
+        auto target_storage_header = target_metadata_snapshot->getSampleBlock();
+
+        /// Build target header with columns that match by name
+        Block target_header;
+        Block source_header_matched;
+        for (const auto & source_column : source_header)
+        {
+            if (target_table_columns.hasPhysical(source_column.name))
+            {
+                target_header.insert(target_storage_header.getByName(source_column.name));
+                source_header_matched.insert(source_column);
+            }
+        }
+
+        if (target_header.columns() == 0)
+        {
+            throw Exception(
+                ErrorCodes::INCORRECT_QUERY,
+                "No matching columns found between select outputs and target stream '{}', "
+                "select output: [{}], target header: [{}]",
+                target_table->getStorageID().getFullTableName(),
+                source_header.dumpNames(),
+                target_storage_header.dumpNames());
+        }
+
+        /// Check type compatibility by trying to create converting actions
+        try
+        {
+            ActionsDAG::makeConvertingActions(
+                source_header_matched.getColumnsWithTypeAndName(),
+                target_header.getColumnsWithTypeAndName(),
+                ActionsDAG::MatchColumnsMode::Name);
+        }
+        catch (const Exception & e)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Column types are not compatible between select outputs and target stream '{}'. "
+                "select output: [{}], target header: [{}], error: {}",
+                target_table->getStorageID().getFullTableName(),
+                source_header_matched.dumpStructure(),
+                target_header.dumpStructure(),
+                e.displayText());
+        }
+    }
+
+}
+
+}
 }

--- a/src/Task/Utils.h
+++ b/src/Task/Utils.h
@@ -3,12 +3,24 @@
 #include <Task/TaskExecutionResult.h>
 #include <Task/TaskInfo.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 
-namespace DB::Task
+namespace DB
+{
+
+class ASTCreateTaskQuery;
+class Context;
+using ContextPtr = std::shared_ptr<const Context>;
+
+namespace Task
 {
 std::vector<TaskInfoPtr> getTaskInfos(const std::string & ns);
 std::string getTaskQuery(const std::string & sql, const Checkpoint & checkpoint);
+
+void validateCreateTaskQuery(const ASTCreateTaskQuery * create_task_query, const ContextPtr & context);
+}
+
 }

--- a/tests/queries_ported/0_stateless/99273_task_validation.sql
+++ b/tests/queries_ported/0_stateless/99273_task_validation.sql
@@ -1,0 +1,40 @@
+-- Test task validation at creation time
+
+-- Test 1: Syntax error in task query
+CREATE TASK test_task_syntax_err SCHEDULE INTERVAL 1 HOUR AS SELECT * FORM non_existent; -- { serverError SYNTAX_ERROR }
+
+-- Test 2: Non-existent target stream
+CREATE TASK test_task_no_target SCHEDULE INTERVAL 1 HOUR INTO non_existent_stream AS SELECT 1; -- { serverError UNKNOWN_STREAM }
+
+-- Test 3: Schema mismatch
+CREATE STREAM target_stream_mismatch (a int, b string);
+CREATE TASK test_task_mismatch SCHEDULE INTERVAL 1 HOUR INTO target_stream_mismatch AS SELECT 1 as c; -- { serverError INCORRECT_QUERY }
+DROP STREAM target_stream_mismatch;
+
+-- Test 4: Valid task creation with matching schema
+CREATE STREAM target_stream_valid (a int);
+CREATE TASK test_task_valid SCHEDULE INTERVAL 1 HOUR INTO target_stream_valid AS SELECT 1 as a;
+DROP TASK test_task_valid;
+DROP STREAM target_stream_valid;
+
+-- Test 5: Valid task creation without target stream
+CREATE TASK test_task_no_target_valid SCHEDULE INTERVAL 1 HOUR AS SELECT 1;
+DROP TASK test_task_no_target_valid;
+
+-- Test 6: Valid task with checkpoint placeholder expanded
+CREATE TASK test_task_checkpoint SCHEDULE INTERVAL 1 HOUR CHECKPOINT '{"last_id": "0"}' AS SELECT * FROM (SELECT 1 as id) WHERE id > ${last_id};
+DROP TASK test_task_checkpoint;
+
+-- Test 7: Invalid checkpoint JSON
+-- CREATE TASK test_task_bad_checkpoint SCHEDULE INTERVAL 1 HOUR CHECKPOINT 'invalid_json' AS SELECT 1; -- { clientError BAD_ARGUMENTS }
+
+-- Test 8: Type incompatibility (cannot cast array to int)
+CREATE STREAM target_stream_type_mismatch (a int);
+CREATE TASK test_task_type_mismatch SCHEDULE INTERVAL 1 HOUR INTO target_stream_type_mismatch AS SELECT [1,2,3] as a; -- { serverError BAD_ARGUMENTS }
+DROP STREAM target_stream_type_mismatch;
+
+-- Test 9: Valid type conversion (int to string is allowed)
+CREATE STREAM target_stream_type_convert (a string);
+CREATE TASK test_task_type_convert SCHEDULE INTERVAL 1 HOUR INTO target_stream_type_convert AS SELECT 1 as a;
+DROP TASK test_task_type_convert;
+DROP STREAM target_stream_type_convert;


### PR DESCRIPTION
# Problem
The task creation does not verify the correctness of query and the target. User get no feedback when there is any error until the task is scheduled to execute.

Possible cases when we should abort task creation due to error includes:
- The task query (after `AS` keyword) has syntax error and cannot be executed.
- The target stream (after `INTO` keyword before `AS` keyword) does not exist.
- The target stream exists, but its schema does not match the task query output.

# Propose
Do additional validation on task creation for the task query and target stream. Make sure it can be executed as in src/Task/TaskExecution.h and src/Task/TaskExecution.cpp . If any error, raise an exception with error message.

# Related Source Code
under src/Task folder

# Test
Add stateless tests for negative cases mentioned above.

