### PR TITLE
Clarify DateTime32 precision errors

### DIFF
--- a/src/DataTypes/registerDataTypeDateTime.cpp
+++ b/src/DataTypes/registerDataTypeDateTime.cpp
@@ -86,6 +86,11 @@ static DataTypePtr create32(const ASTPtr & arguments, [[maybe_unused]] bool comp
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
                         "The datetime32 data type can optionally have only one argument - time zone name");
 
+    const auto * argument = arguments->children[0]->as<ASTLiteral>();
+    if (argument && argument->value.getType() == Field::Types::Which::UInt64)
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                        "The datetime32 data type does not support precision. Use datetime64 for fractional seconds");
+
     const auto timezone = getArgument<String, ArgumentKind::Mandatory>(arguments, 0, "timezone", "datetime32");
 
     return std::make_shared<DataTypeDateTime>(timezone);

--- a/src/DataTypes/tests/gtest_data_types_binary_encoding.cpp
+++ b/src/DataTypes/tests/gtest_data_types_binary_encoding.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <Core/Field.h>
+#include <Common/Exception.h>
 #include <DataTypes/DataTypesBinaryEncoding.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeFixedString.h>
@@ -27,6 +28,7 @@ using namespace DB;
 namespace DB::ErrorCodes
 {
 extern const int UNSUPPORTED_METHOD;
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
 
@@ -134,4 +136,18 @@ GTEST_TEST(DataTypesBinaryEncoding, EncodeAndDecode)
     check(DataTypeFactory::instance().get("json"));
     check(DataTypeFactory::instance().get("json(max_dynamic_paths=10)"));
     check(DataTypeFactory::instance().get("json(max_dynamic_paths=10, max_dynamic_types=10, a.b.c uint32, SKIP a.c, b.g string, SKIP l.d.f)"));
+}
+
+GTEST_TEST(DataTypeFactory, DateTime32PrecisionError)
+{
+    try
+    {
+        DataTypeFactory::instance().get("datetime32(3)");
+        FAIL() << "Expected datetime32 precision to throw";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        EXPECT_NE(std::string(e.what()).find("datetime32 data type does not support precision"), std::string::npos);
+    }
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Not run locally; the change is small and follows the surrounding style.
- Did you separate headers to a different section in existing community code base ? Not applicable.
- Did you surround `proton: starts/ends` for new code in existing community code base ? Not applicable; this updates Proton-specific DateTime32 handling that is already in the file.

Please write user-readable short description of the changes:

This makes the `datetime32(3)` error message more direct.

Before this change, `datetime32(3)` treated `3` as the first `datetime32` argument and reported it as a timezone type error. That is technically accurate from the parser path, but confusing for users because the input looks like a precision argument.

Now, numeric `datetime32(...)` arguments fail with a clearer message explaining that `datetime32` does not support precision and that `datetime64` should be used for fractional seconds.

A gtest regression was added for `DataTypeFactory::instance().get(datetime32(3))` to check the error code and message.

Validation performed:

```powershell
git show --check --oneline --summary HEAD
```

Result:

```text
6b28d1ca Clarify DateTime32 precision errors
```

I could not run the C++ gtest locally on this Windows checkout because there is no configured build directory or C++ toolchain available in the current shell.

Fixes #816