### PR TITLE
bugfix: preserve backfill filter pruning

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyCondition.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyCondition.cpp
@@ -5,6 +5,7 @@
 #include <deque>
 
 /// proton: starts.
+#include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/Streaming/ConcatStep.h>
 #include <Processors/QueryPlan/Streaming/DelayStep.h>
 /// proton: ends.
@@ -31,10 +32,11 @@ void optimizePrimaryKeyCondition(const Stack & stack)
         else if (typeid_cast<ExpressionStep *>(iter->node->step.get()))
             continue;
         /// proton: starts.
-        /// Streaming backfill inserts transparent routing steps between the outer filter and historical source.
+        /// Streaming backfill inserts order/header preserving routing steps between the outer filter and historical source.
         /// Skip them so MergeTree sources can still reuse the filter for index pruning.
         else if (
-            typeid_cast<Streaming::DelayStep *>(iter->node->step.get())
+            typeid_cast<SortingStep *>(iter->node->step.get())
+            || typeid_cast<Streaming::DelayStep *>(iter->node->step.get())
             || typeid_cast<Streaming::ConcatStep *>(iter->node->step.get()))
             continue;
         /// proton: ends.

--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyCondition.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyCondition.cpp
@@ -2,6 +2,8 @@
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <Processors/QueryPlan/Streaming/ConcatStep.h>
+#include <Processors/QueryPlan/Streaming/DelayStep.h>
 #include <deque>
 
 namespace DB::QueryPlanOptimizations
@@ -24,6 +26,12 @@ void optimizePrimaryKeyCondition(const Stack & stack)
         /// Ideally, chain should look like (Expression -> ...) -> (Filter -> ...) -> ReadFromStorage,
         /// So this is likely not needed.
         else if (typeid_cast<ExpressionStep *>(iter->node->step.get()))
+            continue;
+        /// Streaming backfill inserts transparent routing steps between the outer filter and historical source.
+        /// Skip them so MergeTree sources can still reuse the filter for index pruning.
+        else if (
+            typeid_cast<Streaming::DelayStep *>(iter->node->step.get())
+            || typeid_cast<Streaming::ConcatStep *>(iter->node->step.get()))
             continue;
         else
             break;

--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyCondition.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyCondition.cpp
@@ -2,9 +2,12 @@
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <deque>
+
+/// proton: starts.
 #include <Processors/QueryPlan/Streaming/ConcatStep.h>
 #include <Processors/QueryPlan/Streaming/DelayStep.h>
-#include <deque>
+/// proton: ends.
 
 namespace DB::QueryPlanOptimizations
 {
@@ -27,12 +30,14 @@ void optimizePrimaryKeyCondition(const Stack & stack)
         /// So this is likely not needed.
         else if (typeid_cast<ExpressionStep *>(iter->node->step.get()))
             continue;
+        /// proton: starts.
         /// Streaming backfill inserts transparent routing steps between the outer filter and historical source.
         /// Skip them so MergeTree sources can still reuse the filter for index pruning.
         else if (
             typeid_cast<Streaming::DelayStep *>(iter->node->step.get())
             || typeid_cast<Streaming::ConcatStep *>(iter->node->step.get()))
             continue;
+        /// proton: ends.
         else
             break;
     }

--- a/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.reference
+++ b/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.reference
@@ -24,3 +24,16 @@ Granules: 3/3
 Name: _tp_time_index
 Parts: 1/1
 Granules: 3/3
