### PR TITLE
bugfix: handle Python source cancel during MV failover

### DIFF
--- a/src/Processors/Sources/PythonStreamingSource.cpp
+++ b/src/Processors/Sources/PythonStreamingSource.cpp
@@ -15,6 +15,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
+extern const int QUERY_WAS_CANCELLED;
 extern const int UDF_RUNNING_ERROR;
 }
 
@@ -257,7 +258,22 @@ Chunk PythonStreamingSource::generate()
             return {};
         }
 
-        auto next_item = cpython::iterNext(py_iterator);
+        cpython::PyObjectPtr next_item;
+        try
+        {
+            next_item = cpython::iterNext(py_iterator);
+        }
+        catch (const Exception & e)
+        {
+            if (e.code() == ErrorCodes::QUERY_WAS_CANCELLED && (isCancelled() || cancel_requested.load(std::memory_order_acquire)))
+            {
+                exhausted = true;
+                return {};
+            }
+
+            throw;
+        }
+
         if (!next_item)
         {
             /// Iterator exhausted

--- a/src/Processors/tests/gtest_python_streaming_source_projection.cpp
+++ b/src/Processors/tests/gtest_python_streaming_source_projection.cpp
@@ -622,4 +622,151 @@ class BlockingIterator:
     });
 }
 
+TEST_F(CPythonTest, PythonStreamingSourceCancelWithAsyncInterruptStopsCleanly)
+{
+    assertNoLeak([&]() {
+        auto string_type = std::make_shared<DataTypeString>();
+
+        DataTypes element_types = {string_type};
+        Strings element_names = {"type"};
+        auto tuple_type = std::make_shared<DataTypeTuple>(element_types, element_names);
+
+        Block header = {ColumnWithTypeAndName{string_type->createColumn(), string_type, "type"}};
+
+        cpython::PyObjectPtr iterator;
+        cpython::PyObjectPtr iterator_owner;
+        String module_name;
+        {
+            cpython::GILGuard gil_guard(/*use_need_cleanup=*/true);
+
+            module_name = "test_async_cancel_" + cpython::randomModuleName();
+            const std::string python_source = R"PY(
+class BlockingIteratorWithoutCancel:
+    def __init__(self):
+        self._yielded = False
+        self._stop_for_test = False
+
+    def __iter__(self):
+        return self
+
+    def stop_for_test(self):
+        self._stop_for_test = True
+
+    def __next__(self):
+        if not self._yielded:
+            self._yielded = True
+            return [("ticker",)]
+
+        while not self._stop_for_test:
+            pass
+        raise StopIteration
+)PY";
+
+            auto byte_code = cpython::compile(python_source);
+            cpython::executeByteCode(byte_code, module_name);
+
+            auto blocking_iter_class = cpython::getClass("BlockingIteratorWithoutCancel", module_name);
+            iterator_owner = cpython::newInstance(blocking_iter_class);
+            ASSERT_TRUE(iterator_owner);
+
+            iterator = cpython::getIterator(iterator_owner);
+            ASSERT_TRUE(iterator);
+        }
+
+        {
+            auto source = std::make_shared<PythonStreamingSource>(header, std::move(iterator), tuple_type, module_name);
+            auto sink = std::make_shared<NotifyingCollectBlocksSink>(source->getPort().getHeader());
+
+            connect(source->getPort(), sink->getPort());
+
+            auto processors = std::make_shared<Processors>();
+            processors->emplace_back(source);
+            processors->emplace_back(sink);
+
+            QueryStatusPtr element;
+            PipelineExecutor executor(processors, element);
+
+            std::mutex finished_mutex;
+            std::condition_variable finished_cv;
+            bool finished = false;
+            std::exception_ptr execution_exception;
+
+            {
+                cpython::GILGuard release_gil;
+            }
+
+            std::thread executor_thread([&] {
+                try
+                {
+                    executor.execute(1);
+                }
+                catch (...)
+                {
+                    execution_exception = std::current_exception();
+                }
+
+                {
+                    std::lock_guard lock(finished_mutex);
+                    finished = true;
+                }
+                finished_cv.notify_one();
+            });
+
+            SCOPE_EXIT({
+                executor.cancel();
+                if (executor_thread.joinable())
+                    executor_thread.join();
+            });
+
+            ASSERT_TRUE(sink->waitForBlocks(1, std::chrono::seconds(5)));
+
+            executor.cancel();
+
+            bool finished_after_cancel = false;
+            {
+                std::unique_lock lock(finished_mutex);
+                finished_after_cancel = finished_cv.wait_for(lock, std::chrono::milliseconds(500), [&] { return finished; });
+            }
+
+            if (!finished_after_cancel)
+            {
+                cpython::GILGuard gil_guard(/*use_need_cleanup=*/true);
+                cpython::PyObjectPtr stop_method{PyObject_GetAttrString(iterator_owner.get(), "stop_for_test")};
+                ASSERT_TRUE(stop_method);
+                cpython::PyObjectPtr stop_result{PyObject_CallObject(stop_method.get(), nullptr)};
+                if (!stop_result)
+                    PyErr_Clear();
+
+                std::unique_lock lock(finished_mutex);
+                EXPECT_TRUE(finished_cv.wait_for(lock, std::chrono::seconds(2), [&] { return finished; }));
+            }
+
+            EXPECT_TRUE(finished_after_cancel);
+
+            if (execution_exception)
+            {
+                try
+                {
+                    std::rethrow_exception(execution_exception);
+                }
+                catch (const Exception & e)
+                {
+                    ADD_FAILURE() << "Unexpected exception: " << e.displayText();
+                }
+                catch (...)
+                {
+                    ADD_FAILURE() << "Unexpected exception type";
+                }
+            }
+
+            EXPECT_EQ(sink->getBlocks().size(), 1U);
+        }
+
+        {
+            cpython::GILGuard gil_guard(/*use_need_cleanup=*/true);
+            iterator_owner.reset();
+        }
+    });
+}
+
 #endif

