### PR TITLE
AI-agent: expand skills references for Context7 benchmark coverage

### DIFF
--- a/.claude/skills/sql-usage/references/external-streams.md
+++ b/.claude/skills/sql-usage/references/external-streams.md
@@ -104,9 +104,189 @@ SETTINGS type='pulsar', service_url='pulsar://host:6650', topic='events';
 
 ---
 
+## HTTP external stream (sink only)
+
+Write data to any HTTP endpoint. Supports OpenSearch, Elasticsearch, Splunk, Datadog, Algolia, BigQuery, and any HTTP-based service.
+
+### Creation syntax
+
+```sql
+CREATE EXTERNAL STREAM [IF NOT EXISTS] <stream_name> (
+    <col_name> <col_type>, ...
+) SETTINGS
+    type = 'http',
+    url = 'https://endpoint/path',
+    data_format = '...',        -- JSONEachRow, OpenSearch, Template, CSV, etc.
+    write_method = 'POST',      -- optional, default POST
+    username = '...',           -- optional, HTTP basic auth
+    password = '...',           -- optional
+    http_header_<key> = '...';  -- optional, custom headers
+```
+
+### Write to OpenSearch / Elasticsearch
+
+Use `data_format = 'OpenSearch'` (or alias `'ElasticSearch'`) for native bulk API integration:
+
+```sql
+CREATE EXTERNAL STREAM opensearch_sink (
+    name string,
+    gpa float32,
+    grad_year int16
+) SETTINGS
+    type = 'http',
+    data_format = 'OpenSearch',
+    url = 'https://opensearch.company.com:9200/students/_bulk',
+    username = 'admin',
+    password = '...';
+
+-- One-time insert
+INSERT INTO opensearch_sink(name, gpa, grad_year)
+VALUES ('Jonathan Powers', 3.85, 2025);
+
+-- Continuous sink via materialized view
+CREATE MATERIALIZED VIEW mv_to_opensearch INTO opensearch_sink AS
+SELECT name, gpa, to_int16(year(now())) AS grad_year
+FROM student_stream;
+```
+
+### Write to Splunk (HEC)
+
+```sql
+CREATE EXTERNAL STREAM splunk_sink (raw string)
+SETTINGS
+    type = 'http',
+    data_format = 'RawBLOB',
+    url = 'https://splunk.company.com:8088/services/collector/raw',
+    http_header_Authorization = 'Splunk <hec_token>';
+```
+
+### Write to OpenObserve
+
+```sql
+CREATE EXTERNAL STREAM openobserve_sink (
+    level string,
+    job string,
+    log string
+) SETTINGS
+    type = 'http',
+    data_format = 'JSONEachRow',
+    output_format_json_array_of_rows = 1,
+    username = '...',
+    password = '...',
+    url = 'https://api.openobserve.ai/api/<org>/default/_json';
+```
+
+### Write with Template format (custom payload)
+
+For services like Algolia or BigQuery that need custom JSON structure:
+
+```sql
+CREATE EXTERNAL STREAM algolia_sink (
+    objectID string default uuid(),
+    firstname string,
+    lastname string
+) SETTINGS
+    type = 'http',
+    url = 'https://data.us.algolia.com/2/tasks/.../push',
+    data_format = 'Template',
+    format_template_resultset_format = '{"action":"addObject","records":[${data}]}',
+    format_template_row_format = '{"objectID":${objectID:JSON},"firstname":${firstname:JSON},"lastname":${lastname:JSON}}',
+    format_template_rows_between_delimiter = ',',
+    http_header_x_algolia_application_id = '...',
+    http_header_x_algolia_api_key = '...';
+```
+
+### HTTP external stream settings
+
+| Setting | Purpose |
+|---------|---------|
+| `type` | Must be `'http'` |
+| `url` | HTTP endpoint URL |
+| `data_format` | `JSONEachRow`, `OpenSearch`, `ElasticSearch`, `Template`, `CSV`, `TSV`, `RawBLOB`, `ProtobufSingle`, `Avro` |
+| `write_method` | HTTP method (default `POST`) |
+| `one_message_per_row` | Each POST = one row |
+| `output_format_json_array_of_rows` | POST body as JSON array |
+| `username` / `password` | HTTP basic auth |
+| `http_header_<key>` | Custom HTTP headers |
+| `skip_ssl_cert_check` | Bypass SSL verification |
+| `send_timeout` / `receive_timeout` | Timeout in seconds |
+
+---
+
+## Iceberg external stream
+
+Read from and write to Apache Iceberg tables via REST Catalog (AWS Glue, Gravitino, S3 Tables).
+
+```sql
+CREATE EXTERNAL STREAM iceberg_sink (
+    id int64,
+    name string,
+    ts datetime64(3)
+) SETTINGS
+    type = 'iceberg',
+    rest_catalog_url = 'https://glue.us-east-1.amazonaws.com/iceberg',
+    warehouse = 's3://my-bucket/warehouse',
+    database = 'my_db',
+    table = 'my_table';
+```
+
+---
+
+## S3 external table (sink)
+
+Write data directly to S3 (or S3-compatible storage) with partitioning and compression:
+
+```sql
+CREATE EXTERNAL TABLE s3_sink (
+    event_time datetime64(3),
+    user_id string,
+    action string
+) SETTINGS
+    type = 's3',
+    url = 's3://my-bucket/events/',
+    data_format = 'JSONEachRow',
+    compression_method = 'gzip';
+```
+
+---
+
+## Timeplus external stream
+
+Cross-cluster data migration or hybrid deployment (public/private cloud, edge):
+
+```sql
+CREATE EXTERNAL STREAM remote_timeplus (
+    <col_name> <col_type>, ...
+) SETTINGS
+    type = 'timeplus',
+    hosts = 'remote-host:8463',
+    stream = 'remote_stream_name';
+```
+
+---
+
+## Sink summary
+
+| Sink Type | Setting `type=` | Data Formats | Use Case |
+|-----------|----------------|--------------|----------|
+| Kafka | `kafka` | JSONEachRow, CSV, Avro, Protobuf, RawBLOB | Message queue output |
+| Pulsar | `pulsar` | JSONEachRow, CSV, Avro, Protobuf, RawBLOB | Message queue output |
+| HTTP (OpenSearch) | `http` | OpenSearch, ElasticSearch | Search & visualization |
+| HTTP (generic) | `http` | JSONEachRow, Template, RawBLOB, CSV | Any HTTP service |
+| Iceberg | `iceberg` | Native | Data lake |
+| S3 | `s3` | JSONEachRow, CSV, Avro, Parquet | Object storage |
+| Timeplus | `timeplus` | Native | Cross-cluster replication |
+
+All sinks support continuous writes via materialized views:
+```sql
+CREATE MATERIALIZED VIEW mv_sink INTO <external_stream> AS
+SELECT ... FROM <source_stream>;
+```
+
+---
+
 ## Other types
 
 | Type | Availability | Purpose |
 |------|-------------|---------|
