### PR TITLE
ci(run_command): allow --failed rerun to reuse EC2 on first-attempt failure

### DIFF
--- a/.github/workflows/run_command.yml
+++ b/.github/workflows/run_command.yml
@@ -266,6 +266,33 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           tag_name: ${{ steps.execute.outputs.tag_name }}
 
+      - name: Failed-job rerun notice
+        if: ${{ failure() && steps.execute.conclusion == 'failure' && github.run_attempt == 1 }}
+        env:
+          EC2_INSTANCE_ID: ${{ needs.start-runner.outputs.ec2-instance-id }}
+          RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
+        run: |
+          {
+            echo "## Failed-job rerun notice"
+            echo ""
+            echo "The \`execute\` step failed on attempt 1. The \`stop-runner\` job is configured"
+            echo "to skip termination on first-attempt \`execute\` failures so that"
+            echo "\`gh run rerun --failed\` can land back on the same EC2 instance."
+            echo ""
+            echo "- Runner label: \`${RUNNER_LABEL}\`"
+            echo "- EC2 instance: \`${EC2_INSTANCE_ID}\`"
+            echo ""
+            echo "If you are **not** going to rerun, terminate the EC2 manually to avoid"
+            echo "leaking compute:"
+            echo ""
+            echo "\`\`\`bash"
+            echo "aws ec2 terminate-instances --instance-ids ${EC2_INSTANCE_ID}"
+            echo "\`\`\`"
+            echo ""
+            echo "Subsequent attempts (\`run_attempt > 1\`) always run \`stop-runner\`"
+            echo "regardless of outcome."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Artifact
         if: ${{ always() && inputs.upjob != '' }}
         uses: actions/upload-artifact@v6.0.0
@@ -281,7 +308,13 @@ jobs:
       - start-runner # required to get output from the start-runner job
       - execute-command # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    # Skip termination on first-attempt execute-command failure so that
+    # `gh run rerun --failed` can land back on the same EC2 instance.
+    # Run on success, cancellation, or any subsequent attempt regardless
+    # of outcome (so a second failure does not leak the EC2 either).
+    # Note: terminal failures with no rerun leak the EC2 until an external
+    # sweeper or manual `aws ec2 terminate-instances` cleans it up.
+    if: ${{ success() || cancelled() || github.run_attempt > 1 }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.0.0


### PR DESCRIPTION
## Summary

- Change `stop-runner.if` from `always()` to `success() || cancelled() || github.run_attempt > 1`. On a first-attempt `execute-command` failure the EC2 is left alive so `gh run rerun --failed` can land on the same machine.
- Add a step-summary notice on first-attempt failure with the runner label, instance id, and the manual `aws ec2 terminate-instances` fallback for users who do not plan to rerun.

## Motivation

The release build run [#26276953469](https://github.com/timeplus-io/proton/actions/runs/26276953469) failed in `Build_Linux_Arm64 / Execute Command` with a transient `unknown blob` error during `docker push ghcr.io/timeplus-io/proton:${SHA}_arm64v8`. Build, Docker Hub push, and most of the GHCR push had already succeeded — only the final GHCR layer push failed.

`gh run rerun --failed` was the natural next step, but it produced a hang on attempt 2:
- `start-runner` (succeeded on attempt 1) was not re-executed
- `stop-runner` (succeeded on attempt 1 because of `if: always()`) had already terminated the EC2 and deregistered the runner
- `execute-command` (attempt 2) queued indefinitely waiting for a runner label that no longer maps to a live machine

GitHub Actions `--failed` rerun semantics intentionally skip already-successful upstream jobs and reuse their outputs. With ephemeral self-hosted runners that is a footgun: outputs are durable, EC2 instances are not.

## Behavior table

| run_attempt | execute result | stop-runner runs? | EC2 lifetime |
|---|---|---|---|
| 1 | success | yes (`success()` true) | terminate |
| 1 | failure | **no** (new) | kept alive for `--failed` rerun |
| 1 | cancelled | yes (`cancelled()` true) | terminate |
| ≥2 | any | yes (`run_attempt > 1` true) | terminate |

Trade-off: a terminal first-attempt failure with no rerun leaks the EC2 until manual cleanup or a sweeper runs. The step-summary notice surfaces this with a copy-pasteable `terminate-instances` command.

## Caveat for review

This assumes the `yokofly/ec2-github-runner` agent is **not** registered with `--ephemeral`. If it is, the runner agent exits after the first job regardless of EC2 lifetime, so keeping the instance alive still leaves no runner to pick up the re-queued `execute-command`. In that case `--failed` rerun would still hang and the right fix is also to disable ephemeral mode on the start side (or restart the agent on rerun).

Worth confirming against the pinned fork (`522cb941f0d76565385ce7aeb6771bf58451ba1b`) and AMI bootstrap before merge.

## Test plan

- [ ] Validate the YAML parses (done locally with `python3 -c 'yaml.safe_load(...)'`)
- [ ] Confirm runner mode (ephemeral vs. persistent) on the pinned fork
- [ ] Once confirmed, force a transient failure in a feature workflow run and verify `gh run rerun --failed` lands on the same EC2 and succeeds
- [ ] Confirm the step summary renders correctly on a failed `Build_Linux_*` job
- [ ] Decide whether to add a scheduled sweeper for orphan EC2s (probably follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)