### PR TITLE
backport python package requirements install support

### DIFF
--- a/src/CPython/AsyncPythonPackageManager.cpp
+++ b/src/CPython/AsyncPythonPackageManager.cpp
@@ -1,9 +1,9 @@
 #include <CPython/AsyncPythonPackageManager.h>
 #include <CPython/PythonPackage.h>
 
+#include <Interpreters/Context.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/logger_useful.h>
-#include <Interpreters/Context.h>
 
 namespace CurrentMetrics
 {

--- a/src/CPython/AsyncPythonPackageManager.cpp
+++ b/src/CPython/AsyncPythonPackageManager.cpp
@@ -1,8 +1,9 @@
 #include <CPython/AsyncPythonPackageManager.h>
 #include <CPython/PythonPackage.h>
 
-#include <Interpreters/Context.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/logger_useful.h>
+#include <Interpreters/Context.h>
 
 namespace CurrentMetrics
 {
@@ -57,7 +58,11 @@ void AsyncPythonPackageManager::shutdown()
 }
 
 cluster::CallResultV<String> AsyncPythonPackageManager::scheduleInstall(
-    const String & task_id, const String & package_name, const String & package_version, AsyncTaskCallback callback)
+    const String & task_id,
+    const String & package_name,
+    const String & package_version,
+    const PipInstallOptions & install_options,
+    AsyncTaskCallback callback)
 {
     if (shutdown_requested.load())
         return cluster::CallResultV<String>(DB::ErrorCodes::RESOURCE_NOT_INITED, "AsyncPythonPackageManager is shutting down");
@@ -74,6 +79,7 @@ cluster::CallResultV<String> AsyncPythonPackageManager::scheduleInstall(
     }
 
     auto task_result = std::make_shared<AsyncTaskResult>(task_id, package_name, "install", original_spec);
+    task_result->_install_options = install_options;
 
     {
         std::unique_lock lock(results_mutex);
@@ -97,6 +103,42 @@ cluster::CallResultV<String> AsyncPythonPackageManager::scheduleInstall(
     catch (...)
     {
         /// Remove task from tracking if scheduling failed
+        {
+            std::unique_lock lock(results_mutex);
+            task_results.erase(task_id);
+        }
+        return cluster::CallResultV<String>(DB::ErrorCodes::LOGICAL_ERROR, "Failed to schedule task");
+    }
+
+    return cluster::CallResultV<String>(task_id);
+}
+
+cluster::CallResultV<String> AsyncPythonPackageManager::scheduleInstallRequirements(
+    const String & task_id, const String & requirements_text, const PipInstallOptions & install_options, AsyncTaskCallback callback)
+{
+    if (shutdown_requested.load())
+        return cluster::CallResultV<String>(DB::ErrorCodes::RESOURCE_NOT_INITED, "AsyncPythonPackageManager is shutting down");
+
+    auto task_result = std::make_shared<AsyncTaskResult>(task_id, "requirements.txt", "install", "requirements.txt");
+    task_result->_requirements_text = requirements_text;
+    task_result->_install_options = install_options;
+    task_result->_install_from_requirements = true;
+
+    {
+        std::unique_lock lock(results_mutex);
+        if (task_results.find(task_id) != task_results.end())
+            return cluster::CallResultV<String>(DB::ErrorCodes::LOGICAL_ERROR, fmt::format("Task ID {} already exists", task_id));
+
+        task_results[task_id] = task_result;
+    }
+
+    try
+    {
+        thread_pool->scheduleOrThrowOnError([this, task_result, callback]() { install(task_result, callback); });
+        LOG_DEBUG(logger, "Scheduled Python requirements install task: {}", task_id);
+    }
+    catch (...)
+    {
         {
             std::unique_lock lock(results_mutex);
             task_results.erase(task_id);
@@ -151,33 +193,37 @@ void AsyncPythonPackageManager::install(AsyncTaskResultPtr task_result, AsyncTas
 
     try
     {
-        std::string package_with_version = task_result->_original_package_spec;
-
-        auto package = PythonPackage(package_with_version);
+        PythonPackage package = task_result->_install_from_requirements
+            ? PythonPackage::fromRequirementsText(task_result->_requirements_text, task_result->_install_options)
+            : PythonPackage(task_result->_original_package_spec, task_result->_install_options);
         package.install(logger);
 
         /// Extract the actual installed version for metrics tracking
-        try
+        if (!task_result->_install_from_requirements)
         {
-            std::string actual_version = package.getActualInstalledVersion(logger);
-            if (!actual_version.empty())
+            try
             {
-                task_result->installed_version = actual_version;
-                LOG_DEBUG(logger, "Captured installed version '{}' for package '{}'", actual_version, task_result->package_name);
+                std::string actual_version = package.getActualInstalledVersion(logger);
+                if (!actual_version.empty())
+                {
+                    task_result->installed_version = actual_version;
+                    LOG_DEBUG(logger, "Captured installed version '{}' for package '{}'", actual_version, task_result->package_name);
+                }
+                else
+                {
+                    LOG_DEBUG(
+                        logger,
+                        "Could not determine actual installed version for package '{}' after successful install",
+                        task_result->package_name);
+                }
             }
-            else
+            catch (...)
             {
                 LOG_DEBUG(
                     logger,
-                    "Could not determine actual installed version for package '{}' after successful install",
+                    "Exception while extracting actual version for package '{}' after successful install",
                     task_result->package_name);
             }
-        }
-        catch (...)
-        {
-            /// Don't fail the entire installation if version extraction fails
-            LOG_DEBUG(
-                logger, "Exception while extracting actual version for package '{}' after successful install", task_result->package_name);
         }
 
         update(task_result, AsyncTaskStatus::Completed, cluster::Error(), callback);

--- a/src/CPython/AsyncPythonPackageManager.h
+++ b/src/CPython/AsyncPythonPackageManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CPython/PythonPackage.h>
+
 #include <Cluster/Common/CallResult.h>
 #include <Interpreters/Context_fwd.h>
 #include <Common/ThreadPool_fwd.h>
@@ -31,6 +33,9 @@ struct AsyncTaskResult
 
     /// Internal fields for processing (not exposed in system table)
     String _original_package_spec; /// Original specification used for installation (e.g., "requests>2.0")
+    String _requirements_text;
+    PipInstallOptions _install_options;
+    bool _install_from_requirements = false;
 
     AsyncTaskResult(const String & task_id_, const String & package_name_, const String & operation_, const String & original_spec_ = "")
         : task_id(task_id_)
@@ -60,7 +65,17 @@ public:
     ~AsyncPythonPackageManager();
 
     cluster::CallResultV<String> scheduleInstall(
-        const String & task_id, const String & package_name, const String & package_version = "", AsyncTaskCallback callback = nullptr);
+        const String & task_id,
+        const String & package_name,
+        const String & package_version = "",
+        const PipInstallOptions & install_options = {},
+        AsyncTaskCallback callback = nullptr);
+
+    cluster::CallResultV<String> scheduleInstallRequirements(
+        const String & task_id,
+        const String & requirements_text,
+        const PipInstallOptions & install_options = {},
+        AsyncTaskCallback callback = nullptr);
 
     cluster::CallResultV<String>
     scheduleUninstall(const String & task_id, const String & package_name, AsyncTaskCallback callback = nullptr);

--- a/src/CPython/PythonPackage.cpp
+++ b/src/CPython/PythonPackage.cpp
@@ -211,9 +211,9 @@ struct TemporaryRequirementsFile
         static std::atomic<uint64_t> counter = 0;
         file_path = std::filesystem::path("tmp")
             / fmt::format(
-                "python_requirements_{}_{}.txt",
-                std::chrono::steady_clock::now().time_since_epoch().count(),
-                counter.fetch_add(1, std::memory_order_relaxed));
+                        "python_requirements_{}_{}.txt",
+                        std::chrono::steady_clock::now().time_since_epoch().count(),
+                        counter.fetch_add(1, std::memory_order_relaxed));
         file_path_string = file_path.string();
 
         std::ofstream out(file_path, std::ios::out | std::ios::trunc);

--- a/src/CPython/PythonPackage.cpp
+++ b/src/CPython/PythonPackage.cpp
@@ -5,9 +5,21 @@
 
 #include <Common/getExecutablePath.h>
 #include <Common/logger_useful.h>
+#include <Common/re2.h>
 
 #include <Python.h>
-#include <re2/re2.h>
+#include <fmt/ranges.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <unordered_set>
 
 
 namespace DB
@@ -26,11 +38,8 @@ namespace cpython
 {
 namespace
 {
-/// Get the Python interpreter info that matches the UDF runtime configuration
 PythonInterpreterInfo getUDFPythonInterpreterInfo()
 {
-    /// Use the same discovery logic as the UDF runtime in Server_Python.cpp
-    /// This ensures we use the exact same Python interpreter
     std::string program_dir = getExecutablePath();
     size_t last_slash = program_dir.find_last_of('/');
     if (last_slash != std::string::npos)
@@ -39,8 +48,6 @@ PythonInterpreterInfo getUDFPythonInterpreterInfo()
     return PythonInterpreterInfo::collect(program_dir);
 }
 
-/// Build pip command arguments with consistent user strategy
-/// Always uses --user for install-like operations to ensure consistent permissions in containers
 std::vector<std::string> buildPipArgs(const std::vector<std::string> & base_args, bool for_install_like_ops = true)
 {
     std::vector<std::string> args = base_args;
@@ -50,19 +57,200 @@ std::vector<std::string> buildPipArgs(const std::vector<std::string> & base_args
     return args;
 }
 
+void appendPipIndexOptions(std::vector<std::string> & args, const PipInstallOptions & install_options)
+{
+    if (!install_options.index_url.empty())
+    {
+        args.push_back("--index-url");
+        args.push_back(install_options.index_url);
+    }
+
+    for (const auto & extra_index_url : install_options.extra_index_urls)
+    {
+        args.push_back("--extra-index-url");
+        args.push_back(extra_index_url);
+    }
+}
+
+std::string trimCopy(const std::string & value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos)
+        return "";
+
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::string stripPackageExtras(const std::string & package_name)
+{
+    const auto extras_start = package_name.find('[');
+    if (extras_start == std::string::npos)
+        return package_name;
+
+    return trimCopy(package_name.substr(0, extras_start));
+}
+
+std::string extractLookupNameFromPackageSpec(const std::string & package_spec)
+{
+    static constexpr std::array<std::string_view, 8> operators{
+        "===",
+        "==",
+        ">=",
+        "<=",
+        "!=",
+        "~=",
+        ">",
+        "<",
+    };
+
+    size_t version_start = std::string::npos;
+    for (std::string_view op : operators)
+    {
+        const size_t pos = package_spec.find(op);
+        if (pos != std::string::npos)
+            version_start = std::min(version_start, pos);
+    }
+
+    return stripPackageExtras(trimCopy(package_spec.substr(0, version_start)));
+}
+
+std::string canonicalizePythonPackageName(std::string_view package_name)
+{
+    std::string canonical_name;
+    canonical_name.reserve(package_name.size());
+
+    bool previous_was_separator = false;
+    for (unsigned char ch : package_name)
+    {
+        const char lower = static_cast<char>(std::tolower(ch));
+        const bool is_separator = lower == '-' || lower == '_' || lower == '.';
+        if (is_separator)
+        {
+            if (!previous_was_separator)
+                canonical_name.push_back('-');
+
+            previous_was_separator = true;
+            continue;
+        }
+
+        canonical_name.push_back(lower);
+        previous_was_separator = false;
+    }
+
+    return canonical_name;
+}
+
+void addRefreshSiteDirectory(
+    std::vector<std::string> & directories, std::unordered_set<std::string> & seen, const std::string & site_directory)
+{
+    if (!site_directory.empty() && seen.emplace(site_directory).second)
+        directories.push_back(site_directory);
+}
+
+std::vector<std::string> getRefreshSiteDirectories(PyObject * site_module)
+{
+    std::vector<std::string> directories;
+    std::unordered_set<std::string> seen;
+
+    if (const char * user_base = getenv("PYTHONUSERBASE"); user_base && *user_base)
+    {
+        const auto user_site_packages = fmt::format("{}/lib/python{}.{}/site-packages", user_base, PY_MAJOR_VERSION, PY_MINOR_VERSION);
+        addRefreshSiteDirectory(directories, seen, user_site_packages);
+    }
+
+    auto get_user_site_packages = PyObjectPtr{PyObject_GetAttrString(site_module, "getusersitepackages")};
+    if (!get_user_site_packages || !PyCallable_Check(get_user_site_packages.get()))
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to get site.getusersitepackages: {}", getExceptionMessage());
+
+    auto user_site_packages = PyObjectPtr{PyObject_CallFunctionObjArgs(get_user_site_packages.get(), nullptr)};
+    if (!user_site_packages)
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to get Python user site-packages path: {}", getExceptionMessage());
+
+    if (user_site_packages.get() != Py_None)
+    {
+        const char * user_site_packages_str = PyUnicode_AsUTF8(user_site_packages.get());
+        if (!user_site_packages_str)
+            throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to decode Python user site-packages path: {}", getExceptionMessage());
+
+        addRefreshSiteDirectory(directories, seen, user_site_packages_str);
+    }
+
+    auto interpreter_info = getUDFPythonInterpreterInfo();
+    for (const auto & site_package : interpreter_info.site_packages)
+        addRefreshSiteDirectory(directories, seen, site_package);
+
+    return directories;
+}
+
+void logConfluentKafkaCompatibilityWarning(const std::string & package_spec, LoggerPtr logger)
+{
+    const auto lookup_name = canonicalizePythonPackageName(extractLookupNameFromPackageSpec(package_spec));
+    if (lookup_name != "confluent-kafka")
+        return;
+
+    LOG_WARNING(
+        logger,
+        "Installing Python package '{}': the confluent-kafka wheel bundles its own librdkafka "
+        "which may conflict with the librdkafka already linked into the Proton process. "
+        "If you experience import errors or segfaults, try pinning confluent-kafka==2.1.1 "
+        "(known-good version) and restart Proton after installation. "
+        "You can verify the active library version at runtime via confluent_kafka.libversion().",
+        package_spec);
+}
+
+struct TemporaryRequirementsFile
+{
+    explicit TemporaryRequirementsFile(const std::vector<std::string> & requirement_lines)
+    {
+        std::error_code ec;
+        std::filesystem::create_directories("tmp", ec);
+        if (ec)
+            throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Failed to create tmp directory for requirements file: {}", ec.message());
+
+        static std::atomic<uint64_t> counter = 0;
+        file_path = std::filesystem::path("tmp")
+            / fmt::format(
+                "python_requirements_{}_{}.txt",
+                std::chrono::steady_clock::now().time_since_epoch().count(),
+                counter.fetch_add(1, std::memory_order_relaxed));
+        file_path_string = file_path.string();
+
+        std::ofstream out(file_path, std::ios::out | std::ios::trunc);
+        if (!out.is_open())
+            throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Failed to create temporary requirements file '{}'", file_path_string);
+
+        for (const auto & requirement_line : requirement_lines)
+            out << requirement_line << '\n';
+
+        out.flush();
+        if (!out.good())
+            throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Failed to write temporary requirements file '{}'", file_path_string);
+    }
+
+    ~TemporaryRequirementsFile()
+    {
+        std::error_code ec;
+        if (!file_path.empty())
+            std::filesystem::remove(file_path, ec);
+    }
+
+    const std::string & path() const { return file_path_string; }
+
+private:
+    std::filesystem::path file_path;
+    std::string file_path_string;
+};
+
 void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_error, LoggerPtr logger)
 {
     std::string args_str = fmt::format(" {}", fmt::join(args, " "));
-
-    /// Get the correct Python interpreter path that matches UDF runtime
     PythonInterpreterInfo interpreter_info = getUDFPythonInterpreterInfo();
 
     try
     {
         GILGuard gil_guard(true);
 
-        /// Use subprocess to call 'python -m pip' is best practice
-        /// https://stackoverflow.com/a/47059613 and https://github.com/jgonggrijp/pip-review/issues/44
         auto subprocess_module = PyObjectPtr{PyImport_ImportModule("subprocess")};
         if (!subprocess_module)
             throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to import subprocess module");
@@ -71,7 +259,6 @@ void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_er
         if (!subprocess_run || !PyCallable_Check(subprocess_run.get()))
             throw Exception(ErrorCodes::PYTHON_EXECUTE_ERROR, "Failed to get subprocess.run function");
 
-        /// Build command list: [interpreter_path, "-m", "pip"] + args
         auto cmd_list = PyObjectPtr{PyList_New(args.size() + 3)};
         auto python_arg = PyObjectPtr{PyUnicode_FromString(interpreter_info.path.c_str())};
         auto m_arg = PyObjectPtr{PyUnicode_FromString("-m")};
@@ -87,11 +274,9 @@ void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_er
             PyList_SetItem(cmd_list.get(), i + 3, arg.release());
         }
 
-        /// Call subprocess.run() with command list
         auto run_args = PyObjectPtr{PyTuple_New(1)};
         PyTuple_SetItem(run_args.get(), 0, cmd_list.release());
 
-        /// Add keyword arguments: check=True, capture_output=True, text=True
         auto kwargs = PyObjectPtr{PyDict_New()};
         auto check_key = PyObjectPtr{PyUnicode_FromString("check")};
         auto check_value = PyObjectPtr{PyBool_FromLong(1)};
@@ -105,18 +290,12 @@ void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_er
         auto text_value = PyObjectPtr{PyBool_FromLong(1)};
         PyDict_SetItem(kwargs.get(), text_key.get(), text_value.get());
 
-        /// Set environment to ensure consistent paths with UDF runtime
-        /// This ensures packages are installed to the same location UDF runtime expects
         auto env_key = PyObjectPtr{PyUnicode_FromString("env")};
-        auto env_dict = PyObjectPtr{PyDict_New()};
-
-        /// Copy current environment
         auto os_module = PyObjectPtr{PyImport_ImportModule("os")};
         auto environ = PyObjectPtr{PyObject_GetAttrString(os_module.get(), "environ")};
         auto copy_method = PyObjectPtr{PyObject_GetAttrString(environ.get(), "copy")};
         auto current_env = PyObjectPtr{PyObject_CallObject(copy_method.get(), nullptr)};
 
-        /// Ensure PYTHONHOME and PYTHONUSERBASE are set correctly
         auto pythonhome_key = PyObjectPtr{PyUnicode_FromString("PYTHONHOME")};
         auto pythonhome_value = PyObjectPtr{PyUnicode_FromString(interpreter_info.prefix.c_str())};
         PyDict_SetItem(current_env.get(), pythonhome_key.get(), pythonhome_value.get());
@@ -126,14 +305,14 @@ void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_er
         auto result = PyObjectPtr{PyObject_Call(subprocess_run.get(), run_args.get(), kwargs.get())};
         if (!result)
         {
-            /// Extract stderr from CalledProcessError before clearing Python exception
             std::string stderr_msg;
             if (PyErr_Occurred())
             {
-                PyObject *ptype, *pvalue, *ptraceback;
+                PyObject * ptype = nullptr;
+                PyObject * pvalue = nullptr;
+                PyObject * ptraceback = nullptr;
                 PyErr_Fetch(&ptype, &pvalue, &ptraceback);
 
-                /// Check if it's a CalledProcessError and extract stderr
                 if (pvalue && PyObject_HasAttrString(pvalue, "stderr"))
                 {
                     auto stderr_obj = PyObjectPtr{PyObject_GetAttrString(pvalue, "stderr")};
@@ -145,13 +324,11 @@ void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_er
                     }
                 }
 
-                /// Clean up the fetched exception objects
                 Py_XDECREF(ptype);
                 Py_XDECREF(pvalue);
                 Py_XDECREF(ptraceback);
             }
 
-            /// Clear any Python exception to avoid GIL issues in destructor
             PyErr_Clear();
 
             if (log_failure_as_error)
@@ -169,13 +346,11 @@ void runPipCommand(const std::vector<std::string> & args, bool log_failure_as_er
             throw Exception::createRuntime(ErrorCodes::PYTHON_PIP_ERROR, error_message);
         }
 
-        /// Get return code
         auto returncode_attr = PyObjectPtr{PyObject_GetAttrString(result.get(), "returncode")};
         long returncode = PyLong_AsLong(returncode_attr.get());
 
         if (returncode != 0)
         {
-            /// Get stderr for error message
             auto stderr_attr = PyObjectPtr{PyObject_GetAttrString(result.get(), "stderr")};
             const char * stderr_str = PyUnicode_AsUTF8(stderr_attr.get());
             std::string error_message = stderr_str ? stderr_str : "Unknown error";
@@ -236,18 +411,236 @@ void PythonPackage::ensurePythonInterpreterReady()
     }
 }
 
+PythonPackage::PythonPackage(const std::string & package_with_version_, PipInstallOptions install_options_)
+    : PythonPackage(
+          package_with_version_,
+          /*requirements_text_*/ "",
+          /*install_from_requirements_*/ false,
+          std::move(install_options_))
+{
+}
+
+PythonPackage::PythonPackage(
+    const std::string & package_with_version_,
+    const std::string & requirements_text_,
+    bool install_from_requirements_,
+    PipInstallOptions install_options_)
+    : package_with_version(package_with_version_)
+    , requirements_text(requirements_text_)
+    , install_from_requirements(install_from_requirements_)
+    , install_options(std::move(install_options_))
+    , logger(getLogger("PythonPackage"))
+{
+    if (!install_options.index_url.empty())
+    {
+        validatePipIndexUrl(install_options.index_url, "--index-url");
+        install_options.index_url = trimCopy(install_options.index_url);
+    }
+
+    for (auto & extra_index_url : install_options.extra_index_urls)
+    {
+        validatePipIndexUrl(extra_index_url, "--extra-index-url");
+        extra_index_url = trimCopy(extra_index_url);
+    }
+
+    if (install_from_requirements)
+    {
+        parseRequirementsText(requirements_text);
+    }
+    else
+    {
+        validatePackageSpecification(package_with_version);
+        parsePackageWithVersion();
+    }
+}
+
+PythonPackage PythonPackage::fromRequirementsText(const std::string & requirements_text_, PipInstallOptions install_options_)
+{
+    return PythonPackage(
+        /*package_with_version_*/ "",
+        requirements_text_,
+        /*install_from_requirements_*/ true,
+        std::move(install_options_));
+}
+
+void PythonPackage::validatePipIndexUrl(const std::string & index_url, const char * option_name)
+{
+    const auto trimmed = trimCopy(index_url);
+    if (trimmed.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Empty value is not allowed for {}", option_name);
+
+    if (trimmed.size() > 2048)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} value exceeds maximum length of 2048 characters", option_name);
+
+    if (trimmed.find_first_of(" \t\r\n") != std::string::npos)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} value cannot contain whitespace", option_name);
+
+    static const re2::RE2 valid_index_url_pattern(R"(^(https?://)[^\s]+$)");
+    if (!re2::RE2::FullMatch(trimmed, valid_index_url_pattern))
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid {} value '{}'. Only http(s) URLs are supported", option_name, index_url);
+    }
+}
+
+void PythonPackage::refreshImportState(LoggerPtr logger)
+{
+    if (!Py_IsInitialized())
+        return;
+
+    if (!logger)
+        logger = getLogger("PythonPackage");
+
+    GILGuard gil_guard(true);
+
+    auto site_module = PyObjectPtr{PyImport_ImportModule("site")};
+    if (!site_module)
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to import site module: {}", getExceptionMessage());
+
+    auto add_site_dir = PyObjectPtr{PyObject_GetAttrString(site_module.get(), "addsitedir")};
+    if (!add_site_dir || !PyCallable_Check(add_site_dir.get()))
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to get site.addsitedir: {}", getExceptionMessage());
+
+    size_t refreshed_paths = 0;
+    for (const auto & site_directory : getRefreshSiteDirectories(site_module.get()))
+    {
+        std::error_code ec;
+        if (!std::filesystem::exists(site_directory, ec))
+        {
+            if (ec)
+                LOG_WARNING(logger, "Skipping Python site directory '{}' during refresh: {}", site_directory, ec.message());
+            continue;
+        }
+
+        auto site_dir_arg = PyObjectPtr{PyUnicode_FromString(site_directory.c_str())};
+        auto add_result = PyObjectPtr{PyObject_CallFunctionObjArgs(add_site_dir.get(), site_dir_arg.get(), nullptr)};
+        if (!add_result)
+        {
+            throw Exception(
+                ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to refresh Python site directory '{}': {}", site_directory, getExceptionMessage());
+        }
+
+        ++refreshed_paths;
+    }
+
+    auto importlib_module = PyObjectPtr{PyImport_ImportModule("importlib")};
+    if (!importlib_module)
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to import importlib module: {}", getExceptionMessage());
+
+    auto invalidate_caches = PyObjectPtr{PyObject_GetAttrString(importlib_module.get(), "invalidate_caches")};
+    if (!invalidate_caches || !PyCallable_Check(invalidate_caches.get()))
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to get importlib.invalidate_caches: {}", getExceptionMessage());
+
+    auto invalidate_result = PyObjectPtr{PyObject_CallFunctionObjArgs(invalidate_caches.get(), nullptr)};
+    if (!invalidate_result)
+        throw Exception(ErrorCodes::PYTHON_IMPORT_ERROR, "Failed to invalidate Python import caches: {}", getExceptionMessage());
+
+    size_t extended_namespaces = 0;
+    auto pkg_resources_module = PyObjectPtr{PyImport_ImportModule("pkg_resources")};
+    if (pkg_resources_module)
+    {
+        auto ns_packages_dict = PyObjectPtr{PyObject_GetAttrString(pkg_resources_module.get(), "_namespace_packages")};
+        if (ns_packages_dict && PyDict_Check(ns_packages_dict.get()))
+        {
+            auto pkgutil_module = PyObjectPtr{PyImport_ImportModule("pkgutil")};
+            if (pkgutil_module)
+            {
+                auto extend_path_func = PyObjectPtr{PyObject_GetAttrString(pkgutil_module.get(), "extend_path")};
+                if (extend_path_func && PyCallable_Check(extend_path_func.get()))
+                {
+                    PyObject * modules_dict = PyImport_GetModuleDict();
+                    PyObject * ns_name_obj = nullptr;
+                    PyObject * ns_value_obj = nullptr;
+                    Py_ssize_t pos = 0;
+
+                    while (PyDict_Next(ns_packages_dict.get(), &pos, &ns_name_obj, &ns_value_obj))
+                    {
+                        PyObject * mod_obj = PyDict_GetItem(modules_dict, ns_name_obj);
+                        if (!mod_obj || mod_obj == Py_None || !PyObject_HasAttrString(mod_obj, "__path__"))
+                            continue;
+
+                        auto mod_path = PyObjectPtr{PyObject_GetAttrString(mod_obj, "__path__")};
+                        if (!mod_path)
+                        {
+                            PyErr_Clear();
+                            continue;
+                        }
+
+                        auto new_path
+                            = PyObjectPtr{PyObject_CallFunctionObjArgs(extend_path_func.get(), mod_path.get(), ns_name_obj, nullptr)};
+                        if (new_path)
+                        {
+                            if (PyObject_SetAttrString(mod_obj, "__path__", new_path.get()) == 0)
+                                ++extended_namespaces;
+                        }
+
+                        if (PyErr_Occurred())
+                            PyErr_Clear();
+                    }
+                }
+            }
+        }
+    }
+    if (PyErr_Occurred())
+        PyErr_Clear();
+
+    LOG_DEBUG(
+        logger,
+        "Refreshed Python import state after package change: refreshed_paths={}, extended_namespaces={}",
+        refreshed_paths,
+        extended_namespaces);
+}
+
+std::vector<std::string> PythonPackage::parseRequirementsText(const std::string & requirements_text_value)
+{
+    if (trimCopy(requirements_text_value).empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Requirements text cannot be empty");
+
+    constexpr size_t max_requirements_lines = 1024;
+    std::vector<std::string> requirements;
+    requirements.reserve(32);
+
+    std::istringstream input(requirements_text_value);
+    std::string line;
+    while (std::getline(input, line))
+    {
+        auto trimmed = trimCopy(line);
+        if (trimmed.empty() || trimmed[0] == '#')
+            continue;
+
+        if (trimmed.starts_with("-"))
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Requirements line '{}' is not supported. Please pass index options via API fields instead",
+                trimmed);
+        }
+
+        validatePackageSpecification(trimmed);
+        requirements.push_back(trimmed);
+
+        if (requirements.size() > max_requirements_lines)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS, "Requirements text exceeds maximum number of {} effective lines", max_requirements_lines);
+        }
+    }
+
+    if (requirements.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Requirements text does not contain any valid package specification");
+
+    return requirements;
+}
+
 void PythonPackage::validatePackageSpecification(const std::string & package_spec)
 {
     if (package_spec.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Package specification cannot be empty");
 
-    /// Prevent excessively long package specifications
     if (package_spec.length() > 255)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Package specification '{}' exceeds maximum length of 255 characters", package_spec);
 
-    /// Allows package names with version specifiers like "requests>=2.25.0"
     static const re2::RE2 valid_package_pattern(
-        R"(^([a-zA-Z0-9]([a-zA-Z0-9\-_\.])*[a-zA-Z0-9]|[a-zA-Z0-9])(\s*[><=!~]+\s*[a-zA-Z0-9\.\-_]+(\s*,\s*[><=!~]+\s*[a-zA-Z0-9\.\-_]+)*)?$)");
+        R"(^([a-zA-Z0-9]([a-zA-Z0-9\-_\.]*[a-zA-Z0-9])?)(\[\s*[a-zA-Z0-9]([a-zA-Z0-9\-_\.]*[a-zA-Z0-9])?(\s*,\s*[a-zA-Z0-9]([a-zA-Z0-9\-_\.]*[a-zA-Z0-9])?)*\s*\])?(\s*[><=!~]+\s*[a-zA-Z0-9\.\-_]+(\s*,\s*[><=!~]+\s*[a-zA-Z0-9\.\-_]+)*)?$)");
 
     if (!re2::RE2::FullMatch(package_spec, valid_package_pattern))
     {
@@ -257,7 +650,6 @@ void PythonPackage::validatePackageSpecification(const std::string & package_spe
             package_spec);
     }
 
-    /// Security check: prevent known malicious patterns
     static const std::vector<std::string> blocked_patterns = {"__pycache__", "..", "/", "\\", ":", "*", "?", "\"", "|"};
     for (const auto & pattern : blocked_patterns)
     {
@@ -268,18 +660,11 @@ void PythonPackage::validatePackageSpecification(const std::string & package_spe
 
 void PythonPackage::parsePackageWithVersion()
 {
-    /// Parse package_with_version to extract the package name
-    /// Examples: "slack_sdk===2.1.0" -> name="slack_sdk", version_spec="===2.1.0"
-    ///           "slack_sdk>=2.1.0,<2.3.0" -> name="slack_sdk", version_spec=">=2.1.0,<2.3.0"
-    ///           "slack_sdk" -> name="slack_sdk", version_spec=""
-
     if (package_with_version.empty())
         throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Package specification cannot be empty");
 
-    /// Find the first version operator (===, ==, >=, <=, >, <, !=, ~=)
     size_t version_start = std::string::npos;
     std::vector<std::string> operators = {"===", "==", ">=", "<=", "!=", "~=", ">", "<"};
-
     for (const auto & op : operators)
     {
         size_t pos = package_with_version.find(op);
@@ -289,33 +674,55 @@ void PythonPackage::parsePackageWithVersion()
 
     if (version_start == std::string::npos)
     {
-        /// No version specified
         name = package_with_version;
         version_spec = "";
     }
     else
     {
-        /// Version specified
         name = package_with_version.substr(0, version_start);
         version_spec = package_with_version.substr(version_start);
     }
 
-    /// Trim whitespace from name
-    size_t name_start = name.find_first_not_of(" \t");
-    size_t name_end = name.find_last_not_of(" \t");
+    const size_t name_start = name.find_first_not_of(" \t");
+    const size_t name_end = name.find_last_not_of(" \t");
     if (name_start != std::string::npos && name_end != std::string::npos)
         name = name.substr(name_start, name_end - name_start + 1);
 
-    if (name.empty())
+    lookup_name = stripPackageExtras(name);
+    if (lookup_name.empty())
         throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Package name cannot be empty in specification: {}", package_with_version);
 }
 
 void PythonPackage::validateInstall(LoggerPtr logger) const
 {
-    /// Use pip show command to check if package is already installed locally
-    /// pip show returns exit code 0 if package is installed, non-zero if not installed
+    if (install_from_requirements)
+    {
+        auto requirements = parseRequirementsText(requirements_text);
+        TemporaryRequirementsFile requirements_file(requirements);
+
+        auto dry_run_args = buildPipArgs({"install", "--dry-run", "--quiet"});
+        appendPipIndexOptions(dry_run_args, install_options);
+        dry_run_args.push_back("-r");
+        dry_run_args.push_back(requirements_file.path());
+
+        try
+        {
+            runPipCommand(
+                dry_run_args,
+                /*log_failure_as_error=*/false,
+                logger);
+        }
+        catch (const Exception & e)
+        {
+            LOG_DEBUG(logger, "Requirements validation failed: {}", e.message());
+            throw Exception::createRuntime(e.code(), fmt::format("Failed to validate requirements installation: {}", e.message()));
+        }
+
+        return;
+    }
+
     auto show_args = buildPipArgs({"show", "--quiet"});
-    show_args.push_back(name);
+    show_args.push_back(lookup_name);
 
     try
     {
@@ -327,12 +734,10 @@ void PythonPackage::validateInstall(LoggerPtr logger) const
     }
     catch (...)
     {
-        /// Package not installed locally, try dry-run install to validate it can actually be installed
-        /// This will catch packages that exist in PyPI but are broken/malformed
-
         try
         {
             auto dry_run_args = buildPipArgs({"install", "--dry-run", "--quiet"});
+            appendPipIndexOptions(dry_run_args, install_options);
             dry_run_args.push_back(package_with_version);
 
             runPipCommand(
@@ -381,13 +786,9 @@ void PythonPackage::validateInstall(LoggerPtr logger) const
 
 void PythonPackage::validateUninstall(LoggerPtr logger) const
 {
-    /// For uninstall, we only need to check if the package exists
-    /// Use the same robust logic as getActualInstalledVersion()
     std::string installed_version = getActualInstalledVersion(logger);
     if (installed_version.empty())
-    {
         throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Package '{}' is not installed and cannot be uninstalled", name);
-    }
 
     LOG_DEBUG(logger, "Package '{}' (version: {}) found and can be uninstalled", name, installed_version);
 }
@@ -404,26 +805,35 @@ std::vector<PythonPackage> PythonPackage::list()
     if (!distributions || !PyCallable_Check(distributions.get()))
         throw Exception(ErrorCodes::PYTHON_EXECUTE_ERROR, "Failed to get distributions, {}", getExceptionMessage());
 
-    auto dist_iter = PyObjectPtr{PyObject_CallObject(distributions.get(), NULL)};
+    auto dist_iter = PyObjectPtr{PyObject_CallObject(distributions.get(), nullptr)};
     if (!dist_iter)
         throw Exception(ErrorCodes::PYTHON_EXECUTE_ERROR, "Failed to get distributions iterator, {}", getExceptionMessage());
 
-    PyObjectPtr dist;
     PythonPackages packages;
-
     for (auto dist = PyObjectPtr{PyIter_Next(dist_iter.get())}; dist; dist.reset(PyIter_Next(dist_iter.get())))
     {
-        auto name = PyObjectPtr{PyObject_GetAttrString(dist.get(), "name")};
-        auto version = PyObjectPtr{PyObject_GetAttrString(dist.get(), "version")};
+        auto name_obj = PyObjectPtr{PyObject_GetAttrString(dist.get(), "name")};
+        auto version_obj = PyObjectPtr{PyObject_GetAttrString(dist.get(), "version")};
 
-        if (name && version)
+        if (!name_obj || !version_obj)
+            continue;
+
+        if (!PyUnicode_Check(name_obj.get()) || !PyUnicode_Check(version_obj.get()))
         {
-            const char * package_name = PyUnicode_AsUTF8(name.get());
-            const char * package_version = PyUnicode_AsUTF8(version.get());
-            /// For list(), we construct the package_with_version as name==version
-            std::string package_with_version = std::string{package_name} + "==" + std::string{package_version};
-            packages.emplace_back(package_with_version);
+            PyErr_Clear();
+            continue;
         }
+
+        const char * package_name = PyUnicode_AsUTF8(name_obj.get());
+        const char * package_version = PyUnicode_AsUTF8(version_obj.get());
+        if (!package_name || !package_version)
+        {
+            PyErr_Clear();
+            continue;
+        }
+
+        std::string package_with_version = std::string{package_name} + "==" + std::string{package_version};
+        packages.emplace_back(package_with_version);
     }
 
     return packages;
@@ -436,48 +846,85 @@ PythonInterpreterInfo PythonPackage::getPythonInterpreterInfo()
 
 void PythonPackage::install(LoggerPtr logger) const
 {
-    LOG_INFO(logger, "Starting Python package installation: {}", package_with_version);
-
-    /// Pre-install validation
-    validateInstall(logger);
-
-    try
+    if (install_from_requirements)
     {
+        LOG_INFO(logger, "Starting Python requirements installation");
+
+        validateInstall(logger);
+
+        auto requirements = parseRequirementsText(requirements_text);
+        TemporaryRequirementsFile requirements_file(requirements);
+
         auto args = buildPipArgs({"install"});
-        args.push_back(package_with_version);
+        appendPipIndexOptions(args, install_options);
+        args.push_back("-r");
+        args.push_back(requirements_file.path());
 
         runPipCommand(
             args,
             /*log_failure_as_error=*/true,
             logger);
 
-        LOG_INFO(logger, "Successfully installed Python package: {}", package_with_version);
+        try
+        {
+            refreshImportState(logger);
+        }
+        catch (const Exception & e)
+        {
+            LOG_WARNING(logger, "Installed Python requirements but failed to refresh runtime imports: {}", e.message());
+        }
+
+        for (const auto & requirement : requirements)
+            logConfluentKafkaCompatibilityWarning(requirement, logger);
+
+        LOG_INFO(logger, "Successfully installed Python requirements");
+        return;
     }
-    catch (...)
+
+    LOG_INFO(logger, "Starting Python package installation: {}", package_with_version);
+
+    validateInstall(logger);
+
+    auto args = buildPipArgs({"install"});
+    appendPipIndexOptions(args, install_options);
+    args.push_back(package_with_version);
+
+    runPipCommand(
+        args,
+        /*log_failure_as_error=*/true,
+        logger);
+
+    try
     {
-        throw;
+        refreshImportState(logger);
     }
+    catch (const Exception & e)
+    {
+        LOG_WARNING(logger, "Installed Python package '{}' but failed to refresh runtime imports: {}", package_with_version, e.message());
+    }
+
+    logConfluentKafkaCompatibilityWarning(package_with_version, logger);
+
+    LOG_INFO(logger, "Successfully installed Python package: {}", package_with_version);
 }
 
 void PythonPackage::uninstall(LoggerPtr logger) const
 {
-    if (name.empty())
+    if (lookup_name.empty())
         throw Exception(ErrorCodes::PYTHON_PIP_ERROR, "Failed to uninstall package: name is empty");
 
     LOG_INFO(logger, "Starting Python package uninstallation: {}", name);
 
     try
     {
-        /// pip uninstall automatically finds packages regardless of where they were installed
-        /// (user site-packages, target directory, or system site-packages)
-        /// It doesn't support --user or --target flags, so we use for_install_like_ops=false
         auto args = buildPipArgs({"uninstall", "-y"}, /*for_install_like_ops=*/false);
-        args.push_back(name);
+        args.push_back(lookup_name);
 
         runPipCommand(
             args,
             /*log_failure_as_error=*/true,
             logger);
+
         LOG_INFO(logger, "Successfully uninstalled Python package: {}", name);
     }
     catch (const Exception & e)
@@ -494,7 +941,7 @@ void PythonPackage::uninstall(LoggerPtr logger) const
 
 std::string PythonPackage::getActualInstalledVersion(LoggerPtr logger) const
 {
-    if (name.empty())
+    if (lookup_name.empty())
     {
         LOG_DEBUG(logger, "Cannot get version for empty package name");
         return "";
@@ -504,7 +951,6 @@ std::string PythonPackage::getActualInstalledVersion(LoggerPtr logger) const
     {
         GILGuard gil_guard(true);
 
-        /// Use subprocess to call 'python -m pip show' to get package information
         PythonInterpreterInfo interpreter_info = getUDFPythonInterpreterInfo();
 
         auto subprocess_module = PyObjectPtr{PyImport_ImportModule("subprocess")};
@@ -521,13 +967,12 @@ std::string PythonPackage::getActualInstalledVersion(LoggerPtr logger) const
             return "";
         }
 
-        /// Build command: [interpreter_path, "-m", "pip", "show", package_name]
         auto cmd_list = PyObjectPtr{PyList_New(5)};
         auto python_arg = PyObjectPtr{PyUnicode_FromString(interpreter_info.path.c_str())};
         auto m_arg = PyObjectPtr{PyUnicode_FromString("-m")};
         auto pip_arg = PyObjectPtr{PyUnicode_FromString("pip")};
         auto show_arg = PyObjectPtr{PyUnicode_FromString("show")};
-        auto package_arg = PyObjectPtr{PyUnicode_FromString(name.c_str())};
+        auto package_arg = PyObjectPtr{PyUnicode_FromString(lookup_name.c_str())};
 
         PyList_SetItem(cmd_list.get(), 0, python_arg.release());
         PyList_SetItem(cmd_list.get(), 1, m_arg.release());
@@ -535,11 +980,9 @@ std::string PythonPackage::getActualInstalledVersion(LoggerPtr logger) const
         PyList_SetItem(cmd_list.get(), 3, show_arg.release());
         PyList_SetItem(cmd_list.get(), 4, package_arg.release());
 
-        /// Call subprocess.run() with command list
         auto run_args = PyObjectPtr{PyTuple_New(1)};
         PyTuple_SetItem(run_args.get(), 0, cmd_list.release());
 
-        /// Add keyword arguments: capture_output=True, text=True, check=False (we handle errors)
         auto kwargs = PyObjectPtr{PyDict_New()};
         auto capture_key = PyObjectPtr{PyUnicode_FromString("capture_output")};
         auto capture_value = PyObjectPtr{PyBool_FromLong(1)};
@@ -550,10 +993,9 @@ std::string PythonPackage::getActualInstalledVersion(LoggerPtr logger) const
         PyDict_SetItem(kwargs.get(), text_key.get(), text_value.get());
 
         auto check_key = PyObjectPtr{PyUnicode_FromString("check")};
-        auto check_value = PyObjectPtr{PyBool_FromLong(0)}; /// Don't raise exception on non-zero exit
+        auto check_value = PyObjectPtr{PyBool_FromLong(0)};
         PyDict_SetItem(kwargs.get(), check_key.get(), check_value.get());
 
-        /// Set environment to ensure consistent paths
         auto env_key = PyObjectPtr{PyUnicode_FromString("env")};
         auto os_module = PyObjectPtr{PyImport_ImportModule("os")};
         auto environ = PyObjectPtr{PyObject_GetAttrString(os_module.get(), "environ")};
@@ -568,60 +1010,55 @@ std::string PythonPackage::getActualInstalledVersion(LoggerPtr logger) const
         auto result = PyObjectPtr{PyObject_Call(subprocess_run.get(), run_args.get(), kwargs.get())};
         if (!result)
         {
-            LOG_DEBUG(logger, "Failed to execute pip show command for package '{}'", name);
+            LOG_DEBUG(logger, "Failed to execute pip show command for package '{}'", lookup_name);
             PyErr_Clear();
             return "";
         }
 
-        /// Check return code
         auto returncode_attr = PyObjectPtr{PyObject_GetAttrString(result.get(), "returncode")};
         long returncode = PyLong_AsLong(returncode_attr.get());
 
         if (returncode != 0)
         {
-            LOG_DEBUG(logger, "Package '{}' is not installed (pip show returned {})", name, returncode);
+            LOG_DEBUG(logger, "Package '{}' is not installed (pip show returned {})", lookup_name, returncode);
             return "";
         }
 
-        /// Get stdout and parse version
         auto stdout_attr = PyObjectPtr{PyObject_GetAttrString(result.get(), "stdout")};
         const char * stdout_str = PyUnicode_AsUTF8(stdout_attr.get());
         if (!stdout_str)
         {
-            LOG_DEBUG(logger, "Failed to get stdout from pip show for package '{}'", name);
+            LOG_DEBUG(logger, "Failed to get stdout from pip show for package '{}'", lookup_name);
             return "";
         }
 
         std::string output(stdout_str);
 
-        /// Parse the Version line from pip show output
-        /// Expected format: "Version: 2.31.0"
         static const re2::RE2 version_pattern(R"((?m)^Version:\s*([^\r\n]+))");
         std::string version;
         if (re2::RE2::PartialMatch(output, version_pattern, &version))
         {
-            /// Trim whitespace
             size_t start = version.find_first_not_of(" \t\r\n");
             size_t end = version.find_last_not_of(" \t\r\n");
             if (start != std::string::npos && end != std::string::npos)
             {
                 version = version.substr(start, end - start + 1);
-                LOG_DEBUG(logger, "Extracted version '{}' for package '{}'", version, name);
+                LOG_DEBUG(logger, "Extracted version '{}' for package '{}'", version, lookup_name);
                 return version;
             }
         }
 
-        LOG_DEBUG(logger, "Could not parse version from pip show output for package '{}'", name);
+        LOG_DEBUG(logger, "Could not parse version from pip show output for package '{}'", lookup_name);
         return "";
     }
     catch (const Exception & e)
     {
-        LOG_DEBUG(logger, "Exception while getting version for package '{}': {}", name, e.message());
+        LOG_DEBUG(logger, "Exception while getting version for package '{}': {}", lookup_name, e.message());
         return "";
     }
     catch (...)
     {
-        LOG_DEBUG(logger, "Unknown exception while getting version for package '{}'", name);
+        LOG_DEBUG(logger, "Unknown exception while getting version for package '{}'", lookup_name);
         return "";
     }
 }

--- a/src/CPython/PythonPackage.h
+++ b/src/CPython/PythonPackage.h
@@ -4,17 +4,24 @@
 
 #include <Common/Logger.h>
 
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace DB::cpython
 {
+struct PipInstallOptions
+{
+    std::string index_url;
+    std::vector<std::string> extra_index_urls;
+};
+
 class PythonPackage
 {
 public:
-    PythonPackage(const std::string & package_with_version_)
-        : package_with_version(package_with_version_), logger(getLogger("PythonPackage"))
-    {
-        validatePackageSpecification(package_with_version_);
-        parsePackageWithVersion();
-    }
+    explicit PythonPackage(const std::string & package_with_version_, PipInstallOptions install_options_ = {});
+
+    static PythonPackage fromRequirementsText(const std::string & requirements_text_, PipInstallOptions install_options_ = {});
 
     static std::vector<PythonPackage> list();
 
@@ -25,6 +32,15 @@ public:
 
     /// Validate package name and specification format (static validation)
     static void validatePackageSpecification(const std::string & package_spec);
+
+    /// Refresh site-packages and import caches after package installation.
+    static void refreshImportState(LoggerPtr logger = {});
+
+    /// Validate pip private index URL format.
+    static void validatePipIndexUrl(const std::string & index_url, const char * option_name);
+
+    /// Validate requirements text content.
+    static std::vector<std::string> parseRequirementsText(const std::string & requirements_text);
 
     /// Pre-install validation: check if package exists and can be installed (using dry-run)
     void validateInstall(LoggerPtr logger) const;
@@ -40,10 +56,20 @@ public:
 
     std::string package_with_version;
     std::string name;
+    std::string lookup_name;
     std::string version_spec;
+    std::string requirements_text;
+    bool install_from_requirements = false;
+    PipInstallOptions install_options;
     LoggerPtr logger;
 
 private:
+    PythonPackage(
+        const std::string & package_with_version_,
+        const std::string & requirements_text_,
+        bool install_from_requirements_,
+        PipInstallOptions install_options_);
+
     void parsePackageWithVersion();
 };
 

--- a/src/CPython/tests/gtest_python_package.cpp
+++ b/src/CPython/tests/gtest_python_package.cpp
@@ -1,0 +1,342 @@
+#include "config.h"
+
+#if USE_PYTHON_UDF
+
+#include <CPython/GILGuard.h>
+#include <CPython/PythonPackage.h>
+#include <CPython/Utils.h>
+#include <CPython/tests/CPythonTest.h>
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+
+#include <base/scope_guard.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+using namespace DB::cpython;
+
+namespace DB::ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+}
+
+namespace
+{
+void expectInvalidPackageSpecification(const std::string & package_spec)
+{
+    try
+    {
+        PythonPackage::validatePackageSpecification(package_spec);
+        FAIL() << "Expected package specification to be rejected: " << package_spec;
+    }
+    catch (const DB::Exception & e)
+    {
+        EXPECT_EQ(e.code(), DB::ErrorCodes::BAD_ARGUMENTS);
+    }
+}
+}
+
+TEST(PythonPackageTest, AcceptsPackageSpecificationsWithExtras)
+{
+    EXPECT_NO_THROW(PythonPackage::validatePackageSpecification("confluent-kafka[protobuf,avro]"));
+    EXPECT_NO_THROW(PythonPackage::validatePackageSpecification("confluent-kafka[protobuf, avro]"));
+    EXPECT_NO_THROW(PythonPackage::validatePackageSpecification("confluent-kafka[protobuf]>=2.1.1"));
+    EXPECT_NO_THROW(PythonPackage::validatePackageSpecification("requests[socks]>=2.25.0,<3.0.0"));
+}
+
+TEST(PythonPackageTest, RejectsMalformedExtrasSpecifications)
+{
+    expectInvalidPackageSpecification("confluent-kafka[]");
+    expectInvalidPackageSpecification("confluent-kafka[protobuf,]");
+    expectInvalidPackageSpecification("confluent-kafka[,protobuf]");
+    expectInvalidPackageSpecification("confluent-kafka[protobuf,,avro]");
+    expectInvalidPackageSpecification("confluent-kafka[protobuf");
+}
+
+TEST(PythonPackageTest, ParsesExtrasAndVersionSpecifiers)
+{
+    PythonPackage package("confluent-kafka[protobuf, avro]>=2.1.1");
+
+    EXPECT_EQ(package.name, "confluent-kafka[protobuf, avro]");
+    EXPECT_EQ(package.lookup_name, "confluent-kafka");
+    EXPECT_EQ(package.version_spec, ">=2.1.1");
+    EXPECT_EQ(package.package_with_version, "confluent-kafka[protobuf, avro]>=2.1.1");
+}
+
+TEST(PythonPackageTest, ParsesRequirementsTextWithExtras)
+{
+    const auto requirements = PythonPackage::parseRequirementsText(R"(
+confluent-kafka[protobuf,avro]
+confluent-kafka[protobuf, avro]>=2.1.1
+)");
+
+    ASSERT_EQ(requirements.size(), 2);
+    EXPECT_EQ(requirements[0], "confluent-kafka[protobuf,avro]");
+    EXPECT_EQ(requirements[1], "confluent-kafka[protobuf, avro]>=2.1.1");
+}
+
+TEST_F(CPythonTest, RefreshImportStateProcessesPthFiles)
+{
+    namespace fs = std::filesystem;
+
+    const auto unique_suffix = std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    const auto test_root = fs::absolute(fs::path("tmp") / ("gtest_python_package_refresh_" + unique_suffix));
+    const auto user_base = test_root / "userbase";
+    const auto site_packages = user_base / "lib/python3.10/site-packages";
+    const auto extra_modules = test_root / "extra_modules";
+    const auto module_name = "python_package_refresh_" + unique_suffix;
+
+    fs::create_directories(site_packages);
+    fs::create_directories(extra_modules);
+
+    {
+        std::ofstream module_file(extra_modules / (module_name + ".py"), std::ios::out | std::ios::trunc);
+        module_file << "VALUE = 11719\n";
+    }
+
+    {
+        std::ofstream pth_file(site_packages / (module_name + ".pth"), std::ios::out | std::ios::trunc);
+        pth_file << extra_modules.string() << '\n';
+    }
+
+    const char * previous_user_base = getenv("PYTHONUSERBASE");
+    const std::string previous_user_base_value = previous_user_base ? previous_user_base : "";
+
+    ASSERT_EQ(setenv("PYTHONUSERBASE", user_base.c_str(), 1), 0);
+    SCOPE_EXIT({
+        if (previous_user_base)
+            setenv("PYTHONUSERBASE", previous_user_base_value.c_str(), 1);
+        else
+            unsetenv("PYTHONUSERBASE");
+
+        std::error_code error_code;
+        fs::remove_all(test_root, error_code);
+    });
+
+    GILGuard gil_guard(true);
+
+    auto before_refresh = PyObjectPtr{PyImport_ImportModule(module_name.c_str())};
+    EXPECT_FALSE(before_refresh);
+    if (PyErr_Occurred())
+        PyErr_Clear();
+
+    ASSERT_NO_THROW(PythonPackage::refreshImportState(getLogger("PythonPackageTest")));
+
+    auto module = PyObjectPtr{PyImport_ImportModule(module_name.c_str())};
+    ASSERT_TRUE(module) << getExceptionMessage();
+
+    auto value = PyObjectPtr{PyObject_GetAttrString(module.get(), "VALUE")};
+    ASSERT_TRUE(value);
+    EXPECT_EQ(PyLong_AsLong(value.get()), 11719);
+
+    unloadModule(module_name);
+}
+
+TEST_F(CPythonTest, RefreshImportStateProcessesDefaultUserSiteWhenPyUserBaseUnset)
+{
+    namespace fs = std::filesystem;
+
+    const auto unique_suffix = std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    const auto test_root = fs::absolute(fs::path("tmp") / ("gtest_python_package_default_user_site_" + unique_suffix));
+    const auto user_base = test_root / "userbase";
+    const auto user_site = user_base / "lib/python3.10/site-packages";
+    const auto extra_modules = test_root / "extra_modules";
+    const auto module_name = "python_package_default_user_site_" + unique_suffix;
+
+    fs::create_directories(user_site);
+    fs::create_directories(extra_modules);
+
+    {
+        std::ofstream module_file(extra_modules / (module_name + ".py"), std::ios::out | std::ios::trunc);
+        module_file << "VALUE = 11726\n";
+    }
+
+    {
+        std::ofstream pth_file(user_site / (module_name + ".pth"), std::ios::out | std::ios::trunc);
+        pth_file << extra_modules.string() << '\n';
+    }
+
+    const char * previous_user_base_env = getenv("PYTHONUSERBASE");
+    const std::string previous_user_base_value = previous_user_base_env ? previous_user_base_env : "";
+
+    ASSERT_EQ(unsetenv("PYTHONUSERBASE"), 0);
+
+    GILGuard gil_guard(true);
+
+    auto site_module = PyObjectPtr{PyImport_ImportModule("site")};
+    ASSERT_TRUE(site_module) << getExceptionMessage();
+
+    auto previous_user_base = PyObjectPtr{PyObject_GetAttrString(site_module.get(), "USER_BASE")};
+    ASSERT_TRUE(previous_user_base) << getExceptionMessage();
+    auto previous_user_site = PyObjectPtr{PyObject_GetAttrString(site_module.get(), "USER_SITE")};
+    ASSERT_TRUE(previous_user_site) << getExceptionMessage();
+
+    auto user_base_obj = PyObjectPtr{PyUnicode_FromString(user_base.c_str())};
+    auto user_site_obj = PyObjectPtr{PyUnicode_FromString(user_site.c_str())};
+    ASSERT_TRUE(user_base_obj);
+    ASSERT_TRUE(user_site_obj);
+    ASSERT_EQ(PyObject_SetAttrString(site_module.get(), "USER_BASE", user_base_obj.get()), 0) << getExceptionMessage();
+    ASSERT_EQ(PyObject_SetAttrString(site_module.get(), "USER_SITE", user_site_obj.get()), 0) << getExceptionMessage();
+
+    auto sys_module = PyObjectPtr{PyImport_ImportModule("sys")};
+    ASSERT_TRUE(sys_module);
+    auto sys_path = PyObjectPtr{PyObject_GetAttrString(sys_module.get(), "path")};
+    ASSERT_TRUE(sys_path);
+    auto remove_func = PyObjectPtr{PyObject_GetAttrString(sys_path.get(), "remove")};
+
+    SCOPE_EXIT({
+        if (previous_user_base_env)
+            setenv("PYTHONUSERBASE", previous_user_base_value.c_str(), 1);
+        else
+            unsetenv("PYTHONUSERBASE");
+
+        PyObject_SetAttrString(site_module.get(), "USER_BASE", previous_user_base.get());
+        PyObject_SetAttrString(site_module.get(), "USER_SITE", previous_user_site.get());
+        if (PyErr_Occurred())
+            PyErr_Clear();
+
+        if (remove_func)
+        {
+            auto unused = PyObjectPtr{PyObject_CallFunctionObjArgs(remove_func.get(), user_site_obj.get(), nullptr)};
+            (void)unused;
+        }
+        if (PyErr_Occurred())
+            PyErr_Clear();
+
+        unloadModule(module_name);
+
+        std::error_code error_code;
+        fs::remove_all(test_root, error_code);
+    });
+
+    auto before_refresh = PyObjectPtr{PyImport_ImportModule(module_name.c_str())};
+    EXPECT_FALSE(before_refresh);
+    if (PyErr_Occurred())
+        PyErr_Clear();
+
+    ASSERT_NO_THROW(PythonPackage::refreshImportState(getLogger("PythonPackageTest")));
+
+    auto module = PyObjectPtr{PyImport_ImportModule(module_name.c_str())};
+    ASSERT_TRUE(module) << getExceptionMessage();
+
+    auto value = PyObjectPtr{PyObject_GetAttrString(module.get(), "VALUE")};
+    ASSERT_TRUE(value);
+    EXPECT_EQ(PyLong_AsLong(value.get()), 11726);
+}
+
+TEST_F(CPythonTest, RefreshImportStateExtendsNamespacePackagePaths)
+{
+    namespace fs = std::filesystem;
+
+    auto pkg_resources_module = PyObjectPtr{PyImport_ImportModule("pkg_resources")};
+    if (!pkg_resources_module)
+    {
+        PyErr_Clear();
+        GTEST_SKIP() << "pkg_resources not available, skipping namespace package test";
+    }
+
+    const auto unique_suffix = std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    const auto test_root = fs::absolute(fs::path("tmp") / ("gtest_python_package_ns_" + unique_suffix));
+    const auto user_base = test_root / "userbase";
+    const auto site_packages = user_base / "lib/python3.10/site-packages";
+
+    const auto dir1 = test_root / "dir1";
+    const auto dir2 = test_root / "dir2";
+    const auto ns_name = "ns_pkg_" + unique_suffix;
+
+    fs::create_directories(site_packages);
+    fs::create_directories(dir1 / ns_name);
+    fs::create_directories(dir2 / ns_name);
+
+    {
+        std::ofstream f(dir1 / ns_name / "__init__.py");
+        f << "import pkg_resources; pkg_resources.declare_namespace(__name__)\n";
+    }
+    {
+        std::ofstream f(dir1 / ns_name / "child_a.py");
+        f << "VALUE = 100\n";
+    }
+    {
+        std::ofstream f(dir2 / ns_name / "child_b.py");
+        f << "VALUE = 200\n";
+    }
+    {
+        std::ofstream f(site_packages / (ns_name + ".pth"));
+        f << dir2.string() << '\n';
+    }
+
+    const char * previous_user_base = getenv("PYTHONUSERBASE");
+    const std::string previous_user_base_value = previous_user_base ? previous_user_base : "";
+
+    ASSERT_EQ(setenv("PYTHONUSERBASE", user_base.c_str(), 1), 0);
+    SCOPE_EXIT({
+        if (previous_user_base)
+            setenv("PYTHONUSERBASE", previous_user_base_value.c_str(), 1);
+        else
+            unsetenv("PYTHONUSERBASE");
+
+        std::error_code ec;
+        fs::remove_all(test_root, ec);
+    });
+
+    GILGuard gil_guard(true);
+
+    auto sys_module = PyObjectPtr{PyImport_ImportModule("sys")};
+    ASSERT_TRUE(sys_module);
+    auto sys_path = PyObjectPtr{PyObject_GetAttrString(sys_module.get(), "path")};
+    ASSERT_TRUE(sys_path);
+    auto dir1_str = PyObjectPtr{PyUnicode_FromString(dir1.c_str())};
+    PyList_Insert(sys_path.get(), 0, dir1_str.get());
+
+    const auto child_a_fqn = ns_name + ".child_a";
+    auto mod_a = PyObjectPtr{PyImport_ImportModule(child_a_fqn.c_str())};
+    ASSERT_TRUE(mod_a) << getExceptionMessage();
+    auto val_a = PyObjectPtr{PyObject_GetAttrString(mod_a.get(), "VALUE")};
+    ASSERT_TRUE(val_a);
+    EXPECT_EQ(PyLong_AsLong(val_a.get()), 100);
+
+    const auto child_b_fqn = ns_name + ".child_b";
+    auto mod_b_before = PyObjectPtr{PyImport_ImportModule(child_b_fqn.c_str())};
+    EXPECT_FALSE(mod_b_before) << "child_b should not be importable before refresh";
+    if (PyErr_Occurred())
+        PyErr_Clear();
+
+    ASSERT_NO_THROW(PythonPackage::refreshImportState(getLogger("PythonPackageTest")));
+
+    auto mod_b = PyObjectPtr{PyImport_ImportModule(child_b_fqn.c_str())};
+    ASSERT_TRUE(mod_b) << "child_b should be importable after refresh: " << getExceptionMessage();
+    auto val_b = PyObjectPtr{PyObject_GetAttrString(mod_b.get(), "VALUE")};
+    ASSERT_TRUE(val_b);
+    EXPECT_EQ(PyLong_AsLong(val_b.get()), 200);
+
+    PyObject * modules_dict = PyImport_GetModuleDict();
+    auto ns_key = PyObjectPtr{PyUnicode_FromString(ns_name.c_str())};
+    auto a_key = PyObjectPtr{PyUnicode_FromString(child_a_fqn.c_str())};
+    auto b_key = PyObjectPtr{PyUnicode_FromString(child_b_fqn.c_str())};
+    PyDict_DelItem(modules_dict, ns_key.get());
+    PyDict_DelItem(modules_dict, a_key.get());
+    PyDict_DelItem(modules_dict, b_key.get());
+    if (PyErr_Occurred())
+        PyErr_Clear();
+
+    auto ns_packages_dict = PyObjectPtr{PyObject_GetAttrString(pkg_resources_module.get(), "_namespace_packages")};
+    if (ns_packages_dict && PyDict_Check(ns_packages_dict.get()))
+        PyDict_DelItem(ns_packages_dict.get(), ns_key.get());
+    if (PyErr_Occurred())
+        PyErr_Clear();
+
+    auto remove_func = PyObjectPtr{PyObject_GetAttrString(sys_path.get(), "remove")};
+    if (remove_func)
+    {
+        auto unused = PyObjectPtr{PyObject_CallFunctionObjArgs(remove_func.get(), dir1_str.get(), nullptr)};
+        (void)unused;
+    }
+    if (PyErr_Occurred())
+        PyErr_Clear();
+}
+
+#endif

--- a/src/Cluster/Protocol/PipPythonPackageRequestData.cpp
+++ b/src/Cluster/Protocol/PipPythonPackageRequestData.cpp
@@ -13,7 +13,7 @@ namespace cluster::protocol
 
 PipPythonPackageRequestData::~PipPythonPackageRequestData() = default;
 
-void PipPythonPackageRequestData::serialize(DB::WriteBuffer & wb, uint16_t /*version*/) const
+void PipPythonPackageRequestData::serialize(DB::WriteBuffer & wb, uint16_t version) const
 {
     cluster::serializeEnum(operation, wb);
 
@@ -22,15 +22,24 @@ void PipPythonPackageRequestData::serialize(DB::WriteBuffer & wb, uint16_t /*ver
         DB::writeStringBinary(name, wb);
 
     DB::writeVarUInt(package_versions.size(), wb);
-    for (const auto & version : package_versions)
-        DB::writeStringBinary(version, wb);
+    for (const auto & package_version : package_versions)
+        DB::writeStringBinary(package_version, wb);
 
     DB::writeVarUInt(initiator, wb);
     DB::writeVarInt(timeout_ms, wb);
     DB::writeStringBinary(task_id, wb);
+
+    if (version >= 2)
+    {
+        DB::writeStringBinary(requirements_text, wb);
+        DB::writeStringBinary(index_url, wb);
+        DB::writeVarUInt(extra_index_urls.size(), wb);
+        for (const auto & extra_index_url : extra_index_urls)
+            DB::writeStringBinary(extra_index_url, wb);
+    }
 }
 
-void PipPythonPackageRequestData::doDeserialize(DB::ReadBuffer & rb, uint16_t /*version*/)
+void PipPythonPackageRequestData::doDeserialize(DB::ReadBuffer & rb, uint16_t version)
 {
     operation = cluster::deserializeEnum<Operation>(rb);
 
@@ -49,6 +58,24 @@ void PipPythonPackageRequestData::doDeserialize(DB::ReadBuffer & rb, uint16_t /*
     DB::readVarUInt(initiator, rb);
     DB::readVarInt(timeout_ms, rb);
     DB::readStringBinary(task_id, rb);
+
+    if (version >= 2)
+    {
+        DB::readStringBinary(requirements_text, rb);
+        DB::readStringBinary(index_url, rb);
+
+        size_t extra_index_urls_count;
+        DB::readVarUInt(extra_index_urls_count, rb);
+        extra_index_urls.resize(extra_index_urls_count);
+        for (size_t i = 0; i < extra_index_urls_count; ++i)
+            DB::readStringBinary(extra_index_urls[i], rb);
+    }
+    else
+    {
+        requirements_text.clear();
+        index_url.clear();
+        extra_index_urls.clear();
+    }
 }
 
 size_t PipPythonPackageRequestData::approximateSerializedSize() const noexcept
@@ -66,6 +93,11 @@ size_t PipPythonPackageRequestData::approximateSerializedSize() const noexcept
 
     /// task_id size
     size += approximateSerializedSizeOf(task_id);
+    size += approximateSerializedSizeOf(requirements_text);
+    size += approximateSerializedSizeOf(index_url);
+    size += sizeof(size_t);
+    for (const auto & extra_index_url : extra_index_urls)
+        size += approximateSerializedSizeOf(extra_index_url);
     return size;
 }
 
@@ -89,9 +121,13 @@ std::string PipPythonPackageRequestData::doString() const
     }
 
     return fmt::format(
-        "operation={} packages=[{}] initiator=0x{:x} timeout_ms={} task_id={}",
+        "operation={} packages=[{}] requirements_text_bytes={} index_url='{}' extra_index_urls={} initiator=0x{:x} timeout_ms={} "
+        "task_id={}",
         magic_enum::enum_name(operation),
         packages_str,
+        requirements_text.size(),
+        index_url,
+        fmt::join(extra_index_urls, ","),
         initiator,
         timeout_ms,
         task_id);

--- a/src/Cluster/Protocol/PipPythonPackageRequestData.h
+++ b/src/Cluster/Protocol/PipPythonPackageRequestData.h
@@ -23,12 +23,18 @@ struct PipPythonPackageRequestData final : public ProtocolData
         Operation operation_,
         std::vector<std::string> && package_names_,
         std::vector<std::string> && package_versions_,
+        std::string && requirements_text_,
+        std::string && index_url_,
+        std::vector<std::string> && extra_index_urls_,
         cluster::NodeID initiator_,
         int64_t timeout_ms_,
         std::string && task_id_ = "")
         : operation(operation_)
         , package_names(std::move(package_names_))
         , package_versions(std::move(package_versions_))
+        , requirements_text(std::move(requirements_text_))
+        , index_url(std::move(index_url_))
+        , extra_index_urls(std::move(extra_index_urls_))
         , initiator(initiator_)
         , timeout_ms(timeout_ms_)
         , task_id(std::move(task_id_))
@@ -39,7 +45,7 @@ struct PipPythonPackageRequestData final : public ProtocolData
 
     protocol::OpCode opCode() const noexcept override { return protocol::OpCode::PipPythonPackage; }
 
-    std::pair<uint16_t, uint16_t> supportedVersionsRange() const noexcept override { return {1, 1}; }
+    std::pair<uint16_t, uint16_t> supportedVersionsRange() const noexcept override { return {1, 2}; }
 
     void serialize(DB::WriteBuffer & wb, uint16_t version) const override;
 
@@ -54,6 +60,9 @@ public:
     Operation operation = Operation::Install;
     std::vector<std::string> package_names;
     std::vector<std::string> package_versions;
+    std::string requirements_text;
+    std::string index_url;
+    std::vector<std::string> extra_index_urls;
 
     cluster::NodeID initiator = Nulls::NullNodeID;
     int64_t timeout_ms = 0;

--- a/src/Cluster/Requests/PipPythonPackageRequest.h
+++ b/src/Cluster/Requests/PipPythonPackageRequest.h
@@ -15,12 +15,24 @@ public:
         protocol::PipPythonPackageRequestData::Operation operation_,
         std::vector<std::string> && package_names_,
         std::vector<std::string> && package_versions_,
+        std::string requirements_text_,
+        std::string index_url_,
+        std::vector<std::string> extra_index_urls_,
         NodeID initiator_,
         int64_t timeout_ms,
         uint16_t request_version_,
         std::string && task_id_ = "")
         : Request(request_version_)
-        , request_data(operation_, std::move(package_names_), std::move(package_versions_), initiator_, timeout_ms, std::move(task_id_))
+        , request_data(
+              operation_,
+              std::move(package_names_),
+              std::move(package_versions_),
+              std::move(requirements_text_),
+              std::move(index_url_),
+              std::move(extra_index_urls_),
+              initiator_,
+              timeout_ms,
+              std::move(task_id_))
     {
     }
 

--- a/src/Interpreters/Apply/MetadataUpdater_PythonPackage.cpp
+++ b/src/Interpreters/Apply/MetadataUpdater_PythonPackage.cpp
@@ -40,7 +40,8 @@ void MetadataUpdater::handlePipPythonPackage(
         {
             case cluster::protocol::PipPythonPackageRequestData::Install:
             {
-                if (data.package_names.empty())
+                const bool install_from_requirements = !data.requirements_text.empty();
+                if (!install_from_requirements && data.package_names.empty())
                 {
                     std::string error_msg = "No package specified for installation";
                     LOG_ERROR(logger, "Failed to install Python package {}: {}", data.doString(), error_msg);
@@ -50,39 +51,61 @@ void MetadataUpdater::handlePipPythonPackage(
                     return;
                 }
 
-                /// Handle single package installation
-                const std::string & package_name = data.package_names[0];
-                std::string package_version = data.package_versions.empty() ? "" : data.package_versions[0];
+                const std::string package_name = install_from_requirements ? "requirements.txt" : data.package_names[0];
+                const std::string package_version = data.package_versions.empty() ? "" : data.package_versions[0];
+                cpython::PipInstallOptions install_options{
+                    .index_url = data.index_url,
+                    .extra_index_urls = data.extra_index_urls,
+                };
 
                 try
                 {
-                    std::string package_with_version = package_name;
-                    if (!package_version.empty())
+                    cpython::PythonPackage package = install_from_requirements
+                        ? cpython::PythonPackage::fromRequirementsText(data.requirements_text, install_options)
+                        : [&]() {
+                              std::string package_with_version = package_name;
+                              if (!package_version.empty())
+                              {
+                                  if (package_version.find_first_of("><!=~") != std::string::npos)
+                                      package_with_version += package_version;
+                                  else
+                                      package_with_version += "==" + package_version;
+                              }
+                              return cpython::PythonPackage(package_with_version, install_options);
+                          }();
+
+                    if (install_from_requirements)
                     {
-                        /// Check if version already contains operators like >, <, =, ~, !
-                        if (package_version.find_first_of("><!=~") != std::string::npos)
-                            package_with_version += package_version; /// Version spec like ">2.0", ">=1.0", etc.
-                        else
-                            package_with_version += "==" + package_version; /// Simple version like "1.0.0"
+                        LOG_DEBUG(
+                            logger,
+                            "Validating Python requirements for async installation: requirements_bytes={}",
+                            data.requirements_text.size());
                     }
-
-                    auto package = cpython::PythonPackage(package_with_version);
-
-                    LOG_DEBUG(
-                        logger,
-                        "Validating Python package for async installation: {}{}",
-                        package_name,
-                        package_version.empty() ? "" : fmt::format("=={}", package_version));
+                    else
+                    {
+                        LOG_DEBUG(
+                            logger,
+                            "Validating Python package for async installation: {}{}",
+                            package_name,
+                            package_version.empty() ? "" : fmt::format("=={}", package_version));
+                    }
 
                     /// Fast validation: check if package exists and can be installed (dry-run)
                     /// This is quick and catches most issues immediately
                     package.validateInstall(logger);
 
-                    LOG_DEBUG(
-                        logger,
-                        "Package validation successful, scheduling async installation: {}{}",
-                        package_name,
-                        package_version.empty() ? "" : fmt::format("=={}", package_version));
+                    if (install_from_requirements)
+                    {
+                        LOG_DEBUG(logger, "Requirements validation successful, scheduling async installation");
+                    }
+                    else
+                    {
+                        LOG_DEBUG(
+                            logger,
+                            "Package validation successful, scheduling async installation: {}{}",
+                            package_name,
+                            package_version.empty() ? "" : fmt::format("=={}", package_version));
+                    }
 
                     /// Acknowledge raft proposal immediately after validation
                     meta_store->getMetaDB().saveAppliedSequence(cluster::AppliedSequence(sn));
@@ -103,44 +126,70 @@ void MetadataUpdater::handlePipPythonPackage(
                     auto async_manager = global_context->getAsyncPythonPackageManager();
                     if (async_manager)
                     {
-                        auto result_ = async_manager->scheduleInstall(
-                            data.task_id,
-                            package_name,
-                            package_version,
-                            [package_name, version_display, this](const cpython::AsyncTaskResult & result) {
-                                if (result.isSuccess())
-                                {
-                                    LOG_INFO(
-                                        logger,
-                                        "Async Python package installation completed successfully: {}{} (task_id={})",
-                                        package_name,
-                                        version_display,
-                                        result.task_id);
-                                }
-                                else
-                                {
-                                    LOG_ERROR(
-                                        logger,
-                                        "Async Python package installation failed: {}{} (task_id={}, error={})",
-                                        package_name,
-                                        version_display,
-                                        result.task_id,
-                                        result.error.string());
-                                }
-                            });
+                        auto result_ = install_from_requirements
+                            ? async_manager->scheduleInstallRequirements(
+                                  data.task_id,
+                                  data.requirements_text,
+                                  install_options,
+                                  [this](const cpython::AsyncTaskResult & result) {
+                                      if (result.isSuccess())
+                                      {
+                                          LOG_INFO(
+                                              logger,
+                                              "Async Python requirements installation completed successfully: task_id={}",
+                                              result.task_id);
+                                      }
+                                      else
+                                      {
+                                          LOG_ERROR(
+                                              logger,
+                                              "Async Python requirements installation failed: task_id={}, error={}",
+                                              result.task_id,
+                                              result.error.string());
+                                      }
+                                  })
+                            : async_manager->scheduleInstall(
+                                  data.task_id,
+                                  package_name,
+                                  package_version,
+                                  install_options,
+                                  [package_name, version_display, this](const cpython::AsyncTaskResult & result) {
+                                      if (result.isSuccess())
+                                      {
+                                          LOG_INFO(
+                                              logger,
+                                              "Async Python package installation completed successfully: {}{} (task_id={})",
+                                              package_name,
+                                              version_display,
+                                              result.task_id);
+                                      }
+                                      else
+                                      {
+                                          LOG_ERROR(
+                                              logger,
+                                              "Async Python package installation failed: {}{} (task_id={}, error={})",
+                                              package_name,
+                                              version_display,
+                                              result.task_id,
+                                              result.error.string());
+                                      }
+                                  });
 
                         if (result_.hasError())
                         {
-                            LOG_ERROR(logger, "Failed to schedule Python package installation: {}", result_.errorString());
+                            LOG_ERROR(logger, "Failed to schedule Python installation task: {}", result_.errorString());
                         }
                         else
                         {
-                            LOG_INFO(
-                                logger,
-                                "Scheduled async Python package installation: {}{} (task_id={})",
-                                package_name,
-                                version_display,
-                                result_.result);
+                            if (install_from_requirements)
+                                LOG_INFO(logger, "Scheduled async Python requirements installation: task_id={}", result_.result);
+                            else
+                                LOG_INFO(
+                                    logger,
+                                    "Scheduled async Python package installation: {}{} (task_id={})",
+                                    package_name,
+                                    version_display,
+                                    result_.result);
                         }
                     }
                     else

--- a/src/Interpreters/InterpreterSystemQuery_Python.cpp
+++ b/src/Interpreters/InterpreterSystemQuery_Python.cpp
@@ -16,7 +16,7 @@
 #include <Interpreters/EnsurePython.h>
 #endif
 
-#include <re2/re2.h>
+#include <Common/re2.h>
 
 
 /// When Python UDF is disabled, these functions always throw and never return.
@@ -47,57 +47,98 @@ IF_NO_PY_UDF_NORETURN void InterpreterSystemQuery::executeInstallPythonPackage([
         "Python UDF support is not enabled. Rebuild with USE_PYTHON_UDF=1 to enable Python package management.");
 #else
 
-    cpython::PythonPackage::validatePackageSpecification(query.python_package_name);
     cpython::PythonPackage::ensurePythonInterpreterReady();
 
-    std::string package_with_version = query.python_package_name;
-    if (!query.python_package_version.empty())
+    const bool install_from_requirements = !query.python_package_requirements_text.empty();
+    if (install_from_requirements && !query.python_package_name.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid install syntax: package name and REQUIREMENTS text cannot be used together");
+
+    if (!install_from_requirements && query.python_package_name.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Python package name cannot be empty");
+
+    cpython::PipInstallOptions install_options;
+    install_options.index_url = query.python_package_index_url;
+    install_options.extra_index_urls.assign(query.python_package_extra_index_urls.begin(), query.python_package_extra_index_urls.end());
+
+    if (!install_options.index_url.empty())
+        cpython::PythonPackage::validatePipIndexUrl(install_options.index_url, "--index-url");
+    for (const auto & extra_index_url : install_options.extra_index_urls)
+        cpython::PythonPackage::validatePipIndexUrl(extra_index_url, "--extra-index-url");
+
+    std::string package_with_version;
+    if (!install_from_requirements)
     {
-        static const re2::RE2 version_pattern(R"(^[a-zA-Z0-9\.\-_]+$)");
-        if (!re2::RE2::FullMatch(query.python_package_version, version_pattern))
+        cpython::PythonPackage::validatePackageSpecification(query.python_package_name);
+
+        package_with_version = query.python_package_name;
+        if (!query.python_package_version.empty())
         {
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Invalid version format '{}'. Versions must contain only letters, numbers, dots, hyphens, and underscores",
-                query.python_package_version);
+            static const re2::RE2 version_pattern(R"(^[a-zA-Z0-9\.\-_]+$)");
+            if (!re2::RE2::FullMatch(query.python_package_version, version_pattern))
+            {
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Invalid version format '{}'. Versions must contain only letters, numbers, dots, hyphens, and underscores",
+                    query.python_package_version);
+            }
+            package_with_version += "==" + query.python_package_version;
         }
-        package_with_version += "==" + query.python_package_version;
     }
 
     auto base_timeout_sec = getContext()->getSettingsRef().query_timeout_sec;
     auto timeout_ms = std::max(30000UL, std::min(300000UL, static_cast<unsigned long>(base_timeout_sec * 1000))); /// 30s-5min bounds
 
-    auto package = cpython::PythonPackage(package_with_version);
+    auto package = install_from_requirements
+        ? cpython::PythonPackage::fromRequirementsText(query.python_package_requirements_text, install_options)
+        : cpython::PythonPackage(package_with_version, install_options);
 
     /// Pre-validation on initiator node: fail fast to avoid unnecessary raft operations
     try
     {
-        LOG_INFO(
-            log,
-            "Starting Python package installation (validating): package='{}', version='{}', timeout={}ms",
-            package.name,
-            package.version_spec.empty() ? "latest" : package.version_spec,
-            timeout_ms);
+        if (install_from_requirements)
+        {
+            LOG_INFO(
+                log,
+                "Starting Python requirements installation (validating): requirements_bytes={}, timeout={}ms",
+                query.python_package_requirements_text.size(),
+                timeout_ms);
+        }
+        else
+        {
+            LOG_INFO(
+                log,
+                "Starting Python package installation (validating): package='{}', version='{}', timeout={}ms",
+                package.name,
+                package.version_spec.empty() ? "latest" : package.version_spec,
+                timeout_ms);
+        }
         package.validateInstall(log);
     }
     catch (const Exception & e)
     {
-        throw Exception(e.code(), "Failed to install Python package '{}': {}", package_with_version, e.message());
+        const auto install_target = install_from_requirements ? "requirements text" : package_with_version;
+        throw Exception(e.code(), "Failed to install Python package '{}': {}", install_target, e.message());
     }
     catch (...)
     {
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Failed to install Python package '{}': Unknown error", package_with_version);
+        const auto install_target = install_from_requirements ? "requirements text" : package_with_version;
+        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Failed to install Python package '{}': Unknown error", install_target);
     }
 
     auto & metastore = Globals::getMetaStore();
     std::string task_id = toString(UUIDHelpers::generateV4());
     std::string task_id_for_logging = task_id;
 
-    /// Use parsed package name and version from PythonPackage object for accurate tracking
-    std::vector<std::string> package_names = {package.name};
+    std::vector<std::string> package_names;
+    if (!install_from_requirements)
+        package_names = {package.name};
+
     std::vector<std::string> package_versions;
-    if (!package.version_spec.empty())
+    if (!install_from_requirements && !package.version_spec.empty())
         package_versions = {package.version_spec};
+
+    const uint16_t request_version
+        = (install_from_requirements || !install_options.index_url.empty() || !install_options.extra_index_urls.empty()) ? 2 : 1;
 
     try
     {
@@ -105,39 +146,62 @@ IF_NO_PY_UDF_NORETURN void InterpreterSystemQuery::executeInstallPythonPackage([
             cluster::protocol::PipPythonPackageRequestData::Install,
             std::move(package_names),
             std::move(package_versions),
+            install_from_requirements ? query.python_package_requirements_text : "",
+            install_options.index_url,
+            install_options.extra_index_urls,
             getContext()->getNodeID(),
             timeout_ms,
-            /*request_version=*/1,
+            request_version,
             std::move(task_id));
 
-        LOG_INFO(
-            log,
-            "Initiating cluster-wide Python package install: package='{}', version='{}', task_id='{}', timeout={}ms",
-            package.name,
-            package.version_spec.empty() ? "latest" : package.version_spec,
-            task_id_for_logging,
-            timeout_ms);
+        if (install_from_requirements)
+        {
+            LOG_INFO(
+                log,
+                "Initiating cluster-wide Python requirements install: requirements_bytes={}, task_id='{}', timeout={}ms",
+                query.python_package_requirements_text.size(),
+                task_id_for_logging,
+                timeout_ms);
+        }
+        else
+        {
+            LOG_INFO(
+                log,
+                "Initiating cluster-wide Python package install: package='{}', version='{}', task_id='{}', timeout={}ms",
+                package.name,
+                package.version_spec.empty() ? "latest" : package.version_spec,
+                task_id_for_logging,
+                timeout_ms);
+        }
 
         auto system_command_resp = metastore.pythonPackageOperation(std::move(python_package_req));
 
         if (system_command_resp->hasError())
         {
             const auto & err = system_command_resp->error();
+            const auto install_target = install_from_requirements ? "requirements text" : query.python_package_name;
             LOG_ERROR(
                 log,
                 "Cluster operation failed for Python package '{}': error_code={}, error_message={}",
-                query.python_package_name,
+                install_target,
                 err.error_code,
                 err.error_message);
-            throw Exception(err.error_code, "Failed to install Python package '{}': {}", query.python_package_name, err.error_message);
+            throw Exception(err.error_code, "Failed to install Python package '{}': {}", install_target, err.error_message);
         }
 
-        LOG_INFO(
-            log,
-            "Successfully completed Python package installation: package='{}', version='{}', task_id='{}'",
-            package.name,
-            package.version_spec.empty() ? "latest" : package.version_spec,
-            task_id_for_logging);
+        if (install_from_requirements)
+        {
+            LOG_INFO(log, "Successfully completed Python requirements installation: task_id='{}'", task_id_for_logging);
+        }
+        else
+        {
+            LOG_INFO(
+                log,
+                "Successfully completed Python package installation: package='{}', version='{}', task_id='{}'",
+                package.name,
+                package.version_spec.empty() ? "latest" : package.version_spec,
+                task_id_for_logging);
+        }
     }
     catch (const Exception &)
     {
@@ -145,8 +209,9 @@ IF_NO_PY_UDF_NORETURN void InterpreterSystemQuery::executeInstallPythonPackage([
     }
     catch (...)
     {
-        LOG_ERROR(log, "Cluster operation failed for Python package '{}': Unknown exception", query.python_package_name);
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Failed to install Python package '{}': Unknown error", query.python_package_name);
+        const auto install_target = install_from_requirements ? "requirements text" : query.python_package_name;
+        LOG_ERROR(log, "Cluster operation failed for Python package '{}': Unknown exception", install_target);
+        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Failed to install Python package '{}': Unknown error", install_target);
     }
 #endif
 }
@@ -195,6 +260,9 @@ IF_NO_PY_UDF_NORETURN void InterpreterSystemQuery::executeUninstallPythonPackage
             cluster::protocol::PipPythonPackageRequestData::Uninstall,
             std::move(package_names),
             std::move(package_versions),
+            "",
+            "",
+            std::vector<std::string>{},
             getContext()->getNodeID(),
             timeout_ms,
             /*request_version=*/1,

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -261,8 +261,8 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
 
         for (const auto & extra_index_url : python_package_extra_index_urls)
         {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " EXTRA_INDEX_URL "
-                          << (settings.hilite ? hilite_none : "") << quoteString(extra_index_url);
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " EXTRA_INDEX_URL " << (settings.hilite ? hilite_none : "")
+                          << quoteString(extra_index_url);
         }
     }
     else if (type == Type::UNINSTALL_PYTHON_PACKAGE)

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -240,10 +240,29 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
     else if (type == Type::INSTALL_PYTHON_PACKAGE)
     {
         /// SYSTEM INSTALL PYTHON PACKAGE 'package_name' ['version']
-        settings.ostr << " " << quoteString(python_package_name);
-        if (!python_package_version.empty())
+        /// SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'requirements_text'
+        if (!python_package_requirements_text.empty())
         {
-            settings.ostr << " " << quoteString(python_package_version);
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " REQUIREMENTS " << (settings.hilite ? hilite_none : "")
+                          << quoteString(python_package_requirements_text);
+        }
+        else
+        {
+            settings.ostr << " " << quoteString(python_package_name);
+            if (!python_package_version.empty())
+                settings.ostr << " " << quoteString(python_package_version);
+        }
+
+        if (!python_package_index_url.empty())
+        {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " INDEX_URL " << (settings.hilite ? hilite_none : "")
+                          << quoteString(python_package_index_url);
+        }
+
+        for (const auto & extra_index_url : python_package_extra_index_urls)
+        {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " EXTRA_INDEX_URL "
+                          << (settings.hilite ? hilite_none : "") << quoteString(extra_index_url);
         }
     }
     else if (type == Type::UNINSTALL_PYTHON_PACKAGE)

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -5,6 +5,8 @@
 
 #include "config.h"
 
+#include <vector>
+
 
 namespace DB
 {
@@ -140,6 +142,9 @@ public:
 
     String python_package_name;
     String python_package_version;
+    String python_package_requirements_text;
+    String python_package_index_url;
+    std::vector<String> python_package_extra_index_urls;
 
     String getID(char) const override { return "SYSTEM query"; }
 

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -517,17 +517,50 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
         case Type::INSTALL_PYTHON_PACKAGE:
         {
             /// SYSTEM INSTALL PYTHON PACKAGE 'package_name' ['version']
-            ASTPtr package_ast;
-            if (!ParserStringLiteral{}.parse(pos, package_ast, expected))
-                return false;
-
-            res->python_package_name = package_ast->as<ASTLiteral &>().value.safeGet<String>();
-
-            /// Optional version parameter
-            ASTPtr version_ast;
-            if (ParserStringLiteral{}.parse(pos, version_ast, expected))
+            /// SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'requirements_text'
+            if (ParserKeyword{"REQUIREMENTS"}.ignore(pos, expected))
             {
-                res->python_package_version = version_ast->as<ASTLiteral &>().value.safeGet<String>();
+                ASTPtr requirements_ast;
+                if (!ParserStringLiteral{}.parse(pos, requirements_ast, expected))
+                    return false;
+
+                res->python_package_requirements_text = requirements_ast->as<ASTLiteral &>().value.safeGet<String>();
+            }
+            else
+            {
+                ASTPtr package_ast;
+                if (!ParserStringLiteral{}.parse(pos, package_ast, expected))
+                    return false;
+
+                res->python_package_name = package_ast->as<ASTLiteral &>().value.safeGet<String>();
+
+                ASTPtr version_ast;
+                if (ParserStringLiteral{}.parse(pos, version_ast, expected))
+                    res->python_package_version = version_ast->as<ASTLiteral &>().value.safeGet<String>();
+            }
+
+            while (true)
+            {
+                if (ParserKeyword{"INDEX_URL"}.ignore(pos, expected))
+                {
+                    ASTPtr index_url_ast;
+                    if (!ParserStringLiteral{}.parse(pos, index_url_ast, expected))
+                        return false;
+
+                    res->python_package_index_url = index_url_ast->as<ASTLiteral &>().value.safeGet<String>();
+                }
+                else if (ParserKeyword{"EXTRA_INDEX_URL"}.ignore(pos, expected))
+                {
+                    ASTPtr extra_index_url_ast;
+                    if (!ParserStringLiteral{}.parse(pos, extra_index_url_ast, expected))
+                        return false;
+
+                    res->python_package_extra_index_urls.push_back(extra_index_url_ast->as<ASTLiteral &>().value.safeGet<String>());
+                }
+                else
+                {
+                    break;
+                }
             }
             break;
         }

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -303,6 +303,30 @@ INSTANTIATE_TEST_SUITE_P(ParserDropStreamQuery, ParserTest,
                              })));
 /// proton: ends
 
+/// proton: starts. `SYSTEM INSTALL/UNINSTALL PYTHON PACKAGE ...` test cases
+INSTANTIATE_TEST_SUITE_P(ParserSystemPythonPackageQuery, ParserTest,
+                         ::testing::Combine(
+                             ::testing::Values(std::make_shared<ParserSystemQuery>()),
+                             ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
+                                 {
+                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests'",
+                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests'"
+                                 },
+                                 {
+                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests' '2.32.3' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple' EXTRA_INDEX_URL 'https://backup.example/simple'",
+                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests' '2.32.3' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple' EXTRA_INDEX_URL 'https://backup.example/simple'"
+                                 },
+                                 {
+                                     "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'python-slugify==8.0.4' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple'",
+                                     "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'python-slugify==8.0.4' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple'"
+                                 },
+                                 {
+                                     "SYSTEM UNINSTALL PYTHON PACKAGE 'requests'",
+                                     "SYSTEM UNINSTALL PYTHON PACKAGE 'requests'"
+                                 }
+                             })));
+/// proton: ends
+
 /// proton: starts. `SYSTEM PAUSE/RESUME/ABORT/RECOVER MATERIALIZED VIEW <db.mv> [PERMANENT]` test cases
 INSTANTIATE_TEST_SUITE_P(ParserSystemCommandQueryForMV, ParserTest,
                          ::testing::Combine(
@@ -497,4 +521,3 @@ INSTANTIATE_TEST_SUITE_P(
             {"EMIT TIMEOUT 30s", "TIMEOUT 30s"},
             {"EMIT STREAM TIMEOUT 30s", "STREAM TIMEOUT 30s"}})));
 /// proton: end
-

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -304,27 +304,22 @@ INSTANTIATE_TEST_SUITE_P(ParserDropStreamQuery, ParserTest,
 /// proton: ends
 
 /// proton: starts. `SYSTEM INSTALL/UNINSTALL PYTHON PACKAGE ...` test cases
-INSTANTIATE_TEST_SUITE_P(ParserSystemPythonPackageQuery, ParserTest,
-                         ::testing::Combine(
-                             ::testing::Values(std::make_shared<ParserSystemQuery>()),
-                             ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
-                                 {
-                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests'",
-                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests'"
-                                 },
-                                 {
-                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests' '2.32.3' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple' EXTRA_INDEX_URL 'https://backup.example/simple'",
-                                     "SYSTEM INSTALL PYTHON PACKAGE 'requests' '2.32.3' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple' EXTRA_INDEX_URL 'https://backup.example/simple'"
-                                 },
-                                 {
-                                     "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'python-slugify==8.0.4' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple'",
-                                     "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'python-slugify==8.0.4' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL 'https://mirror.example/simple'"
-                                 },
-                                 {
-                                     "SYSTEM UNINSTALL PYTHON PACKAGE 'requests'",
-                                     "SYSTEM UNINSTALL PYTHON PACKAGE 'requests'"
-                                 }
-                             })));
+INSTANTIATE_TEST_SUITE_P(
+    ParserSystemPythonPackageQuery,
+    ParserTest,
+    ::testing::Combine(
+        ::testing::Values(std::make_shared<ParserSystemQuery>()),
+        ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
+            {"SYSTEM INSTALL PYTHON PACKAGE 'requests'", "SYSTEM INSTALL PYTHON PACKAGE 'requests'"},
+            {"SYSTEM INSTALL PYTHON PACKAGE 'requests' '2.32.3' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL "
+             "'https://mirror.example/simple' EXTRA_INDEX_URL 'https://backup.example/simple'",
+             "SYSTEM INSTALL PYTHON PACKAGE 'requests' '2.32.3' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL "
+             "'https://mirror.example/simple' EXTRA_INDEX_URL 'https://backup.example/simple'"},
+            {"SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'python-slugify==8.0.4' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL "
+             "'https://mirror.example/simple'",
+             "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'python-slugify==8.0.4' INDEX_URL 'https://pypi.org/simple' EXTRA_INDEX_URL "
+             "'https://mirror.example/simple'"},
+            {"SYSTEM UNINSTALL PYTHON PACKAGE 'requests'", "SYSTEM UNINSTALL PYTHON PACKAGE 'requests'"}})));
 /// proton: ends
 
 /// proton: starts. `SYSTEM PAUSE/RESUME/ABORT/RECOVER MATERIALIZED VIEW <db.mv> [PERMANENT]` test cases

--- a/src/Server/RestRouterHandlers/PythonPackageHandler.cpp
+++ b/src/Server/RestRouterHandlers/PythonPackageHandler.cpp
@@ -1,15 +1,23 @@
+#include <Interpreters/executeSelectQuery.h>
 #include <Server/RestRouterHandlers/PythonPackageHandler.h>
 
 #if USE_PYTHON_UDF
 #include <CPython/PythonPackage.h>
-#include <Interpreters/EnsurePython.h>
-#include <Interpreters/executeSelectQuery.h>
-#include <Server/RestRouterHandlers/SchemaValidator.h>
 
 #include <boost/algorithm/string/replace.hpp>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+extern const int BAD_REQUEST_PARAMETER;
+extern const int UNKNOWN_EXCEPTION;
+extern const int BAD_ARGUMENTS;
+extern const int ACCESS_DENIED;
+extern const int RESOURCE_NOT_INITED;
+extern const int TIMEOUT_EXCEEDED;
+}
 
 namespace
 {
@@ -36,32 +44,147 @@ String buildSuccessResponse(const String & message, const String & query_id)
     return resp_str_stream.str();
 }
 
-std::map<String, std::map<String, String>> INSTALL_PYTHON_PACKAGE_SCHEMA
-    = {{"required", {{"name", "string"}}}, {"optional", {{"version", "string"}, {"VERSION", "string"}}}};
-
-std::map<String, std::map<String, String>> UNINSTALL_PYTHON_PACKAGE_SCHEMA = {{"required", {{"name", "string"}}}};
+String escapeSingleQuoted(const String & input)
+{
+    String escaped = input;
+    boost::replace_all(escaped, "'", "''");
+    return escaped;
 }
 
-namespace ErrorCodes
+std::vector<String> parseExtraIndexUrls(const Poco::JSON::Object::Ptr & payload)
 {
-extern const int BAD_REQUEST_PARAMETER;
-extern const int UNKNOWN_EXCEPTION;
-extern const int BAD_ARGUMENTS;
-extern const int ACCESS_DENIED;
-extern const int RESOURCE_NOT_INITED;
-extern const int TIMEOUT_EXCEEDED;
+    std::vector<String> extra_index_urls;
+    if (!payload->has("extra_index_url"))
+        return extra_index_urls;
+
+    const auto value = payload->get("extra_index_url");
+    if (value.isString())
+    {
+        extra_index_urls.push_back(value.toString());
+        return extra_index_urls;
+    }
+
+    if (!value.isArray())
+        throw Exception(ErrorCodes::BAD_REQUEST_PARAMETER, "'extra_index_url' must be a string or array of strings");
+
+    auto array = value.extract<Poco::JSON::Array::Ptr>();
+    for (size_t i = 0; i < array->size(); ++i)
+    {
+        const auto element = array->get(i);
+        if (!element.isString())
+            throw Exception(ErrorCodes::BAD_REQUEST_PARAMETER, "'extra_index_url' array must contain only strings");
+        extra_index_urls.push_back(element.toString());
+    }
+
+    return extra_index_urls;
+}
+
+String buildInstallOptionsClause(const Poco::JSON::Object::Ptr & payload)
+{
+    String options_clause;
+
+    if (payload->has("index_url"))
+    {
+        const auto index_url = payload->get("index_url");
+        if (!index_url.isString())
+            throw Exception(ErrorCodes::BAD_REQUEST_PARAMETER, "'index_url' must be a string");
+        options_clause += fmt::format(" INDEX_URL '{}'", escapeSingleQuoted(index_url.toString()));
+    }
+
+    for (const auto & extra_index_url : parseExtraIndexUrls(payload))
+        options_clause += fmt::format(" EXTRA_INDEX_URL '{}'", escapeSingleQuoted(extra_index_url));
+
+    return options_clause;
+}
 }
 
 bool PythonPackageHandler::validatePost(const Poco::JSON::Object::Ptr & payload, String & error_msg) const
 {
-    if (!validateSchema(INSTALL_PYTHON_PACKAGE_SCHEMA, payload, error_msg))
-        return false;
+    const bool has_name = payload->has("name");
+    const bool has_packages = payload->has("packages");
+    const bool has_requirements = payload->has("requirements");
 
-    String package_name = payload->get("name").toString();
-
-    if (package_name.empty())
+    const size_t mode_count = static_cast<size_t>(has_name) + static_cast<size_t>(has_packages) + static_cast<size_t>(has_requirements);
+    if (mode_count == 0)
     {
-        error_msg = "Package name cannot be empty";
+        error_msg = "One of 'name', 'packages', or 'requirements' is required";
+        return false;
+    }
+    if (mode_count > 1)
+    {
+        error_msg = "Only one of 'name', 'packages', or 'requirements' can be provided";
+        return false;
+    }
+
+    if (has_name)
+    {
+        if (!payload->get("name").isString())
+        {
+            error_msg = "'name' must be a string";
+            return false;
+        }
+        if (payload->get("name").toString().empty())
+        {
+            error_msg = "Package name cannot be empty";
+            return false;
+        }
+    }
+
+    if (has_requirements)
+    {
+        if (!payload->get("requirements").isString())
+        {
+            error_msg = "'requirements' must be a string";
+            return false;
+        }
+        if (payload->get("requirements").toString().empty())
+        {
+            error_msg = "Requirements text cannot be empty";
+            return false;
+        }
+    }
+
+    if (has_packages)
+    {
+        if (!payload->get("packages").isArray())
+        {
+            error_msg = "'packages' must be an array";
+            return false;
+        }
+
+        auto packages = payload->getArray("packages");
+        if (packages->size() == 0)
+        {
+            error_msg = "'packages' cannot be empty";
+            return false;
+        }
+
+        for (size_t i = 0; i < packages->size(); ++i)
+        {
+            if (!packages->isObject(i))
+            {
+                error_msg = "'packages' array must contain objects";
+                return false;
+            }
+
+            auto package_obj = packages->getObject(i);
+            if (!package_obj->has("name") || !package_obj->get("name").isString() || package_obj->get("name").toString().empty())
+            {
+                error_msg = "Each package in 'packages' must have a non-empty string field 'name'";
+                return false;
+            }
+        }
+    }
+
+    if (has_requirements && (payload->has("version") || payload->has("VERSION")))
+    {
+        error_msg = "'version' and 'VERSION' are only valid for single package install";
+        return false;
+    }
+
+    if (has_packages && (payload->has("version") || payload->has("VERSION")))
+    {
+        error_msg = "Top-level 'version' and 'VERSION' are not allowed when 'packages' is provided";
         return false;
     }
 
@@ -116,83 +239,136 @@ std::pair<String, Int32> PythonPackageHandler::executePost(const Poco::JSON::Obj
 {
     try
     {
-        if (!payload->has("name"))
+        const String install_options_clause = buildInstallOptionsClause(payload);
+        std::vector<String> install_queries;
+        std::vector<String> install_targets;
+
+        if (payload->has("requirements"))
         {
-            return {jsonErrorResponse("Missing required field 'name'", ErrorCodes::BAD_REQUEST_PARAMETER), HTTPResponse::HTTP_BAD_REQUEST};
+            String requirements_text = payload->get("requirements").toString();
+            install_queries.push_back(fmt::format(
+                "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS '{}'{}", escapeSingleQuoted(requirements_text), install_options_clause));
+            install_targets.push_back("requirements");
         }
-
-        String package_name = payload->get("name").toString();
-        String package_version;
-
-        if (payload->has("version") && payload->has("VERSION"))
+        else if (payload->has("packages"))
         {
-            const auto lower = payload->get("version").toString();
-            const auto upper = payload->get("VERSION").toString();
-            if (lower != upper)
+            auto packages = payload->getArray("packages");
+            for (size_t i = 0; i < packages->size(); ++i)
             {
-                return {
-                    jsonErrorResponse(
-                        "Conflicting parameters: both 'version' and 'VERSION' are provided with different values",
-                        ErrorCodes::BAD_REQUEST_PARAMETER),
-                    HTTPResponse::HTTP_BAD_REQUEST};
+                auto package_obj = packages->getObject(i);
+                String package_name = package_obj->get("name").toString();
+                String package_version;
+
+                if (package_obj->has("version") && package_obj->has("VERSION"))
+                {
+                    const auto lower = package_obj->get("version").toString();
+                    const auto upper = package_obj->get("VERSION").toString();
+                    if (lower != upper)
+                    {
+                        return {
+                            jsonErrorResponse(
+                                "Conflicting parameters: both 'version' and 'VERSION' are provided with different values in 'packages'",
+                                ErrorCodes::BAD_REQUEST_PARAMETER),
+                            HTTPResponse::HTTP_BAD_REQUEST};
+                    }
+                }
+
+                if (package_obj->has("version"))
+                    package_version = package_obj->get("version").toString();
+                else if (package_obj->has("VERSION"))
+                    package_version = package_obj->get("VERSION").toString();
+
+                if (package_version.empty())
+                {
+                    install_queries.push_back(
+                        fmt::format("SYSTEM INSTALL PYTHON PACKAGE '{}'{}", escapeSingleQuoted(package_name), install_options_clause));
+                    install_targets.push_back(package_name);
+                }
+                else
+                {
+                    install_queries.push_back(fmt::format(
+                        "SYSTEM INSTALL PYTHON PACKAGE '{}' '{}'{}",
+                        escapeSingleQuoted(package_name),
+                        escapeSingleQuoted(package_version),
+                        install_options_clause));
+                    install_targets.push_back(fmt::format("{}@{}", package_name, package_version));
+                }
             }
-        }
-
-        if (payload->has("version"))
-            package_version = payload->get("version").toString();
-        else if (payload->has("VERSION"))
-            package_version = payload->get("VERSION").toString();
-
-        if (package_name.empty())
-            return {jsonErrorResponse("Package name cannot be empty", ErrorCodes::BAD_REQUEST_PARAMETER), HTTPResponse::HTTP_BAD_REQUEST};
-
-        /// Construct the SYSTEM INSTALL PYTHON PACKAGE query
-        String query;
-        if (package_version.empty())
-        {
-            String escaped_package_name = package_name;
-            boost::replace_all(escaped_package_name, "'", "''");
-            query = fmt::format("SYSTEM INSTALL PYTHON PACKAGE '{}'", escaped_package_name);
         }
         else
         {
-            String escaped_package_name = package_name;
-            String escaped_package_version = package_version;
-            boost::replace_all(escaped_package_name, "'", "''");
-            boost::replace_all(escaped_package_version, "'", "''");
-            query = fmt::format("SYSTEM INSTALL PYTHON PACKAGE '{}' '{}'", escaped_package_name, escaped_package_version);
+            String package_name = payload->get("name").toString();
+            String package_version;
+
+            if (payload->has("version") && payload->has("VERSION"))
+            {
+                const auto lower = payload->get("version").toString();
+                const auto upper = payload->get("VERSION").toString();
+                if (lower != upper)
+                {
+                    return {
+                        jsonErrorResponse(
+                            "Conflicting parameters: both 'version' and 'VERSION' are provided with different values",
+                            ErrorCodes::BAD_REQUEST_PARAMETER),
+                        HTTPResponse::HTTP_BAD_REQUEST};
+                }
+            }
+
+            if (payload->has("version"))
+                package_version = payload->get("version").toString();
+            else if (payload->has("VERSION"))
+                package_version = payload->get("VERSION").toString();
+
+            if (package_version.empty())
+            {
+                install_queries.push_back(
+                    fmt::format("SYSTEM INSTALL PYTHON PACKAGE '{}'{}", escapeSingleQuoted(package_name), install_options_clause));
+                install_targets.push_back(package_name);
+            }
+            else
+            {
+                install_queries.push_back(fmt::format(
+                    "SYSTEM INSTALL PYTHON PACKAGE '{}' '{}'{}",
+                    escapeSingleQuoted(package_name),
+                    escapeSingleQuoted(package_version),
+                    install_options_clause));
+                install_targets.push_back(fmt::format("{}@{}", package_name, package_version));
+            }
         }
 
-        LOG_DEBUG(log, "Executing Python package install query: {}", query);
-
-        try
+        for (const auto & query : install_queries)
         {
+            LOG_DEBUG(log, "Executing Python package install query: {}", query);
             executeNonInsertQuery(query, query_context, /*callback=*/{}, /*internal=*/true);
         }
-        catch (const Exception & e)
-        {
-            Int32 http_status;
-            auto error_code = e.code();
 
-            if (error_code == ErrorCodes::BAD_ARGUMENTS)
-                http_status = HTTPResponse::HTTP_BAD_REQUEST;
-            else if (error_code == ErrorCodes::ACCESS_DENIED)
-                http_status = HTTPResponse::HTTP_FORBIDDEN;
-            else if (error_code == ErrorCodes::RESOURCE_NOT_INITED)
-                http_status = HTTPResponse::HTTP_SERVICE_UNAVAILABLE;
-            else if (error_code == ErrorCodes::TIMEOUT_EXCEEDED)
-                http_status = HTTPResponse::HTTP_REQUEST_TIMEOUT;
-            else
-                http_status = HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
-
-            return {jsonErrorResponse(fmt::format("Failed to install Python package: {}", e.message()), e.code()), http_status};
-        }
-
-        String message = fmt::format("Successfully installed Python package '{}'", package_name);
-        if (!package_version.empty())
-            message += fmt::format(" version '{}'", package_version);
+        String message;
+        if (payload->has("requirements"))
+            message = "Successfully installed Python requirements";
+        else if (install_targets.size() == 1)
+            message = fmt::format("Successfully installed Python package '{}'", install_targets.front());
+        else
+            message = fmt::format("Successfully installed {} Python packages", install_targets.size());
 
         return {buildSuccessResponse(message, query_context->getCurrentQueryId()), HTTPResponse::HTTP_OK};
+    }
+    catch (const Exception & e)
+    {
+        Int32 http_status;
+        auto error_code = e.code();
+
+        if (error_code == ErrorCodes::BAD_ARGUMENTS || error_code == ErrorCodes::BAD_REQUEST_PARAMETER)
+            http_status = HTTPResponse::HTTP_BAD_REQUEST;
+        else if (error_code == ErrorCodes::ACCESS_DENIED)
+            http_status = HTTPResponse::HTTP_FORBIDDEN;
+        else if (error_code == ErrorCodes::RESOURCE_NOT_INITED)
+            http_status = HTTPResponse::HTTP_SERVICE_UNAVAILABLE;
+        else if (error_code == ErrorCodes::TIMEOUT_EXCEEDED)
+            http_status = HTTPResponse::HTTP_REQUEST_TIMEOUT;
+        else
+            http_status = HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+
+        return {jsonErrorResponse(fmt::format("Failed to install Python package: {}", e.message()), e.code()), http_status};
     }
     catch (const std::exception & e)
     {
@@ -210,13 +386,11 @@ std::pair<String, Int32> PythonPackageHandler::executeDelete(const Poco::JSON::O
 {
     try
     {
-        /// Get package name from path parameter (not JSON payload)
         String package_name = getPathParameter("name", "");
 
         if (package_name.empty())
             return {jsonErrorResponse("Missing package name in path", ErrorCodes::BAD_REQUEST_PARAMETER), HTTPResponse::HTTP_BAD_REQUEST};
 
-        /// Construct the SYSTEM UNINSTALL PYTHON PACKAGE query
         String escaped_package_name = package_name;
         boost::replace_all(escaped_package_name, "'", "''");
         String query = fmt::format("SYSTEM UNINSTALL PYTHON PACKAGE '{}'", escaped_package_name);

--- a/src/Server/RestRouterHandlers/RestRouterFactory.h
+++ b/src/Server/RestRouterHandlers/RestRouterFactory.h
@@ -283,7 +283,7 @@ public:
 
 #if USE_PYTHON_UDF
             factory.registerRouterHandler(
-                fmt::format("/{}/v1/python_packages(/?(\\?[\\w\\-=&#]+){{0,1}}$|/(?P<name>[%\\w]+))", prefix),
+                fmt::format("/{}/v1/python_packages(/?(\\?[\\w\\-=&#]+){{0,1}}$|/(?P<name>[%\\w.\\-]+))", prefix),
                 "GET/POST/DELETE",
                 [](ContextMutablePtr query_context) { /// STYLE_CHECK_ALLOW_BRACE_SAME_LINE_LAMBDA
                     return std::make_shared<DB::PythonPackageHandler>(query_context);

--- a/tests/cluster/smoke/0042_python_package_management/01_python_package_restapi.yaml
+++ b/tests/cluster/smoke/0042_python_package_management/01_python_package_restapi.yaml
@@ -3,6 +3,7 @@ tags:
 
 cluster:
   - p1k1
+  - p3k1
 
 description: |
   Test for Python libraries operation with restapi:
@@ -21,7 +22,7 @@ steps:
     node: [p2]
     <<end>>
     shell: |
-      curl -X POST http://localhost:8123/proton/v1/python_packages -H "Content-Type: text/plain; charset=utf-8" -d '{"name": "arrow"}' 2>/dev/null
+      curl -X POST http://localhost:8123/timeplusd/v1/python_packages -H "Content-Type: text/plain; charset=utf-8" -d '{"name": "arrow"}' 2>/dev/null
 
   - type: command
     name: python-pkg-01-install-specified
@@ -31,7 +32,7 @@ steps:
     node: [p2]
     <<end>>
     shell: |
-      curl -X POST http://localhost:8123/proton/v1/python_packages \
+      curl -X POST http://localhost:8123/timeplusd/v1/python_packages \
         -H "Content-Type: text/plain; charset=utf-8" \
         -H "x-timeplus-user: proton" \
         -H "x-timeplus-key: proton@t+" \
@@ -44,7 +45,7 @@ steps:
     name: python-pkg-01-get-arrow
     node: [p1]
     shell: |
-      curl -X GET http://localhost:8123/proton/v1/python_packages  2>/dev/null | jq -c '.data[] | select(.name == "arrow") | length > 0'
+      curl -X GET http://localhost:8123/timeplusd/v1/python_packages  2>/dev/null | jq -c '.data[] | select(.name == "arrow") | length > 0'
 
   - type: command
     name: python-pkg-01-get-pandas
@@ -53,7 +54,7 @@ steps:
       i=0
       resp=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "pandas") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -n "$out" ]; then
           printf '%s\n' "$out"
@@ -72,6 +73,43 @@ steps:
     target_name: python-pkg-01-get-pandas
     expected_result: ['{"name":"pandas","version":"==2.3.2"}']
 
+  - type: command
+    name: python-pkg-01-install-requirements
+    <<if eq .nodes "1">>
+    node: [p1]
+    <<else>>
+    node: [p2]
+    <<end>>
+    shell: |
+      curl -X POST http://localhost:8123/timeplusd/v1/python_packages \
+        -H "Content-Type: text/plain; charset=utf-8" \
+        -d '{"requirements": "python-slugify==8.0.4", "index_url": "https://pypi.org/simple"}' 2>/dev/null
+
+  - type: wait
+    time: 5
+
+  - type: command
+    name: python-pkg-01-get-requirements-package
+    node: [p1]
+    shell: |
+      i=0
+      resp=""
+      while [ "$i" -lt 60 ]; do
+        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages 2>/dev/null)"
+        out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "python-slugify") | {name: .name, version: .version}' 2>/dev/null)"
+        if [ -n "$out" ]; then
+          printf '%s\n' "$out"
+          exit 0
+        fi
+        i=$((i+1))
+        sleep 2
+      done
+      printf '%s\n' "$resp" | jq -c '.' 2>/dev/null || printf '%s\n' "$resp"
+
+  - type: check
+    target_name: python-pkg-01-get-requirements-package
+    expected_result: ['{"name":"python-slugify","version":"==8.0.4"}']
+
   - type: wait
     time: 1
 
@@ -82,7 +120,7 @@ steps:
     node: [p3]
     <<end>>
     shell: |
-      curl -X DELETE http://localhost:8123/proton/v1/python_packages/arrow 2>/dev/null
+      curl -X DELETE http://localhost:8123/timeplusd/v1/python_packages/arrow 2>/dev/null
 
   - type: wait
     time: 1
@@ -94,9 +132,21 @@ steps:
     node: [p3]
     <<end>>
     shell: |
-      curl -X DELETE http://localhost:8123/proton/v1/python_packages/pandas \
+      curl -X DELETE http://localhost:8123/timeplusd/v1/python_packages/pandas \
         -H "x-timeplus-user: proton" \
         -H "x-timeplus-key: proton@t+" 2>/dev/null
+
+  - type: wait
+    time: 5
+
+  - type: command
+    <<if eq .nodes "1">>
+    node: [p1]
+    <<else>>
+    node: [p3]
+    <<end>>
+    shell: |
+      curl -X DELETE http://localhost:8123/timeplusd/v1/python_packages/python-slugify 2>/dev/null
 
   - type: wait
     time: 5
@@ -108,7 +158,7 @@ steps:
       i=0
       last=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "arrow") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -z "$out" ]; then
           exit 0
@@ -126,7 +176,7 @@ steps:
       i=0
       last=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "pandas") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -z "$out" ]; then
           exit 0
@@ -143,4 +193,26 @@ steps:
 
   - type: check
     target_name: python-pkg-01-uninstall-pandas
+    expected_result: ['']
+
+  - type: command
+    name: python-pkg-01-uninstall-requirements-package
+    node: [p1]
+    shell: |
+      i=0
+      last=""
+      while [ "$i" -lt 60 ]; do
+        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages 2>/dev/null)"
+        out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "python-slugify") | {name: .name, version: .version}' 2>/dev/null)"
+        if [ -z "$out" ]; then
+          exit 0
+        fi
+        last="$out"
+        i=$((i+1))
+        sleep 2
+      done
+      printf '%s\n' "$last"
+
+  - type: check
+    target_name: python-pkg-01-uninstall-requirements-package
     expected_result: ['']

--- a/tests/cluster/smoke/0042_python_package_management/01_python_package_restapi.yaml
+++ b/tests/cluster/smoke/0042_python_package_management/01_python_package_restapi.yaml
@@ -3,7 +3,6 @@ tags:
 
 cluster:
   - p1k1
-  - p3k1
 
 description: |
   Test for Python libraries operation with restapi:
@@ -16,23 +15,15 @@ description: |
 steps:
   - type: command
     name: python-pkg-01-install
-    <<if eq .nodes "1">>
     node: [p1]
-    <<else>>
-    node: [p2]
-    <<end>>
     shell: |
-      curl -X POST http://localhost:8123/timeplusd/v1/python_packages -H "Content-Type: text/plain; charset=utf-8" -d '{"name": "arrow"}' 2>/dev/null
+      curl -X POST http://localhost:8123/proton/v1/python_packages -H "Content-Type: text/plain; charset=utf-8" -d '{"name": "arrow"}' 2>/dev/null
 
   - type: command
     name: python-pkg-01-install-specified
-    <<if eq .nodes "1">>
     node: [p1]
-    <<else>>
-    node: [p2]
-    <<end>>
     shell: |
-      curl -X POST http://localhost:8123/timeplusd/v1/python_packages \
+      curl -X POST http://localhost:8123/proton/v1/python_packages \
         -H "Content-Type: text/plain; charset=utf-8" \
         -H "x-timeplus-user: proton" \
         -H "x-timeplus-key: proton@t+" \
@@ -45,7 +36,7 @@ steps:
     name: python-pkg-01-get-arrow
     node: [p1]
     shell: |
-      curl -X GET http://localhost:8123/timeplusd/v1/python_packages  2>/dev/null | jq -c '.data[] | select(.name == "arrow") | length > 0'
+      curl -X GET http://localhost:8123/proton/v1/python_packages  2>/dev/null | jq -c '.data[] | select(.name == "arrow") | length > 0'
 
   - type: command
     name: python-pkg-01-get-pandas
@@ -54,7 +45,7 @@ steps:
       i=0
       resp=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "pandas") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -n "$out" ]; then
           printf '%s\n' "$out"
@@ -75,13 +66,9 @@ steps:
 
   - type: command
     name: python-pkg-01-install-requirements
-    <<if eq .nodes "1">>
     node: [p1]
-    <<else>>
-    node: [p2]
-    <<end>>
     shell: |
-      curl -X POST http://localhost:8123/timeplusd/v1/python_packages \
+      curl -X POST http://localhost:8123/proton/v1/python_packages \
         -H "Content-Type: text/plain; charset=utf-8" \
         -d '{"requirements": "python-slugify==8.0.4", "index_url": "https://pypi.org/simple"}' 2>/dev/null
 
@@ -95,7 +82,7 @@ steps:
       i=0
       resp=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "python-slugify") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -n "$out" ]; then
           printf '%s\n' "$out"
