### PR TITLE
Add keep_range_join_max_buckets setting to cap range join bucket count

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1141,6 +1141,7 @@ Possible values: non-negative numbers. Note that if the value is too small or to
     M(UInt64, join_buffered_data_block_size, 0, "For streaming join, when buffered data in memory, the data block size directs to merge small data blocks to form bigger ones to improve memory efficiency. 0 means disable merging small data blocks.", 0) \
     M(Int64, join_quiesce_threshold_ms, 0, "For streaming join, when left or right stream is in quiesce, the maximum time to wait before the join.", 0) \
     M(Int64, max_join_range, 300, "Max join range", 0) \
+    M(UInt64, keep_range_join_max_buckets, 0, "Max number of range buckets to keep per stream in a range join. When the number of buckets exceeds this limit, the oldest buckets are reclaimed even if the watermark has not advanced. 0 means no limit.", 0) \
     M(Bool, compact_kv_stream, true, "Control if compact a changelog kv or versioned kv stream during query", 0) \
     M(UInt64, keep_versions, 3, "Control how many versions for each key kept in memory when joining. Used in versioned_kv join", 0) \
     M(Int64, join_latency_threshold, 0, "Control when to start join left stream with right stream for alignment join scenarios. Zero means system picked threshold", 0) \

--- a/src/Interpreters/Streaming/HashJoin/HybridHashJoin/HashIndex.cpp
+++ b/src/Interpreters/Streaming/HashJoin/HybridHashJoin/HashIndex.cpp
@@ -132,6 +132,20 @@ size_t HashIndex::removeOldBuckets(std::string_view stream)
                 break;
         }
 
+        /// Enforce max bucket count: when one stream is idle, the watermark-based
+        /// reclamation cannot advance, causing unbounded bucket accumulation.
+        /// Remove the oldest excess buckets to cap memory usage.
+        auto max_buckets = range_asof_join_ctx.max_buckets;
+        if (max_buckets > 0)
+        {
+            while (range_bucket_hash_indexes.size() > max_buckets)
+            {
+                auto oldest = range_bucket_hash_indexes.begin();
+                buckets_to_remove.push_back(oldest->first);
+                range_bucket_hash_indexes.erase(oldest);
+            }
+        }
+
         remaining_bytes = metrics.totalBytes();
     }
 

--- a/src/Interpreters/Streaming/HashJoin/MemoryHashJoin/joinData.cpp
+++ b/src/Interpreters/Streaming/HashJoin/MemoryHashJoin/joinData.cpp
@@ -85,6 +85,20 @@ size_t BufferedStreamData::removeOldBuckets(std::string_view stream)
                 break;
         }
 
+        /// Enforce max bucket count: when one stream is idle, the watermark-based
+        /// reclamation cannot advance, causing unbounded bucket accumulation.
+        /// Remove the oldest excess buckets to cap memory usage.
+        auto max_buckets = range_asof_join_ctx.max_buckets;
+        if (max_buckets > 0)
+        {
+            while (range_bucket_hash_blocks.size() > max_buckets)
+            {
+                auto oldest = range_bucket_hash_blocks.begin();
+                buckets_to_remove.push_back(oldest->first);
+                range_bucket_hash_blocks.erase(oldest);
+            }
+        }
+
         remaining_bytes = metrics.totalBytes();
     }
 

--- a/src/Interpreters/Streaming/HashJoin/RangeAsofJoinContext.h
+++ b/src/Interpreters/Streaming/HashJoin/RangeAsofJoinContext.h
@@ -29,6 +29,11 @@ struct RangeAsofJoinContext
     Int64 lower_bound = 0;
     Int64 upper_bound = 0;
 
+    /// Max number of range buckets to keep per stream. When the bucket count exceeds this limit,
+    /// the oldest buckets are reclaimed regardless of watermark position.
+    /// 0 means no limit (watermark-only reclamation).
+    UInt64 max_buckets = 0;
+
     RangeType type = RangeType::None;
 
     void validate(Int64 max_range) const;
