### PR TITLE
nlog: replace ConcurrentHashMap with phmap::parallel_flat_hash_map

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -301,3 +301,6 @@
 [submodule "contrib/ulid-c"]
 	path = contrib/ulid-c
 	url = https://github.com/ClickHouse/ulid-c.git
+[submodule "contrib/parallel-hashmap"]
+	path = contrib/parallel-hashmap
+	url = https://github.com/greg7mdp/parallel-hashmap.git

--- a/src/Cluster/Base/Concurrent/ConcurrentHashMap.h
+++ b/src/Cluster/Base/Concurrent/ConcurrentHashMap.h
@@ -1,19 +1,29 @@
 #pragma once
 
-#include <absl/container/flat_hash_map.h>
+#include <parallel_hashmap/phmap.h>
 #include <boost/noncopyable.hpp>
 
+#include <functional>
 #include <shared_mutex>
+#include <vector>
 
 namespace cluster
 {
-/// This is a naive concurrent hash map implementation and so far it shall work just good enough
-/// Future exploration: folly ConcurrentHashMap, libcuckoo etc
+/// Thread-safe concurrent hash map backed by phmap::parallel_flat_hash_map.
+/// Replaces the previous absl::flat_hash_map + single std::shared_mutex design.
+/// Locking is now per-submap (16 submaps, each with its own std::shared_mutex),
+/// so operations on keys in different submaps proceed fully in parallel.
 
 template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
 class ConcurrentHashMap : private boost::noncopyable
 {
 public:
+    using MapType = phmap::parallel_flat_hash_map<
+        K, V, Hash, KeyEqual,
+        phmap::priv::Allocator<std::pair<const K, V>>,
+        4,                   // 2^4 = 16 submaps
+        std::shared_mutex>;  // reader-writer lock per submap
+
     ConcurrentHashMap() { }
 
     template <typename InputIt>
@@ -23,16 +33,12 @@ public:
 
     bool insert(const std::pair<const K, V> & elem)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.insert(elem);
-        return inserted;
+        return hash_map.insert(elem).second;
     }
 
     bool insert(std::pair<const K, V> && elem)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.insert(std::move(elem));
-        return inserted;
+        return hash_map.insert(std::move(elem)).second;
     }
 
     /// \return a pair of V and bool. If bool is true means the element is
@@ -40,81 +46,59 @@ public:
     template <typename M>
     bool insertOrAssign(const K & k, M && obj)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.insert_or_assign(k, std::move(obj));
-        return inserted;
+        return hash_map.insert_or_assign(k, std::forward<M>(obj)).second;
     }
 
     template <typename M>
     bool insertOrAssign(K && k, M && obj)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.insert_or_assign(std::move(k), std::move(obj));
-        return inserted;
+        return hash_map.insert_or_assign(std::move(k), std::forward<M>(obj)).second;
     }
 
     template <typename InputIt>
     void insert(InputIt first, InputIt last)
     {
-        std::unique_lock guard{hlock};
         hash_map.insert(first, last);
     }
 
     template <typename... Args>
     bool emplace(Args &&... args)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.emplace(std::forward<Args>(args)...);
-        return inserted;
+        return hash_map.emplace(std::forward<Args>(args)...).second;
     }
 
     template <typename... Args>
     bool tryEmplace(const K & k, Args &&... args)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.try_emplace(k, std::forward<Args>(args)...);
-        return inserted;
+        return hash_map.try_emplace(k, std::forward<Args>(args)...).second;
     }
 
     template <typename... Args>
     bool tryEmplace(K && k, Args &&... args)
     {
-        std::unique_lock guard{hlock};
-        auto [_, inserted] = hash_map.try_emplace(std::move(k), std::forward<Args>(args)...);
-        return inserted;
+        return hash_map.try_emplace(std::move(k), std::forward<Args>(args)...).second;
     }
 
     size_t erase(const K & k)
     {
-        std::unique_lock guard{hlock};
         return hash_map.erase(k);
     }
 
     template <typename Key>
     size_t erase(Key && k)
     {
-        std::unique_lock guard{hlock};
         return hash_map.erase(std::move(k));
     }
 
-    template <typename Pred>
-    size_t eraseIf(Pred pred)
-    {
-        std::unique_lock guard{hlock};
-        return std::erase_if(hash_map, pred);
-    }
 
     std::vector<std::pair<K, V>> items() const
     {
         std::vector<std::pair<K, V>> results;
 
-        {
-            std::shared_lock guard{hlock};
-            results.reserve(hash_map.size());
-
-            for (const auto & item : hash_map)
-                results.push_back(item);
-        }
+        results.reserve(hash_map.size());
+        hash_map.for_each([&results](const auto & item) {
+            results.push_back(item);
+        });
 
         return results;
     }
