### PR TITLE
perf: add Python GIL wait instrumentation

### DIFF
--- a/src/CPython/GILGuard.h
+++ b/src/CPython/GILGuard.h
@@ -1,7 +1,21 @@
 #pragma once
 
 #include <Python.h>
+#include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
+#include <Common/ProfileEvents.h>
+#include <Common/Stopwatch.h>
+
+namespace ProfileEvents
+{
+extern const Event PythonGILAcquired;
+extern const Event PythonGILWaitMicroseconds;
+}
+
+namespace CurrentMetrics
+{
+extern const Metric PythonGILWait;
+}
 
 namespace DB
 {
@@ -30,7 +44,13 @@ public:
 
         try
         {
-            state = PyGILState_Ensure();
+            Stopwatch watch;
+            {
+                CurrentMetrics::Increment waiting{CurrentMetrics::PythonGILWait};
+                state = PyGILState_Ensure();
+            }
+            ProfileEvents::increment(ProfileEvents::PythonGILAcquired);
+            ProfileEvents::increment(ProfileEvents::PythonGILWaitMicroseconds, watch.elapsedMicroseconds());
             acquired = true;
         }
         catch (...)

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -181,6 +181,7 @@
     \
     M(S3DiskNoKeyErrors, "The number of `NoSuchKey` errors that occur when reading data from S3 cloud storage through ClickHouse disks.") \
     M(S3CachedCredentialsProviders, "Total number of cached credentials providers") \
+    M(PythonGILWait, "Number of threads currently waiting to acquire the Python GIL") \
 
 
 namespace CurrentMetrics

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -541,6 +541,9 @@
     \
     M(S3CachedCredentialsProvidersReused, "Total number of reused credentials provider from the cache") \
     M(S3CachedCredentialsProvidersAdded, "Total number of newly added credentials providers to the cache") \
+    \
+    M(PythonGILAcquired, "Number of times the Python GIL was acquired") \
+    M(PythonGILWaitMicroseconds, "Total time spent waiting to acquire the Python GIL in microseconds") \
 
 
 namespace ProfileEvents


### PR DESCRIPTION
Add GIL observability 

This change adds:

ProfileEvents::PythonGILAcquired
ProfileEvents::PythonGILWaitMicroseconds
CurrentMetrics::PythonGILWait
Instrumentation is placed in cpython::GILGuard, so it measures GIL acquisition count, cumulative wait time, and current waiters.