@@ -36,12 +41,13 @@ struct RangeAsofJoinContext
     String string() const
     {
         return fmt::format(
-            "lower_bound={} upper_bound={} left_inequality={} right_inequality={} type={}",
+            "lower_bound={} upper_bound={} left_inequality={} right_inequality={} type={} max_buckets={}",
             lower_bound,
             upper_bound,
             magic_enum::enum_name(left_inequality),
             magic_enum::enum_name(right_inequality),
-            magic_enum::enum_name(type));
+            magic_enum::enum_name(type),
+            max_buckets);
     }
 
     void serialize(WriteBuffer & wb) const;

--- a/src/Interpreters/Streaming/tests/gtest_streaming_hash_join.cpp
+++ b/src/Interpreters/Streaming/tests/gtest_streaming_hash_join.cpp
@@ -230,6 +230,8 @@ std::shared_ptr<TableJoin> initTableJoin(
 
     table_join->setEmitChangeLog(Streaming::isJoinResultChangelog(left_data_stream_semantic, right_data_stream_semantic));
 
+    table_join->setRangeJoinMaxBuckets(context->getSettingsRef().keep_range_join_max_buckets);
+
     return table_join;
 }
 
@@ -4488,4 +4490,154 @@ TEST(StreamingHashJoin, AppendFullLatestJoinAppend)
              },
          }},
         context);