+-- backfill in order
+Condition: (_tp_time in [\'1775790000\', +inf))
+Parts: 1/3
+Granules: 3/5
+Condition: (to_YYYYMM(_tp_time) in [202604, +inf))
+Parts: 1/1
+Granules: 3/3
+Condition: (to_start_of_hour(_tp_time) in [1775790000, +inf))
+Parts: 1/1
+Granules: 3/3
+Name: _tp_time_index
+Parts: 1/1
+Granules: 3/3

--- a/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.reference
+++ b/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.reference
@@ -1,0 +1,26 @@
+-- query_mode=table
+Condition: (_tp_time in [\'1775790000\', +inf))
+Parts: 1/3
+Granules: 3/5
+Condition: (to_YYYYMM(_tp_time) in [202604, +inf))
+Parts: 1/1
+Granules: 3/3
+Condition: (to_start_of_hour(_tp_time) in [1775790000, +inf))
+Parts: 1/1
+Granules: 3/3
+Name: _tp_time_index
+Parts: 1/1
+Granules: 3/3
+-- backfill
+Condition: (_tp_time in [\'1775790000\', +inf))
+Parts: 1/3
+Granules: 3/5
+Condition: (to_YYYYMM(_tp_time) in [202604, +inf))
+Parts: 1/1
+Granules: 3/3
+Condition: (to_start_of_hour(_tp_time) in [1775790000, +inf))
+Parts: 1/1
+Granules: 3/3
+Name: _tp_time_index
+Parts: 1/1
+Granules: 3/3

--- a/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.sql
+++ b/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.sql
@@ -1,0 +1,55 @@
+DROP STREAM IF EXISTS 99274_backfill_historical_filter_pruning;
+
+CREATE STREAM 99274_backfill_historical_filter_pruning(id int32)
+SETTINGS flush_threshold_count = 1, index_granularity = 1;
+
+SELECT sleep(1) FORMAT Null;
+
+INSERT INTO 99274_backfill_historical_filter_pruning(id, _tp_time)
+SELECT 1, to_datetime64('2024-01-03 00:00:00', 3, 'UTC')
+UNION ALL
+SELECT 2, to_datetime64('2024-02-03 00:00:00', 3, 'UTC')
+UNION ALL
+SELECT 3, to_datetime64('2026-04-10 02:00:00', 3, 'UTC')
+UNION ALL
+SELECT 4, to_datetime64('2026-04-10 03:00:00', 3, 'UTC')
+UNION ALL
+SELECT 5, to_datetime64('2026-04-10 04:00:00', 3, 'UTC');
+
+SELECT sleep(3) FORMAT Null;
+OPTIMIZE STREAM 99274_backfill_historical_filter_pruning FINAL;
+SELECT sleep(1) FORMAT Null;
+
+SELECT '-- query_mode=table';
+SELECT trim(leading ' ' from explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM 99274_backfill_historical_filter_pruning
+    WHERE _tp_time >= to_datetime64('2026-04-10 03:00:00', 3, 'UTC')
+    ORDER BY id
+    SETTINGS query_mode = 'table'
+)
+WHERE explain LIKE '%Condition:%'
+   OR explain LIKE '%Name:%'
+   OR explain LIKE '%Parts:%'
+   OR explain LIKE '%Granules:%';
+
+SELECT '-- backfill';
+SELECT trim(leading ' ' from explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM 99274_backfill_historical_filter_pruning
+    WHERE _tp_time >= to_datetime64('2026-04-10 03:00:00', 3, 'UTC')
+    ORDER BY id
+    SETTINGS enable_backfill_from_historical_store = 1
+)
+WHERE explain LIKE '%Condition:%'
+   OR explain LIKE '%Name:%'
+   OR explain LIKE '%Parts:%'
+   OR explain LIKE '%Granules:%';
+
+DROP STREAM IF EXISTS 99274_backfill_historical_filter_pruning;

--- a/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.sql
+++ b/tests/queries_ported/0_stateless/99274_backfill_historical_filter_pruning.sql
@@ -52,4 +52,20 @@ WHERE explain LIKE '%Condition:%'
    OR explain LIKE '%Parts:%'
    OR explain LIKE '%Granules:%';
 
+SELECT '-- backfill in order';
+SELECT trim(leading ' ' from explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM 99274_backfill_historical_filter_pruning
+    WHERE _tp_time >= to_datetime64('2026-04-10 03:00:00', 3, 'UTC')
+    ORDER BY id
+    SETTINGS enable_backfill_from_historical_store = 1, force_backfill_in_order = 1
+)
+WHERE explain LIKE '%Condition:%'
+   OR explain LIKE '%Name:%'
+   OR explain LIKE '%Parts:%'
+   OR explain LIKE '%Granules:%';
+
 DROP STREAM IF EXISTS 99274_backfill_historical_filter_pruning;


### PR DESCRIPTION
## Summary
- allow `optimizePrimaryKeyCondition()` to walk through streaming `DelayStep` and `ConcatStep` when collecting ancestor filters for historical MergeTree sources
- restore `_tp_time`-based MinMax/partition/primary-key pruning on the historical branch of StorageStream backfill queries
- add a stateless SQL regression that compares pure historical reads and backfill historical reads using the default StorageStream partition/order/index layout

## Verification
- `CLICKHOUSE_PORT_TCP=8483 CLICKHOUSE_PORT_HTTP=8143 ./ported-clickhouse-test.py -b ../build/programs/stripped/bin/proton -q queries_ported 99274_backfill_historical_filter_pruning`

## Context
- draft for issue #558
- self-review found no additional blockers in the current diff
