### PR TITLE
Update REST API header names

### DIFF
--- a/spec/rest-api/ddl-service.yaml
+++ b/spec/rest-api/ddl-service.yaml
@@ -17,13 +17,13 @@ paths:
             schema:
               $ref: '#/components/schemas/tabularTable'
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -34,7 +34,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -44,7 +44,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -54,7 +54,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -69,13 +69,13 @@ paths:
     get:
       summary: Get list of tabular tables
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -86,7 +86,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -96,7 +96,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -106,7 +106,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -134,13 +134,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -151,7 +151,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -161,7 +161,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -171,7 +171,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -191,13 +191,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -208,7 +208,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -218,7 +218,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -228,7 +228,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -251,13 +251,13 @@ paths:
             schema:
               $ref: "#/components/schemas/rawstoreTable"
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -268,7 +268,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -278,7 +278,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -288,7 +288,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -303,13 +303,13 @@ paths:
     get:
       summary: Get list of rawstore tables
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -320,7 +320,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -330,7 +330,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -340,7 +340,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -368,13 +368,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -385,7 +385,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -395,7 +395,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -405,7 +405,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -425,13 +425,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -442,7 +442,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -452,7 +452,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -462,7 +462,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -490,13 +490,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -507,7 +507,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -517,7 +517,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -527,7 +527,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -560,13 +560,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -577,7 +577,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -587,7 +587,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -597,7 +597,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -622,13 +622,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -639,7 +639,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -649,7 +649,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -659,7 +659,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:

--- a/spec/rest-api/ingest.yaml
+++ b/spec/rest-api/ingest.yaml
@@ -74,13 +74,13 @@ paths:
           in: query
           name: mode
           description: 'ingest mode, only works for Stream engine. ''''sync"： proton inserts data asynchronously but does not track the insert status.''async'' the default insert mode, proton inserts data asynchronously but track the status and retry if insert fails. ''ordered'' proton inserts data synchronously. '
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -91,7 +91,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -101,7 +101,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -111,7 +111,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -329,13 +329,13 @@ paths:
           in: query
           name: mode
           description: 'ingest mode, only works for Stream engine. ''''sync"： proton inserts data asynchronously but does not track the insert status.''async'' the default insert mode, proton inserts data asynchronously but track the status and retry if insert fails. ''ordered'' proton inserts data synchronously. '
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -346,7 +346,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -356,7 +356,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -366,7 +366,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -380,13 +380,13 @@ paths:
         description: rawstore name to insert data into
   /statuses:
     parameters:
-      - name: x-proton-request-id
+      - name: x-timeplus-request-id
         in: header
         required: false
         description: the unique id to identify a ddl request
         schema:
           type: string
-      - name: x-proton-query-id
+      - name: x-timeplus-query-id
         in: header
         required: false
         description: the unique id to identify a ddl request
@@ -397,7 +397,7 @@ paths:
         required: false
         schema:
           type: string
-      - name: x-proton-user
+      - name: x-timeplus-user
         in: header
         required: false
         schema:
@@ -407,7 +407,7 @@ paths:
         required: false
         schema:
           type: string
-      - name: x-proton-key
+      - name: x-timeplus-key
         in: header
         required: false
         schema:
@@ -417,7 +417,7 @@ paths:
         required: false
         schema:
           type: string
-      - name: x-proton-quota
+      - name: x-timeplus-quota
         in: header
         required: false
         schema:

--- a/spec/rest-api/search.yaml
+++ b/spec/rest-api/search.yaml
@@ -163,13 +163,13 @@ paths:
           in: query
           name: default_format
           description: 'query result output format, like CSV, JSONEachRow, et al. The default value is ''JSONCompact'''
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -180,7 +180,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -190,7 +190,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -200,7 +200,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:

--- a/spec/rest-api/sqlanalyze.yaml
+++ b/spec/rest-api/sqlanalyze.yaml
@@ -36,13 +36,13 @@ paths:
         description: Post the query to analyze
       description: Analyze the query and get the required and result columns
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a ddl request
           schema:
             type: string
-        - name: x-proton-query-id
+        - name: x-timeplus-query-id
           in: header
           required: false
           description: the unique id to identify a ddl request
@@ -53,7 +53,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -63,7 +63,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -73,7 +73,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:

--- a/spec/rest-api/udfs.yaml
+++ b/spec/rest-api/udfs.yaml
@@ -17,7 +17,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UDF'
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify arequest
@@ -28,7 +28,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -38,7 +38,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -48,7 +48,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -63,7 +63,7 @@ paths:
     get:
       summary: List all user defined functions (UDF)
       parameters:
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a request
@@ -74,7 +74,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -84,7 +84,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -94,7 +94,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -123,7 +123,7 @@ paths:
           schema:
             type: string
           description: the UDF function name
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a request
@@ -134,7 +134,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -144,7 +144,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -154,7 +154,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:
@@ -180,7 +180,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: x-proton-request-id
+        - name: x-timeplus-request-id
           in: header
           required: false
           description: the unique id to identify a request
@@ -191,7 +191,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-user
+        - name: x-timeplus-user
           in: header
           required: false
           schema:
@@ -201,7 +201,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-key
+        - name: x-timeplus-key
           in: header
           required: false
           schema:
@@ -211,7 +211,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: x-proton-quota
+        - name: x-timeplus-quota
           in: header
           required: false
           schema:


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Not run; this only changes REST API YAML specs.
- Did you separate headers to a different section in existing community code base ? Not applicable.
- Did you surround `proton: starts/ends` for new code in existing community code base ? Not applicable.

Please write user-readable short description of the changes:

This updates the REST API spec to use the current `x-timeplus-*` header names instead of the older `x-proton-*` names.

The server already accepts and emits `x-timeplus-*` headers in the REST handlers. This keeps the OpenAPI spec aligned with that behavior and cleans up the remaining stale header names under `spec/rest-api`.

Validation performed:

```powershell
rg -n x-proton spec/rest-api -g *.yaml
```

Result: no matches.

```powershell
git show --check --oneline --summary HEAD
```

Result:

```text
d8cfc1a5 Update REST API header names
```

Fixes #728