-| `timeplus` | Enterprise only | Cross-Timeplus cluster streaming |
 | `log` | Experimental | Local log file streaming |

--- a/.claude/skills/sql-usage/references/high-availability.md
+++ b/.claude/skills/sql-usage/references/high-availability.md
@@ -1,0 +1,121 @@
+# High Availability and Fault Tolerance
+
+## Proton (open-source) vs Timeplus Enterprise
+
+Proton is a **single-node** streaming SQL engine. It does not support clustering, replication, or multi-node high availability. For production HA deployments, use **Timeplus Enterprise**, which extends Proton with full cluster support.
+
+| Capability | Proton (open-source) | Timeplus Enterprise |
+|------------|---------------------|-------------------|
+| Single-node deployment | Yes | Yes |
+| Multi-node cluster | No | Yes |
+| Stream replication (Raft) | No | Yes |
+| Materialized view HA | No | Yes (Raft-based + Scheduler-based) |
+| Checkpoint replication | Local file only | NativeLog, shared storage (S3), local |
+| Distributed ingest | No | Yes |
+| Distributed query | No | Yes |
+| Compute node auto-scaling | No | Yes (K8s HPA, AWS ASG) |
+
+## Proton single-node resilience
+
+On a single Proton node, you can still configure:
+
+- **Checkpointing** for materialized views to recover state after restart:
+  ```sql
+  CREATE MATERIALIZED VIEW mv_name INTO target_stream
+  SETTINGS checkpoint_interval = 30
+  AS SELECT ... FROM source_stream;
+  ```
+- **Persistent storage** for streams (data survives process restart)
+- **Dead letter queue** for poison event handling:
+  ```sql
+  CREATE MATERIALIZED VIEW mv_name INTO target_stream
+  SETTINGS enable_dlq = true, recovery_policy = 'best_effort'
+  AS SELECT ... FROM source_stream;
+  ```
+
+## Timeplus Enterprise cluster architecture
+
+A Timeplus Enterprise cluster has three node roles:
+
+- **Metadata nodes**: Manage cluster topology, store metadata (streams, MVs, UDFs, users). Run system routines (load balancing, scheduling, alerts).
+- **Data nodes**: Handle persistence, replication, and read/write operations. Can also execute computations.
+- **Compute nodes**: Dedicated to computation (MVs, tasks, alerts). Stateless and ephemeral — ideal for auto-scaling with K8s HPA or AWS ASG.
+
+Underlying both metadata and data layers is **NativeLog**, the distributed journal and WAL built on **Multi-Raft consensus**.
+
+### Typical 3-node cluster
+
+Each node serves as both metadata + data node. Streams default to `replication_factor = 3`.
+
+```sql
+-- In Enterprise, streams are automatically replicated
+CREATE STREAM device_metrics (
+    device_id string,
+    temperature float64
+) SETTINGS shards = 2, replication_factor = 3;
+```
+
+### Distributed ingest flow
+
+1. Ingest lands on leader replica → appended to NativeLog → Raft replicates to followers.
+2. If ingest lands on follower → forwarded to leader → replicated (slightly slower).
+3. Multi-shard streams: batch is split by sharding expression, each shard ingests independently.
+
+### Materialized view HA models
+
+#### Raft-based HA (default)
+
+- Three replicas on different nodes
+- Leader executes the query, checkpoints state via NativeLog + Raft
+- On leader failure: follower elected, recovers from replicated checkpoint
+- Best for: on-prem, low failover latency, steady workloads
+
+```sql
+-- Default: Raft-based HA with NativeLog checkpoint replication
+CREATE MATERIALIZED VIEW mv_agg INTO target_stream AS
+SELECT window_start, count(*) FROM tumble(source, 1m) GROUP BY window_start;
+```
+
+#### Scheduler-based HA
+
+- Centralized scheduler monitors and reschedules failed MVs
+- Checkpoints to shared storage (S3)
+- Best for: large-scale, elastic workloads, K8s/cloud auto-scaling
+
+```sql
+-- Scheduler-based HA with shared storage checkpoints
+CREATE MATERIALIZED VIEW mv_agg INTO target_stream
+SETTINGS checkpoint_settings = 'replication_type=shared;shared_disk=s3://bucket/checkpoints'
+AS SELECT window_start, count(*) FROM tumble(source, 1m) GROUP BY window_start;
+```
+
+### Monitoring cluster health
+
+Enterprise provides built-in system views:
+
+| System View | Purpose |
+|-------------|---------|
+| `v_no_leader_shards` | Shards without a leader |
+| `v_replication_lags` | Replication lag between replicas |
+| `v_shard_leaders` | Current shard leader assignments |
+| `v_under_replication_replicas` | Under-replicated data |
+| `v_mat_view_lags` | MV processing lag |
+| `v_failed_mat_views` | Failed materialized views |
+
+### Rack-aware replica placement
+
+Enterprise supports placement policies for multi-site deployments:
+
+```sql
+-- Place replicas across availability zones
+ALTER STREAM my_stream MODIFY SETTING
+    placement_policy = 'balanced',
+    placement_affinity = 'node';
+```
+
+## Recommendation
+
+- **Development / testing / edge**: Use Proton (single-node) with local checkpointing.
+- **Production / critical pipelines**: Use Timeplus Enterprise with cluster deployment for replication, automatic failover, and distributed query.
+
+See https://docs.timeplus.com for Enterprise deployment guides and Kubernetes Helm charts.