@@ -123,13 +107,10 @@ public:
     {
         std::vector<V> results;
 
-        {
-            std::shared_lock guard{hlock};
-            results.reserve(hash_map.size());
-
-            for (const auto & item : hash_map)
-                results.push_back(item.second);
-        }
+        results.reserve(hash_map.size());
+        hash_map.for_each([&results](const auto & item) {
+            results.push_back(item.second);
+        });
 
         return results;
     }
@@ -137,40 +118,24 @@ public:
     /// Apply `func` to every element in the hash map
     void apply(std::function<void(const std::pair<K, V> &)> func) const
     {
-        std::shared_lock guard{hlock};
-        for (const auto & item : hash_map)
+        hash_map.for_each([&func](const auto & item) {
             func(item);
+        });
     }
-
-    //    void apply(const std::function<void(const std::pair<K, V> &)> & func) const
-    //    {
-    //        std::shared_lock guard{hlock};
-    //        for (const auto & item : hash_map)
-    //            func(item);
-    //    }
-    //    void apply(std::function<void(const std::pair<K, V> &)> && func) const
-    //    {
-    //        std::shared_lock guard{hlock};
-    //        for (const auto & item : hash_map)
-    //            func(item);
-    //    }
 
     void clear()
     {
-        std::unique_lock guard{hlock};
         hash_map.clear();
     }
 
     bool contains(const K & k) const noexcept
     {
-        std::shared_lock guard{hlock};
         return hash_map.contains(k);
     }
 
     template <typename Key>
     bool contains(const Key & k) const noexcept
     {
-        std::shared_lock guard{hlock};
         return hash_map.contains(k);
     }
 
@@ -178,32 +143,23 @@ public:
     /// return false if it doesn't contains `k` and `v` will stay unassigned
     bool at(const K & k, V & v) const
     {
-        std::shared_lock guard{hlock};
-        auto it = hash_map.find(k);
-        if (it != hash_map.end())
-        {
-            v = it->second;
-            return true;
-        }
-        else
-            return false;
+        return hash_map.if_contains(k, [&v](const auto & item) {
+            v = item.second;
+        });
     }
 
     size_t size() const noexcept
     {
-        std::shared_lock guard{hlock};
         return hash_map.size();
     }
 
     bool empty() const noexcept
     {
-        std::shared_lock guard{hlock};
         return hash_map.empty();
     }
 
 private:
-    mutable std::shared_mutex hlock;
-    absl::flat_hash_map<K, V, Hash, KeyEqual> hash_map;
+    MapType hash_map;
 };
 
 template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>>


### PR DESCRIPTION
Fixes #441

This PR replaces the current ConcurrentHashMap implementation in NativeLog, which uses a single std::shared_mutex around an absl::flat_hash_map, with phmap::parallel_flat_hash_map from the parallel-hashmap library. The old design meant every read and write operation competed for one global lock, which becomes a bottleneck under concurrent access.The new implementation uses phmap's internal submap-level locking — the map is split into 16 independent submaps, each with its own std::shared_mutex. This means operations on keys that hash to different submaps run fully in parallel with zero contention. Multiple readers on the same submap can also proceed concurrently thanks to the shared_mutex reader-writer separation.parallel-hashmap is a well-established header-only library built on top of Google's absl::flat_hash_map, widely used in production OLAP systems like Apache Doris. It was the library suggested in the original issue.All 15 public methods are preserved with identical signatures, so LogManager.cpp requires no changes. The only method removed is eraseIf, which was dead code — never called anywhere in the codebase. Template defaults (std::hash<K>, std::equal_to<K>) are kept the same to maintain backward compatibility with StreamIDShard's existing std::hash specialization.

Benchmark references from the original issue:
- https://martin.ankerl.com/2022/08/27/hashmap-bench-01/
- https://greg7mdp.github.io/parallel-hashmap/

Note: The [.gitmodules](cci:7://file:///C:/Users/balav/Videos/proton-nats/.gitmodules:0:0-0:0) merge conflict is due to new submodules added to `develop` since my fork was last synced. Happy to rebase onto latest `develop` if needed — just let me know. The actual code change (ConcurrentHashMap.h) merges cleanly.
