### PR TITLE
Derive subject name according to schema subject strategy

### DIFF
--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -300,13 +300,13 @@ struct FormatSettings
     {
         bool skip_cert_check = false;
         bool force_refresh_schema = false;
+        bool consume_single_schema = false; /// In one topic, there may be multiple mixed schema records (RecordNameStrategy for Avro for example)
         std::string url;
         std::string credentials;
         std::string private_key_file;
         std::string certificate_file;
         std::string ca_location;
         std::string subject_name; /// for schema subject name use to fetch the schema for writing
-        std::string topic_name;
     } kafka_schema_registry{};
     /// proton: ends
 

--- a/src/Formats/KafkaSchemaRegistry.cpp
+++ b/src/Formats/KafkaSchemaRegistry.cpp
@@ -100,9 +100,8 @@ String KafkaSchemaRegistry::fetchSchema(UInt32 id) const
     }
 }
 
-std::pair<UInt32, String> KafkaSchemaRegistry::fetchLatestSchemaForSubject(const String & subject) const
+std::pair<UInt32, String> KafkaSchemaRegistry::fetchLatestSchemaForSubject(const String & subject_name) const
 {
-    auto subject_name = subject + "-value";
     auto latest_schema_version = fetchLatestSubjectVersion(subject_name);
     try
     {
@@ -156,7 +155,7 @@ std::pair<UInt32, String> KafkaSchemaRegistry::fetchLatestSchemaForSubject(const
     }
     catch (Exception & e)
     {
-        e.addMessage(std::format("while fetching latest schema for subject {}", subject));
+        e.addMessage(std::format("while fetching latest schema for subject {}", subject_name));
         throw;
     }
 }

--- a/src/Formats/KafkaSchemaRegistryForAvro.cpp
+++ b/src/Formats/KafkaSchemaRegistryForAvro.cpp
@@ -45,7 +45,7 @@ KafkaSchemaRegistryForAvro::KafkaSchemaRegistryForAvro(
     size_t schema_cache_max_size)
     : registry(base_url, credentials, private_key_file, certificate_file, ca_location, skip_cert_check)
     , schema_cache(schema_cache_max_size)
-    , topic_schema_cache(schema_cache_max_size)
+    , subject_schema_cache(schema_cache_max_size)
 {
 }
 
@@ -56,9 +56,9 @@ avro::ValidSchema KafkaSchemaRegistryForAvro::getSchema(UInt32 id)
     return *schema;
 }
 
-std::pair<UInt32, avro::ValidSchema> KafkaSchemaRegistryForAvro::getSchemaForTopic(const String & topic_name, const String & subject_name, bool force_refresh)
+std::pair<UInt32, avro::ValidSchema> KafkaSchemaRegistryForAvro::getSchemaForSubject(const String & subject_name, bool force_refresh)
 {
-    auto cached_schema_id = topic_schema_cache.get(topic_name);
+    auto cached_schema_id = subject_schema_cache.get(subject_name);
 
     if (!force_refresh && cached_schema_id)
         return {*cached_schema_id, getSchema(*cached_schema_id)};
@@ -66,7 +66,7 @@ std::pair<UInt32, avro::ValidSchema> KafkaSchemaRegistryForAvro::getSchemaForTop
     auto schema_and_id = fetchAndCompileSchemaForSubject(subject_name);
     schema_cache.set(schema_and_id.first, std::make_shared<avro::ValidSchema>(std::move(schema_and_id.second)));
     auto schema_id = schema_and_id.first;
-    topic_schema_cache.set(topic_name, std::make_shared<UInt32>(schema_id));
+    subject_schema_cache.set(subject_name, std::make_shared<UInt32>(schema_id));
     return {schema_id, getSchema(schema_id)};
 }
 

--- a/src/Formats/KafkaSchemaRegistryForAvro.h
+++ b/src/Formats/KafkaSchemaRegistryForAvro.h
@@ -37,8 +37,8 @@ public:
     KafkaSchemaRegistryForAvro & operator=(const KafkaSchemaRegistryForAvro &) = delete;
 
     avro::ValidSchema getSchema(UInt32 id);
-    /// Returns the schema ID and schema for a topic.
-    std::pair<UInt32, avro::ValidSchema> getSchemaForTopic(const String & topic_name, const String & subject_name, bool force_refresh = false);
+    /// Returns the schema ID and schema for a subject.
+    std::pair<UInt32, avro::ValidSchema> getSchemaForSubject(const String & subject_name, bool force_refresh = false);
 
 private:
     avro::ValidSchema fetchAndCompileSchema(UInt32 id);
@@ -46,7 +46,7 @@ private:
 
     KafkaSchemaRegistry registry;
     CacheBase<UInt32, avro::ValidSchema> schema_cache;