@@ -114,25 +101,19 @@ steps:
     time: 1
 
   - type: command
-    <<if eq .nodes "1">>
+    name: python-pkg-01-delete-arrow
     node: [p1]
-    <<else>>
-    node: [p3]
-    <<end>>
     shell: |
-      curl -X DELETE http://localhost:8123/timeplusd/v1/python_packages/arrow 2>/dev/null
+      curl -X DELETE http://localhost:8123/proton/v1/python_packages/arrow 2>/dev/null
 
   - type: wait
     time: 1
 
   - type: command
-    <<if eq .nodes "1">>
+    name: python-pkg-01-delete-pandas
     node: [p1]
-    <<else>>
-    node: [p3]
-    <<end>>
     shell: |
-      curl -X DELETE http://localhost:8123/timeplusd/v1/python_packages/pandas \
+      curl -X DELETE http://localhost:8123/proton/v1/python_packages/pandas \
         -H "x-timeplus-user: proton" \
         -H "x-timeplus-key: proton@t+" 2>/dev/null
 
@@ -140,13 +121,10 @@ steps:
     time: 5
 
   - type: command
-    <<if eq .nodes "1">>
+    name: python-pkg-01-delete-requirements-package
     node: [p1]
-    <<else>>
-    node: [p3]
-    <<end>>
     shell: |
