### PR TITLE
improve discard log messages to include range_time_column name,

### DIFF
--- a/src/Interpreters/Streaming/HashJoin/HybridHashJoin/HashIndex.cpp
+++ b/src/Interpreters/Streaming/HashJoin/HybridHashJoin/HashIndex.cpp
@@ -234,10 +234,12 @@ std::vector<HashIndex::BucketBlock> HashIndex::assignDataBlockToRangeBuckets(Blo
     {
         LOG_INFO(
             join->logger,
-            "Discard {} late events in range bucket {} of left stream since it is later than latest combined watermark {} with "
-            "bucket_size={}",
+            "Discard {} late events in range bucket {} of {} stream (range_time_column={}) since it is later than "
+            "latest combined watermark {} with bucket_size={}",
             rows,
             bucket,
+            id,
+            asof_col_name,
             watermark,
             bucket_size);
     }

--- a/src/Interpreters/Streaming/HashJoin/MemoryHashJoin/joinData.cpp
+++ b/src/Interpreters/Streaming/HashJoin/MemoryHashJoin/joinData.cpp
@@ -264,10 +264,11 @@ std::vector<BufferedStreamData::BucketBlock> BufferedStreamData::assignDataBlock
     {
         LOG_INFO(
             join->logger,
-            "Discard {} late events in range bucket {} of left stream since it is later than latest combined watermark {} with "
-            "bucket_size={}",
+            "Discard {} late events in range bucket {} (range_time_column={}) since it is later than "
+            "latest combined watermark {} with bucket_size={}",
             rows,
             bucket,
+            asof_col_name,
             watermark,
             bucket_size);
     }


### PR DESCRIPTION
Improve discard log messages to include range_time_column= for easier diagnosis of which join level is discarding data.