-    CacheBase<String, UInt32> topic_schema_cache;
+    CacheBase<String, UInt32> subject_schema_cache;
 };
 
 }

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -1,6 +1,6 @@
 #include <Processors/Executors/StreamingFormatExecutor.h>
 #include <Processors/Transforms/AddingDefaultsTransform.h>
-#include <iostream>
+#include <Common/scope_guard_safe.h>
 
 namespace DB
 {
@@ -36,13 +36,16 @@ MutableColumns StreamingFormatExecutor::getResultColumns()
 size_t StreamingFormatExecutor::execute(ReadBuffer & buffer)
 {
     auto & initial_buf = format->getReadBuffer();
+    SCOPE_EXIT_SAFE({
+        /// Format destructor can touch read buffer (for example when we use PeekableReadBuffer),
+        /// but we cannot control lifetime of provided read buffer. To avoid heap use after free
+        /// we can set initial read buffer back, because initial read buffer was created before
+        /// format, so it will be destructed after it.
+        format->setReadBuffer(initial_buf);
+    });
+
     format->setReadBuffer(buffer);
     size_t rows = execute();
-    /// Format destructor can touch read buffer (for example when we use PeekableReadBuffer),
-    /// but we cannot control lifetime of provided read buffer. To avoid heap use after free
-    /// we can set initial read buffer back, because initial read buffer was created before
-    /// format, so it will be destructed after it.
-    format->setReadBuffer(initial_buf);
     return rows;
 }
 

--- a/src/Processors/Formats/Impl/AvroConfluentRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroConfluentRowOutputFormat.cpp
@@ -1170,9 +1170,8 @@ AvroSchemaSerializer::createAction(const Block & header, const avro::NodePtr & n
 AvroConfluentRowOutputFormat::AvroConfluentRowOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & settings_)
     : IRowOutputFormat(header_, out_, ProcessorID::AvroRowOutputFormatID), settings(settings_)
 {
-    chassert(!settings.kafka_schema_registry.topic_name.empty() && !settings.kafka_schema_registry.subject_name.empty());
-    auto schema = KafkaSchemaRegistryForAvro::getOrCreate(settings)->getSchemaForTopic(
-        settings.kafka_schema_registry.topic_name,
+    chassert(!settings.kafka_schema_registry.subject_name.empty());
+    auto schema = KafkaSchemaRegistryForAvro::getOrCreate(settings)->getSchemaForSubject(
         settings.kafka_schema_registry.subject_name,
         settings.kafka_schema_registry.force_refresh_schema);
     schema_id = schema.first;

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -55,6 +55,7 @@
 #include <Poco/URI.h>
 
 /// proton: starts
+#include <base/defines.h>
 #include <Formats/KafkaSchemaRegistry.h>
 #include <Formats/Avro/Schemas.h>
 #include <IO/WriteBufferFromFile.h>
@@ -942,6 +943,11 @@ AvroConfluentRowInputFormat::AvroConfluentRowInputFormat(
     , format_settings(format_settings_)
 
 {
+    if (format_settings.kafka_schema_registry.consume_single_schema)
+    {
+        auto schema = schema_registry->getSchemaForSubject(format_settings.kafka_schema_registry.subject_name);
+        target_schema_id = schema.first; 
+    }
 }
 
 /// proton: starts
@@ -975,6 +981,13 @@ bool AvroConfluentRowInputFormat::readRow(MutableColumns & columns, RowReadExten
 
     /// proton: starts
     SchemaId schema_id = KafkaSchemaRegistry::readSchemaId(*in);
+    if (target_schema_id.has_value() && target_schema_id.value() != schema_id)
+    {
+        /// Skip record with non-target schema id, we assume in a single io stream, there is no mixed schema records 
+        in->tryIgnore(in->available());
+        return false;
+    }
+
     const auto & deserializer = getOrCreateDeserializer(schema_id);
     /// proton: ends
 
@@ -1209,11 +1222,8 @@ NamesAndTypesList AvroExternalSchemaReader::readSchema()
     const bool schema_registry = !format_settings.avro.schema_registry_url.empty() || !format_settings.kafka_schema_registry.url.empty();
     if (schema_registry)
     {
-        if (format_settings.kafka_schema_registry.topic_name.empty() || format_settings.kafka_schema_registry.subject_name.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not read schema: schema registry topic or subject name is not set");
-
-        auto schema = KafkaSchemaRegistryForAvro::getOrCreate(format_settings)->getSchemaForTopic(
-            format_settings.kafka_schema_registry.topic_name,
+        chassert(!format_settings.kafka_schema_registry.subject_name.empty());
+        auto schema = KafkaSchemaRegistryForAvro::getOrCreate(format_settings)->getSchemaForSubject(
             format_settings.kafka_schema_registry.subject_name,
             format_settings.kafka_schema_registry.force_refresh_schema);
         root_node = schema.second.root();

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.h
@@ -200,6 +200,7 @@ private:
     std::unique_ptr<AvroInputStreamReadBufferAdapter> input_stream;
     avro::DecoderPtr decoder;
     FormatSettings format_settings;
+    std::optional<UInt32> target_schema_id;
 };
 
 /// proton: starts

--- a/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -355,7 +355,7 @@ bool ProtobufConfluentRowInputFormat::readRow(MutableColumns & columns, RowReadE
 
 ProtobufConfluentSchemaReader::ProtobufConfluentSchemaReader(const FormatSettings & format_settings)
     : registry(getConfluentSchemaRegistry(format_settings))
-    , subject(format_settings.kafka_schema_registry.topic_name)
+    , subject(format_settings.kafka_schema_registry.subject_name)
     , skip_unsupported_fields(format_settings.protobuf.skip_fields_with_unsupported_types_in_schema_inference)
 {
 }

--- a/src/Storages/ExternalStream/ExternalStreamSettings.h
+++ b/src/Storages/ExternalStream/ExternalStreamSettings.h
@@ -22,6 +22,7 @@ class ASTStorage;
     M(String, ssl_ca_pem, "", "CA certificate string (PEM format) for verifying the server's key.", 0) \
     M(Bool, skip_ssl_cert_check, false, "If set to true, the server's certification won't be verified.", 0) \
     M(String, schema_subject_name, "", "Avro / Protobuf schema subject name in registry. Used to fetch schema in the registry when writing", 0) \
+    M(String, subject_name_strategy, "", "Avro / Protobuf subject name strategy in registry. Default is TopicNameStrategy if not configured. RecordNameStrategy, TopicRecordNameStrategy can be used to mix different type of records in the same topic", 0) \
     M(String, properties, "", "A semi-colon-separated key-value pairs for configuring the kafka client used by the external stream. A key-value pair is separated by a equal sign. Example: 'client.id=my-client-id;group.id=my-group-id'. Note, not all properties are supported, please check the document for supported properties.", 0) \
     M(UInt64, poll_waittime_ms, 500, "How long (in milliseconds) should poll waits.", 0) \
     M(String, sharding_expr, "", "An expression which will be evaluated on each row of data returned by the query to calculate the an integer which will be used to determine the ID of the partition to which the row of data will be sent. If not set, data are sent to any partition randomly.", 0) \
@@ -194,10 +195,33 @@ struct ExternalStreamSettings : public BaseSettings<ExternalStreamSettingsTraits
         /// This is needed otherwise using an external stream with ProtobufSingle format as the target stream
         /// of a MV (or in `INSERT ... SELECT ...`), i.e. more than one rows sent to the stream, exception will be thrown.
         format_settings.protobuf.allow_multiple_rows_without_delimiter = true;
-        /// In case of kafka schema registry is used, the topic name and subject name need to be passed to the
-        /// output format to fetch the schema.
-        format_settings.kafka_schema_registry.topic_name = topic;
-        format_settings.kafka_schema_registry.subject_name = schema_subject_name.value.empty() ? topic.value : schema_subject_name.value;
+
+        /// Derive subject name according to schema subject name strategy
+        /// https://developer.confluent.io/courses/schema-registry/schema-subjects/
+        if (subject_name_strategy.value.empty() || subject_name_strategy.value == "TopicNameStrategy")
+        {
+            /// Ingore subject_name_strategy setting when using TopicNameStrategy, because the subject name is derived from topic name.
+            format_settings.kafka_schema_registry.subject_name = fmt::format("{}-value", topic.value);
+        }
+        else if (subject_name_strategy.value == "TopicRecordNameStrategy")
+        {
+            if (schema_subject_name.value.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "schema_subject_name must be provided when using TopicRecordNameStrategy");
+
+            format_settings.kafka_schema_registry.subject_name = fmt::format("{}-{}", topic.value, schema_subject_name.value);
+            format_settings.kafka_schema_registry.consume_single_schema = true;
+        }
+        else
+        {
+            /// subject_name_strategy.value == "RecordNameStrategy" or CustomNameStrategy
+
+            if (schema_subject_name.value.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "schema_subject_name must be provided when using {}", subject_name_strategy.value);
+
+            format_settings.kafka_schema_registry.subject_name = schema_subject_name.value;
+            format_settings.kafka_schema_registry.consume_single_schema = true;
+        }
+
         /// Kafka schema registry may have multiple historical schema versions. Allow old data missed some fields and read as default value.
         format_settings.avro.allow_missing_fields = true;
 


### PR DESCRIPTION

- Derive subject name according to subject name strategy
- Only consume records with target schema if a topic is mixed with different schemas
- Refactor schema cache to use subject name as key instead of topic name.



It is backward incompatible because previously user set 'schema_subject_name=abc', we will fetch subject 'abc-value'. After the fix, it will fetch a different subject 'abc' which may return 404 if not exists