+}
+
+/// Test that keep_range_join_max_buckets setting limits the number of cached
+/// range buckets, preventing unbounded growth when one stream is idle.
+/// With date_diff_within(2s), bucket_size=2s, so timestamps 0-1s → bucket 0,
+/// 2-3s → bucket 1, 4-5s → bucket 2. Setting max_buckets=2 forces eviction
+/// of bucket 0 when bucket 2 is created. The final step proves eviction:
+/// left 0s can only match right 2s (bucket 1), NOT right 0s/1s (evicted bucket 0).
+TEST(StreamingHashJoin, AppendInnerRangeJoinAppendWithMaxBuckets)
+{
+    auto context = getContext().context;
+    Block left_header = prepareBlock(/*types*/ {"int", "datetime64(3, 'UTC')"}, /*no data*/ "", context);
+    Block right_header = prepareBlock(/*types*/ {"int", "datetime64(3, 'UTC')"}, /*no data*/ "", context);
+
+    auto local_context = Context::createCopy(context);
+    local_context->setSetting("keep_range_join_max_buckets", UInt64(2));
+
+    commonTest(
+        "inner",
+        "all",
+        /*on_clause*/ "t1.col_1 = t2.col_1 and date_diff_within(2s, t1.col_2, t2.col_2)",
+        left_header,
+        Streaming::StorageSemantic::Append,
+        /*left_primary_key_column_indexes*/ std::nullopt,
+        right_header,
+        Streaming::StorageSemantic::Append,
+        /*right_primary_key_column_indexes*/ std::nullopt,
+        /*to_join_steps*/
+        {
+            /// Step 1: seed right with bucket 0 (0s, 1s)
+            {
+                /*to join pos*/ ToJoinStep::RIGHT,
+                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:00')(1, '2023-1-1 00:00:01')", local_context),
+                /*expected join results*/ ExpectedJoinResults{},
+            },
+            /// Step 2: left (0s, 1s) joins against right bucket 0
+            {
+                /*to join pos*/ ToJoinStep::LEFT,
+                /*to join block*/ prepareBlockByHeader(left_header, "(1, '2023-1-1 00:00:00')(1, '2023-1-1 00:00:01')", local_context),
+                /*expected join results*/
+                ExpectedJoinResults{
+                    .values = "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:00')"
+                              "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:01')"
+                              "(1, '2023-1-1 00:00:01', '2023-1-1 00:00:00')"
+                              "(1, '2023-1-1 00:00:01', '2023-1-1 00:00:01')",
+                },
+            },
+            /// Step 3: right adds bucket 1 (2s, 3s) → 2 right buckets, within limit
+            {
+                /*to join pos*/ ToJoinStep::RIGHT,
+                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:02')(1, '2023-1-1 00:00:03')", local_context),
+                /*expected join results*/
+                ExpectedJoinResults{
+                    .values = "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:02')"
+                              "(1, '2023-1-1 00:00:01', '2023-1-1 00:00:02')"
+                              "(1, '2023-1-1 00:00:01', '2023-1-1 00:00:03')",
+                },
+            },
+            /// Step 4: right adds bucket 2 (4s, 5s) → 3 right buckets > max_buckets=2
+            /// → EVICTS right bucket 0 (0s, 1s data gone from right side)
+            {
+                /*to join pos*/ ToJoinStep::RIGHT,
+                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:04')(1, '2023-1-1 00:00:05')", local_context),
+                /*expected join results*/ ExpectedJoinResults{},
+            },
+            /// Step 5: left 0s joins against right — bucket 0 evicted, so only matches right 2s (|0-2|=2 ≤ 2).
+            /// Without eviction, would also match right 0s and 1s.
+            {
+                /*to join pos*/ ToJoinStep::LEFT,
+                /*to join block*/ prepareBlockByHeader(left_header, "(1, '2023-1-1 00:00:00')", local_context),
+                /*expected join results*/
+                ExpectedJoinResults{
+                    .values = "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:02')",
+                },
+            },
+        },
+        local_context);
+}
+
+/// Left range join with max_buckets=2: proves eviction AND null-fill for unmatched left rows.
+/// Same bucket layout as inner join test. Step 5 verifies that after right bucket 0 is evicted,
+/// left 0s only matches right 2s; col_1=2 has no match at all → null-filled.
+TEST(StreamingHashJoin, AppendLeftRangeJoinAppendWithMaxBuckets)
+{
+    auto context = getContext().context;
+    Block left_header = prepareBlock(/*types*/ {"int", "datetime64(3, 'UTC')"}, /*no data*/ "", context);
+    Block right_header = prepareBlock(/*types*/ {"int", "datetime64(3, 'UTC')"}, /*no data*/ "", context);
+
+    auto local_context = Context::createCopy(context);
+    local_context->setSetting("keep_range_join_max_buckets", UInt64(2));
+
+    commonTest(
+        "left",
+        "all",
+        /*on_clause*/ "t1.col_1 = t2.col_1 and date_diff_within(2s, t1.col_2, t2.col_2)",
+        left_header,
+        Streaming::StorageSemantic::Append,
+        /*left_primary_key_column_indexes*/ std::nullopt,
+        right_header,
+        Streaming::StorageSemantic::Append,
+        /*right_primary_key_column_indexes*/ std::nullopt,
+        /*to_join_steps*/
+        {
+            /// Step 1: seed right with bucket 0 (0s, 1s)
+            {
+                /*to join pos*/ ToJoinStep::RIGHT,
+                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:00')(1, '2023-1-1 00:00:01')", local_context),
+                /*expected join results*/ ExpectedJoinResults{},
+            },
+            /// Step 2: left join — col_1=1 matches, col_1=2 gets null-filled
+            {
+                /*to join pos*/ ToJoinStep::LEFT,
+                /*to join block*/ prepareBlockByHeader(left_header, "(1, '2023-1-1 00:00:00')(2, '2023-1-1 00:00:00')", local_context),
+                /*expected join results*/
+                ExpectedJoinResults{
+                    .values = "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:00')"
+                              "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:01')"
+                              "(2, '2023-1-1 00:00:00', '1970-1-1 00:00:00')",
+                },
+            },
+            /// Step 3: right adds bucket 1 (2s, 3s) → 2 right buckets, within limit
+            {
+                /*to join pos*/ ToJoinStep::RIGHT,
+                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:02')(1, '2023-1-1 00:00:03')", local_context),
+                /*expected join results*/
+                ExpectedJoinResults{
+                    .values = "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:02')",
+                },
+            },
+            /// Step 4: right adds bucket 2 (4s, 5s) → 3 right buckets > max_buckets=2
+            /// → EVICTS right bucket 0 (0s, 1s data gone)
+            {
+                /*to join pos*/ ToJoinStep::RIGHT,
+                /*to join block*/ prepareBlockByHeader(right_header, "(1, '2023-1-1 00:00:04')(1, '2023-1-1 00:00:05')", local_context),
+                /*expected join results*/ ExpectedJoinResults{},
+            },
+            /// Step 5: left 0s — after eviction, col_1=1 only matches right 2s;
+            /// col_1=2 still has no match → null-filled.
+            /// Without eviction, col_1=1 would also match right 0s and 1s.
+            {
+                /*to join pos*/ ToJoinStep::LEFT,
+                /*to join block*/ prepareBlockByHeader(left_header, "(1, '2023-1-1 00:00:00')(2, '2023-1-1 00:00:00')", local_context),
+                /*expected join results*/
+                ExpectedJoinResults{
+                    .values = "(1, '2023-1-1 00:00:00', '2023-1-1 00:00:02')"
+                              "(2, '2023-1-1 00:00:00', '1970-1-1 00:00:00')",
+                },
+            },
+        },
+        local_context);
 }

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -398,6 +398,7 @@ public:
     void setRangeAsofLowerBound(Int64 lower_bound) noexcept { range_asof_join_ctx.lower_bound = lower_bound; }
     void setRangeAsofUpperBound(Int64 upper_bound) noexcept { range_asof_join_ctx.upper_bound = upper_bound; }
     void setRangeType(Streaming::RangeType range_type_) noexcept { range_asof_join_ctx.type = range_type_; }