--- a/src/Processors/tests/gtest_python_table_transform_zero_columns.cpp
+++ b/src/Processors/tests/gtest_python_table_transform_zero_columns.cpp
@@ -4,7 +4,9 @@
 
 #include <gtest/gtest.h>
 
+#include <CPython/GILGuard.h>
 #include <CPython/tests/CPythonTest.h>
+#include <Common/Exception.h>
 #include <Processors/Executors/PipelineExecutor.h>
 #include <Processors/ISink.h>
 #include <Processors/Port.h>
@@ -14,7 +16,19 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypesNumber.h>
 
+#include <base/scope_guard.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
 using namespace DB;
+
+namespace DB::ErrorCodes
+{
+extern const int QUERY_WAS_CANCELLED;
+}
 
 namespace
 {
@@ -39,6 +53,75 @@ protected:
 private:
     size_t row_count = 0;
 };
+
+class CollectingBlocksSink final : public ISink
+{
+public:
+    explicit CollectingBlocksSink(Block header) : ISink(std::move(header), ProcessorID::EmptySinkID) { }
+
+    String getName() const override { return "CollectingBlocksSink"; }
+
+    const std::vector<Block> & getBlocks() const { return blocks; }
+
+protected:
+    void consume(Chunk chunk) override
+    {
+        blocks.emplace_back(getPort().getHeader().cloneWithColumns(chunk.detachColumns()));
+    }
+
+private:
+    std::vector<Block> blocks;
+};
+
+bool waitForPythonFlag(const char * attr_name, std::chrono::milliseconds timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        {
+            cpython::GILGuard gil_guard(/*use_need_cleanup=*/true);
+            cpython::PyObjectPtr builtins{PyImport_ImportModule("builtins")};
+            if (builtins)
+            {
+                cpython::PyObjectPtr flag{PyObject_GetAttrString(builtins.get(), attr_name)};
+                if (flag)
+                {
+                    const int is_true = PyObject_IsTrue(flag.get());
+                    if (is_true == 1)
+                        return true;
+                    if (is_true < 0)
+                        PyErr_Clear();
+                }
+                else
+                {
+                    PyErr_Clear();
+                }
+            }
+            else
+            {
+                PyErr_Clear();
+            }
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    return false;
+}
+
+void clearPythonFlag(const char * attr_name)
+{
+    cpython::GILGuard gil_guard(/*use_need_cleanup=*/true);
+    cpython::PyObjectPtr builtins{PyImport_ImportModule("builtins")};
+    if (!builtins)
+    {
+        PyErr_Clear();
+        return;
+    }
+
+    if (PyObject_DelAttrString(builtins.get(), attr_name) < 0)
+        PyErr_Clear();
+}
 }
 
 TEST_F(CPythonTest, PythonTableTransformPreservesRowCountWhenNoColumnsRequested)
@@ -92,6 +175,126 @@ def py_transform(i):
         executor.execute(1);
 
         EXPECT_EQ(sink->getRowCount(), 3U);