-      curl -X DELETE http://localhost:8123/timeplusd/v1/python_packages/python-slugify 2>/dev/null
+      curl -X DELETE http://localhost:8123/proton/v1/python_packages/python-slugify 2>/dev/null
 
   - type: wait
     time: 5
@@ -158,7 +136,7 @@ steps:
       i=0
       last=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "arrow") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -z "$out" ]; then
           exit 0
@@ -176,7 +154,7 @@ steps:
       i=0
       last=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages -H 'x-timeplus-user: proton' -H 'x-timeplus-key: proton@t+' 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "pandas") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -z "$out" ]; then
           exit 0
@@ -202,7 +180,7 @@ steps:
       i=0
       last=""
       while [ "$i" -lt 60 ]; do
-        resp="$(curl -X GET http://localhost:8123/timeplusd/v1/python_packages 2>/dev/null)"
+        resp="$(curl -X GET http://localhost:8123/proton/v1/python_packages 2>/dev/null)"
         out="$(printf '%s' "$resp" | jq -c '.data[]? | select(.name == "python-slugify") | {name: .name, version: .version}' 2>/dev/null)"
         if [ -z "$out" ]; then
           exit 0

--- a/tests/queries_ported/0_stateless/99124_python_package_requirements_syntax.reference
+++ b/tests/queries_ported/0_stateless/99124_python_package_requirements_syntax.reference
@@ -1,0 +1,4 @@
+OK index_url_validation
+OK extra_index_url_validation
+OK requirements_text_validation
+OK requirements_plus_version_rejected