+    void setRangeJoinMaxBuckets(UInt64 max_buckets) noexcept { range_asof_join_ctx.max_buckets = max_buckets; }
     const Streaming::RangeAsofJoinContext & rangeAsofJoinContext() const noexcept { return range_asof_join_ctx; }
     void validateRangeAsof(Int64 max_range) const;
     bool isRangeJoin() const noexcept { return range_asof_join_ctx.type != Streaming::RangeType::None; }

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -805,6 +805,7 @@ void collectJoinedColumns(TableJoin & analyzed_join, ASTTableJoin & table_join,
                     "Range join requires specifying a range on join clause, but only lower bound or upper bound of a range is specified");
 
             analyzed_join.validateRangeAsof(context->getSettingsRef().max_join_range);
+            analyzed_join.setRangeJoinMaxBuckets(context->getSettingsRef().keep_range_join_max_buckets);
             analyzed_join.setStrictness(table_join.strictness);
         }
 


### PR DESCRIPTION

When one stream in a range join is idle, the combined watermark (`min(left, right)`) cannot advance, preventing old bucket reclamation and causing unbounded memory growth. This PR adds a `keep_range_join_max_buckets` query setting (default 0 = no limit) to cap the number of range buckets retained per stream. After normal watermark-based removal in `removeOldBuckets()`, excess oldest buckets are evicted when the count exceeds the configured limit.

## Files changed

| File | Change |
|------|--------|
| `Settings.h` | New `keep_range_join_max_buckets` UInt64 setting (default 0) |
| `RangeAsofJoinContext.h` | Add `max_buckets` field (UInt64) + update `string()` |
| `TableJoin.h` | Add `setRangeJoinMaxBuckets()` setter |
| `TreeRewriter.cpp` | Propagate setting to join context |
| `joinData.cpp` | Enforce max bucket count in `removeOldBuckets()` (MemoryHashJoin) |
| `HashIndex.cpp` | Same enforcement for HybridHashJoin |
| `gtest_streaming_hash_join.cpp` | Inner + left join tests with max_buckets=2 verifying eviction |

## Design notes

- `max_buckets` is **not** serialized in checkpoints -- after recovery, the field retains its constructor-set value from current Settings
- Default 0 means watermark-only reclamation (existing behavior, no regression)
- `std::map<Int64, ...>` guarantees `begin()` is the oldest bucket
- Both MemoryHashJoin and HybridHashJoin paths are updated symmetrically