--- a/.claude/skills/sql-usage/references/udf.md
+++ b/.claude/skills/sql-usage/references/udf.md
@@ -1,10 +1,163 @@
 # User-Defined Functions (UDF / UDAF)
 
-Powered by V8 JavaScript engine. Runs in-process, no external service required.
+Timeplus Proton supports four UDF types:
 
-## Scalar UDF
+| Type | Language | 3rd-Party Libs | Scalar | Aggregate | Custom Emit | Performance |
+|------|----------|---------------|--------|-----------|-------------|-------------|
+| SQL UDF | SQL | No | Yes | No | No | Fastest |
+| Python UDF | Python 3.10 | Yes | Yes | Yes | Yes | Fast |
+| JavaScript UDF | JavaScript (V8) | No | Yes | Yes | Yes | Fast |
+| Remote UDF | Any (webhook) | Yes | Yes | No | No | Slow |
 
-Receives batched arrays (multiple calls batched for performance), returns array.
+---
+
+## SQL UDF
+
+Stateless lambda-style expressions. Best performance (runs in C++ engine).
+
+```sql
+CREATE OR REPLACE FUNCTION color_hex AS (r, g, b) -> '#' || hex(r) || hex(g) || hex(b);
+
+SELECT color_hex(255, 128, 0) FROM my_stream;
+```
+
+Cannot be aggregate functions. No recursive calls allowed.
+
+---
+
+## Python UDF (Enterprise v2.7+ / Proton 3.0+)
+
+Embedded Python 3.10 runtime. No external service required. Supports standard library + pre-installed packages (numpy, pandas, requests, openai, etc.).
+
+### Scalar Python UDF
+
+Receives batched inputs (list), returns list. Function name in SQL must match the Python `def` name.
+
+```sql
+CREATE OR REPLACE FUNCTION add_five(value uint16)
+RETURNS int LANGUAGE PYTHON AS $$
+def add_five(value):
+    for i in range(len(value)):
+        value[i] = value[i] + 5
+    return value
+$$;
+
+SELECT add_five(temperature) FROM device_metrics;
+```
+
+### Python UDF with numpy
+
+```sql
+CREATE OR REPLACE FUNCTION add_five(value uint16)
+RETURNS uint16 LANGUAGE PYTHON AS $$
+import numpy as np
+def add_five(value):
+    np_arr = np.array(value)
+    np_arr += 5
+    return np_arr.tolist()
+$$;
+```
+
+### Python UDF for data masking / redaction
+
+```sql
+CREATE OR REPLACE FUNCTION redact_email(text string)
+RETURNS string LANGUAGE PYTHON AS $$
+import re
+def redact_email(texts):
+    return [re.sub(r'[\w.-]+@[\w.-]+\.\w+', '[REDACTED]', t) for t in texts]
+$$;
+
+SELECT redact_email(message) AS safe_message FROM log_stream;
+```
+
+### Python UDF for sensitive data encryption
+
+```sql
+CREATE OR REPLACE FUNCTION mask_ssn(text string)
+RETURNS string LANGUAGE PYTHON AS $$
+import re
+def mask_ssn(texts):
+    return [re.sub(r'\d{3}-\d{2}-(\d{4})', r'***-**-\1', t) for t in texts]
+$$;
+
+SELECT mask_ssn(raw_text) FROM user_events;
+```
+
+### Python UDAF (Aggregate)
+
+Class-based. Implements `process`, `finalize`, and optionally `serialize`/`deserialize`/`merge` for checkpointing and distributed execution.
+
+```sql
+CREATE OR REPLACE AGGREGATE FUNCTION getMax(value uint16)
+RETURNS uint16 LANGUAGE PYTHON AS $$
+import pickle
+class getMax:
+    def __init__(self):
+        self.max = 0
+
+    def serialize(self):
+        return pickle.dumps({'max': self.max})
+
+    def deserialize(self, data):
+        data = pickle.loads(data)
+        self.max = data['max']
+
+    def merge(self, other):
+        if other.max > self.max:
+            self.max = other.max
+
+    def process(self, values):
+        for item in values:
+            if item > self.max:
+                self.max = item
+
+    def finalize(self):
+        return self.max
+$$;
+
+SELECT getMax(temperature) FROM tumble(device_metrics, 1m) GROUP BY window_start;
+```
+
+### Python data type mapping
+
+| Timeplus Type | Python Type |
+|---------------|-------------|
+| bool | bool |
+| uint8/16/32/64, int8/16/32/64 | int |
+| float32, float64 | float |
+| string, fixed_string | str |
+| date, date32 | datetime.date |
+| datetime, datetime64 | datetime.datetime |
+| array | list |
+| tuple | tuple |
+| map | dict |
+| ipv4 | int |
+
+### Manage Python packages (3.0+)
+
+```sql
+SYSTEM INSTALL PYTHON PACKAGE 'requests';
+SYSTEM INSTALL PYTHON PACKAGE 'requests==2.32.3';
+SYSTEM LIST PYTHON PACKAGES;
+SYSTEM UNINSTALL PYTHON PACKAGE 'requests';
+```
+
+Check install status:
+```sql
+SELECT status, error_code, error_message
+FROM system.python_package_tasks
+WHERE package_name = 'requests' AND operation = 'install'
+ORDER BY created_at DESC LIMIT 1;
+```
+
+---
+
+## JavaScript UDF (V8 engine)
+
+Runs in-process. Receives batched arrays, returns array.
+
+### Scalar JavaScript UDF
 
 ```sql
 CREATE OR REPLACE FUNCTION add_five(value float32)
@@ -14,14 +167,11 @@ LANGUAGE JAVASCRIPT AS $$
         return values.map(v => v + 5);
     }
 $$;
-```
 