--- a/tests/queries_ported/0_stateless/99124_python_package_requirements_syntax.sh
+++ b/tests/queries_ported/0_stateless/99124_python_package_requirements_syntax.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -euo pipefail
+
+tmp_dir="$CURDIR"/../../../tmp
+mkdir -p "$tmp_dir"
+tmp_err="$tmp_dir"/99124_python_package_requirements_syntax.err
+trap 'rm -f "$tmp_err"' EXIT
+
+expect_fail_contains() {
+    local query="$1"
+    local expected_substring="$2"
+    local ok_label="$3"
+
+    if $CLICKHOUSE_CLIENT -q "$query" > /dev/null 2>"$tmp_err"; then
+        echo "Unexpected success: $ok_label"
+        exit 1
+    fi
+
+    if ! grep -qF "$expected_substring" "$tmp_err"; then
+        echo "Missing expected error substring for: $ok_label"
+        cat "$tmp_err"
+        exit 1
+    fi
+
+    echo "$ok_label"
+}
+
+expect_fail_contains \
+    "SYSTEM INSTALL PYTHON PACKAGE 'requests' INDEX_URL 'not-a-url'" \
+    "Invalid --index-url value" \
+    "OK index_url_validation"
+
+expect_fail_contains \
+    "SYSTEM INSTALL PYTHON PACKAGE 'requests' EXTRA_INDEX_URL 'not-a-url'" \
+    "Invalid --extra-index-url value" \
+    "OK extra_index_url_validation"
+
+expect_fail_contains \
+    "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS '-r nested.txt'" \
+    "Requirements line '-r nested.txt' is not supported" \
+    "OK requirements_text_validation"
+
+expect_fail_contains \
+    "SYSTEM INSTALL PYTHON PACKAGE REQUIREMENTS 'requests==2.32.3' '2.0.0'" \
+    "Syntax error" \
+    "OK requirements_plus_version_rejected"


### PR DESCRIPTION
## Summary
- accept PEP 508 extras in `SYSTEM INSTALL PYTHON PACKAGE`, e.g. `confluent-kafka[protobuf, avro]`
- normalize the package lookup name for `pip show` and uninstall so extras-bearing specs do not break package management
- refresh Python import state after install by re-processing site directories and invalidating import caches
- extend `__path__` only for legacy namespace packages declared via `pkg_resources.declare_namespace()` so packages like `google.protobuf` become visible after install without broadening ordinary package semantics
- warn when installing `confluent-kafka` because the wheel bundles its own `librdkafka`, which can conflict with Proton's in-process `librdkafka`; the warning points users to `confluent-kafka==2.1.1` as a known-good version and suggests checking `confluent_kafka.libversion()` at runtime
- add focused unit coverage for extras parsing, lookup-name behavior, `.pth` processing, and namespace package refresh behavior