### PR TITLE
bugfix: fix TimeWheel races and shutdown ordering

### DIFF
--- a/src/Cluster/Common/TimeWheel/TimeWheel.cpp
+++ b/src/Cluster/Common/TimeWheel/TimeWheel.cpp
@@ -62,11 +62,9 @@ bool TimeWheel::add(TimerTaskEntryPtr timer_task_entry)
     else
     {
         /// Out of the interval. Put it into the parent timer
-        if (!overflow_wheel)
-            addOverflowWheel();
-
-        chassert(overflow_wheel);
-        return overflow_wheel->add(std::move(timer_task_entry));
+        auto * overflow = getOrCreateOverflowWheel();
+        chassert(overflow);
+        return overflow->add(std::move(timer_task_entry));
     }
 }
 
@@ -80,15 +78,30 @@ void TimeWheel::advanceClock(int64_t time_ms)
         int64_t new_time = time_ms - (time_ms % tick_ms);
         current_time_ms.store(new_time);
 
-        if (overflow_wheel)
-            overflow_wheel->advanceClock(new_time);
+        /// Benign race: overflow_wheel is monotonic (nullptr → valid, never back).                                                                                           
+        /// A racy nullptr read just skips one tick; the next call catches up.                                                                                                
+        /// We still call getOverflowWheel() (mutex-guarded) to obtain a safe pointer.                                                                                        
+        if (overflow_wheel)                                                                                                                                            
+        {                                                                                                                                                              
+            auto * overflow = getOverflowWheel();                                                                                                                      
+            overflow->advanceClock(new_time);
+        }
     }
 }
 
-void TimeWheel::addOverflowWheel()
+TimeWheel * TimeWheel::getOverflowWheel()
 {
-    chassert(!overflow_wheel);
-    overflow_wheel = std::make_unique<TimeWheel>(interval_ms, wheel_size, current_time_ms, queue, decrement_size);
+    std::lock_guard lock(overflow_wheel_mutex);
+    return overflow_wheel.get();
+}
+
+TimeWheel * TimeWheel::getOrCreateOverflowWheel()
+{
+    std::lock_guard lock(overflow_wheel_mutex);
+    if (!overflow_wheel)
+        overflow_wheel = std::make_unique<TimeWheel>(interval_ms, wheel_size, current_time_ms.load(), queue, decrement_size);
+
+    return overflow_wheel.get();
 }
 
 }

--- a/src/Cluster/Common/TimeWheel/TimeWheel.h
+++ b/src/Cluster/Common/TimeWheel/TimeWheel.h
@@ -2,6 +2,8 @@
 
 #include <Cluster/Common/TimeWheel/DelayQueue.h>
 
+#include <mutex>
+
 namespace cluster
 {
 
@@ -21,7 +23,8 @@ public:
     void advanceClock(int64_t time_ms);
 
 private:
-    void addOverflowWheel();
+    TimeWheel * getOverflowWheel();
+    TimeWheel * getOrCreateOverflowWheel();
 
 private:
     int64_t tick_ms;
@@ -33,7 +36,8 @@ private:
     std::function<void()> decrement_size;
 
     std::vector<TimerTaskListPtr> buckets;
-    std::unique_ptr<TimeWheel> overflow_wheel;
+    std::mutex overflow_wheel_mutex;
+    std::unique_ptr<TimeWheel> overflow_wheel; /// intentionally read without lock in advanceClock (benign race, see comment there)
 };
 
 }

--- a/src/Cluster/Common/TimeWheel/TimerService.cpp
+++ b/src/Cluster/Common/TimeWheel/TimerService.cpp
@@ -32,8 +32,13 @@ void TimerService::shutdown()
     if (stopped.test_and_set())
         return;
 
-    timer.wait();
+    /// Best-effort shutdown: stop polling first so active repeat timers cannot keep the
+    /// current poll cycle self-feeding and block shutdown indefinitely.
     poller.wait();
+    timer.wait();
+
+    /// TODO: if shutdown ever needs lossless timer draining, introduce an explicit
+    /// producer/rearm quiesce protocol instead of relying on this order alone.
 }
 
 TimerTaskEntryPtr TimerService::add(int64_t timeout_ms, TimerCallback task, bool repeat)

--- a/src/Cluster/Common/tests/gtest_timer.cpp
+++ b/src/Cluster/Common/tests/gtest_timer.cpp
@@ -1,7 +1,12 @@
 #include <Cluster/Common/TimeWheel/SystemTimer.h>
+#include <Cluster/Common/TimeWheel/TimerService.h>
 #include <Common/Stopwatch.h>
 
 #include <gtest/gtest.h>
+
+#include <base/sleep.h>
+
+#include <unistd.h>
 
 #include <atomic>
 #include <iostream>
@@ -263,6 +268,22 @@ TEST(TimeWheel, TimerTestWithOverflowWheel)
     GTEST_ASSERT_EQ(counter.load(), 1);
 }
 
+TEST(TimeWheel, TimerTestWithOverflowWheelBoundary)
+{
+    std::atomic_int32_t counter{};
+    {
+        cluster::SystemTimer timer(4, 1, 20);
+        auto timer_task = timer.add(20, [&]() { counter++; });
+        ASSERT_TRUE(timer_task != nullptr);
+
+        /// The equality boundary also falls into the overflow wheel.
+        timer.poll(1024);
+        timer.poll(1024);
+    }
+
+    GTEST_ASSERT_EQ(counter.load(), 1);
+}
+
 TEST(TimeWheel, TimerTestWithOverflowWheelMore)
 {
     std::atomic_int32_t counter{};
@@ -505,4 +526,39 @@ TEST(TimeWheel, CancelAndReinsert)
     timer.poll(20);
     std::this_thread::sleep_for(5ms);
     ASSERT_EQ(counter, 2);
+}
+
+TEST(TimeWheel, TimerServiceShutdownWithActiveRepeatOverflowTimer)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    ASSERT_EXIT(
+        [] {
+            ::alarm(5);
+
+            cluster::TimerService timer_service(/*worker_pool_size=*/1, /*tick_ms=*/1, /*wheel_size=*/20, /*expired_timers_size=*/1);
+            std::atomic_int32_t callback_count{0};
+
+            auto timer_task = timer_service.add(
+                /*timeout_ms=*/20,
+                [&]() {
+                    ++callback_count;
+                    sleepForMilliseconds(10);
+                },
+                /*repeat=*/true);
+
+            if (!timer_task)
+                _exit(2);
+
+            for (int i = 0; i < 4000 && callback_count.load() < 3; ++i)
+                sleepForMilliseconds(1);
+
+            if (callback_count.load() < 3)
+                _exit(3);
+
+            timer_service.shutdown();
+            _exit(0);
+        }(),
+        ::testing::ExitedWithCode(0),
+        "");
 }


### PR DESCRIPTION
poller.wait() first: no more producers
timer.wait() second: then it is safe to stop consumers