+    });
+}
+
+TEST_F(CPythonTest, PythonTableTransformCancelDuringGeneratorIterationDoesNotEmitPartialChunk)
+{
+    assertNoLeak([&]() {
+        constexpr auto blocked_flag = "_tp_python_table_transform_blocked";
+
+        clearPythonFlag(blocked_flag);
+        SCOPE_EXIT({ clearPythonFlag(blocked_flag); });
+
+        auto int32_type = std::make_shared<DataTypeInt32>();
+
+        Block input_header = {ColumnWithTypeAndName{int32_type->createColumn(), int32_type, "i"}};
+
+        auto col = ColumnInt32::create();
+        col->insertValue(1);
+
+        Columns columns;
+        columns.emplace_back(std::move(col));
+        Chunk input_chunk(std::move(columns), 1);
+
+        auto source = std::make_shared<SourceFromSingleChunk>(input_header, std::move(input_chunk));
+
+        Block output_header = {ColumnWithTypeAndName{int32_type->createColumn(), int32_type, "value"}};
+        ColumnsDescription output_columns{ColumnDescription{"value", int32_type}};
+
+        const String python_source = R"PY(
+import builtins
+
+def py_transform(i):
+    def gen():
+        yield [(x,) for x in i]
+        builtins._tp_python_table_transform_blocked = True
+        while True:
+            pass
+    return gen()
+)PY";
+
+        auto transform = std::make_shared<PythonTableTransform>(
+            source->getPort().getHeader(),
+            output_header,
+            python_source,
+            "py_transform",
+            Names{"i"},
+            output_columns,
+            Names{"value"},
+            PythonTableMode::Streaming);
+
+        auto sink = std::make_shared<CollectingBlocksSink>(transform->getOutputPort().getHeader());
+
+        connect(source->getPort(), transform->getInputPort());
+        connect(transform->getOutputPort(), sink->getPort());
+
+        auto processors = std::make_shared<Processors>();
+        processors->emplace_back(source);
+        processors->emplace_back(transform);
+        processors->emplace_back(sink);
+
+        QueryStatusPtr element;
+        PipelineExecutor executor(processors, element);
+
+        std::mutex finished_mutex;
+        std::condition_variable finished_cv;
+        bool finished = false;
+        std::exception_ptr execution_exception;
+
+        {
+            cpython::GILGuard release_gil;
+        }
+
+        std::thread executor_thread([&] {
+            try
+            {
+                executor.execute(1);
+            }
+            catch (...)
+            {
+                execution_exception = std::current_exception();
+            }
+
+            {
+                std::lock_guard lock(finished_mutex);
+                finished = true;
+            }
+            finished_cv.notify_one();
+        });
+
+        SCOPE_EXIT({
+            executor.cancel();
+            if (executor_thread.joinable())
+                executor_thread.join();
+        });
+
+        ASSERT_TRUE(waitForPythonFlag(blocked_flag, std::chrono::seconds(5)));
+
+        executor.cancel();
+
+        {
+            std::unique_lock lock(finished_mutex);
+            ASSERT_TRUE(finished_cv.wait_for(lock, std::chrono::seconds(2), [&] { return finished; }));
+        }
+
+        if (execution_exception)
+        {
+            try
+            {
+                std::rethrow_exception(execution_exception);
+            }
+            catch (const Exception & e)
+            {
+                EXPECT_EQ(e.code(), ErrorCodes::QUERY_WAS_CANCELLED) << e.displayText();
+            }
+            catch (...)
+            {
+                FAIL() << "Unexpected exception type";
+            }
+        }
+
+        EXPECT_TRUE(sink->getBlocks().empty());
     });
 }
 


### PR DESCRIPTION
```
Code: 394. DB::Exception: Query was cancelled. (QUERY_WAS_CANCELLED), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000e1563f7 in /usr/bin/timeplusd
1. DB::Exception::Exception<char const (&) [20], void>(int, char const (&) [20]) @ 0x00000000094bbd21 in /usr/bin/timeplusd
2. DB::cpython::iterNext(DB::cpython::PyObjectPtr const&) @ 0x000000001cb73986 in /usr/bin/timeplusd
3. DB::PythonStreamingSource::generate() @ 0x000000001b0d2ba4 in /usr/bin/timeplusd
4. DB::ISource::tryGenerate() @ 0x0000000014afa3ba in /usr/bin/timeplusd
5. DB::ISource::work() @ 0x0000000014af9f76 in /usr/bin/timeplusd
6. DB::ExecutionThreadContext::executeTask() @ 0x0000000014bc8fb7 in /usr/bin/timeplusd
7. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic<bool>*) @ 0x0000000014bbe723 in /usr/bin/timeplusd
8. DB::PipelineExecutor::executeImpl(unsigned long, DB::ExecuteMode) @ 0x0000000014bbd426 in /usr/bin/timeplusd
9. DB::PipelineExecutor::execute(unsigned long, DB::ExecuteMode) @ 0x0000000014bbcc78 in /usr/bin/timeplusd
10. void std::__function::__policy_invoker<void ()>::__call_impl[abi:ne180100]<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<DB::CompletedPipelineExecutor::execute()::$_0>(DB::CompletedPipelineExecutor::execute()::$_0&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x0000000014bbbad0 in /usr/bin/timeplusd
11. ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000e30307a in /usr/bin/timeplusd
12. void* std::__thread_proxy[abi:ne180100]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000e3084e1 in /usr/bin/timeplusd
13. ? @ 0x0000000000094ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6
14. ? @ 0x00000000001268d0 in /usr/lib/x86_64-linux-gnu/libc.so.6
 
```