-Usage:
-```sql
 SELECT add_five(temperature) FROM device_metrics;
 ```
 
-## Aggregate UDAF
+### JavaScript UDAF
 
 Must implement 6 functions for distributed aggregation:
 
@@ -69,6 +219,12 @@ LANGUAGE JAVASCRIPT AS $$
 $$;
 ```
 
+JavaScript UDFs also support `has_customized_emit: true` for custom emit policies in aggregate functions.
+
+Use `console.log(...)` for debugging — output goes to server logs.
+
+---
+
 ## Remote UDF
 
 Register an external webhook as a UDF. Supports any language/framework.
@@ -80,14 +236,25 @@ URL 'https://my-endpoint.example.com/process'
 EXECUTION_TIMEOUT 5000;
 ```
 
-Slower than JavaScript UDFs. Does not support custom emit policies.
+With authentication:
+```sql
+CREATE REMOTE FUNCTION ip_lookup(ip string)
+RETURNS string
+URL 'https://my-api.example.com/lookup'
+AUTH_METHOD 'auth_header'
+AUTH_HEADER 'Authorization'
+AUTH_KEY 'Bearer my-token';
+```
 
-## Debugging
+Slower than local UDFs. Does not support aggregate functions or custom emit policies.
 
-Use `console.log(...)` in JavaScript UDFs. Output goes to server logs.
+---
 
-## Drop
+## Drop / Show
 
 ```sql
 DROP FUNCTION [IF EXISTS] <function_name>;
+SHOW FUNCTIONS;
+SHOW FUNCTIONS WHERE name LIKE 'get%';
+SHOW CREATE FUNCTION <function_name>;
 ```


### PR DESCRIPTION
## Summary
- **udf.md**: Expanded from JavaScript-only to all 4 UDF types (SQL, Python, JavaScript, Remote) with practical examples including data masking/redaction, numpy, UDAF with pickle, and package management
- **external-streams.md**: Added HTTP external stream sinks (OpenSearch/Elasticsearch, Splunk HEC, OpenObserve, Algolia), Iceberg, S3, Timeplus external streams, and a sink summary table
- **high-availability.md**: New reference clarifying Proton (single-node) vs Timeplus Enterprise (cluster HA), covering Raft-based and Scheduler-based HA models, system monitoring views, and deployment recommendations

## Motivation
Context7 benchmarks for these 3 topics scored low (35/100, 28/100, 1/100) because the indexed repo content lacked coverage. These reference docs give Context7 the content it needs to answer real user questions about Python UDFs, OpenSearch sinks, and HA deployment.

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] After merge, wait for Context7 re-index and re-run benchmarks
- [ ] Confirm benchmark scores improve for all 3 topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)