### PR TITLE
Use Proton root for Docker user override

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -21,6 +21,15 @@ PROTON_USER="${PROTON_USER:-default}"
 PROTON_PASSWORD="${PROTON_PASSWORD:-}"
 PROTON_ACCESS_MANAGEMENT="${PROTON_DEFAULT_ACCESS_MANAGEMENT:-0}"
 
+xml_escape() {
+    sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g' \
+        -e "s/'/\&apos;/g"
+}
+
 for dir in "$PYTHON_SITE_PACKAGE_PATH"
 do
     # check if variable not empty
@@ -36,6 +45,29 @@ do
         exit 1
     fi
 done
+
+if [ -n "$PROTON_PASSWORD" ] || [ "$PROTON_USER" != "default" ] || [ "$PROTON_ACCESS_MANAGEMENT" != "0" ]; then
+    if [[ ! "$PROTON_USER" =~ ^[A-Za-z0-9_][A-Za-z0-9_@.-]*$ ]]; then
+        echo >&2 "Invalid PROTON_USER '$PROTON_USER'. Only letters, digits, '_', '@', '.', and '-' are supported."
+        exit 1
+    fi
+
+    PROTON_USERS_D="$(dirname "$PROTON_CONFIG")/users.d"
+    mkdir -p "$PROTON_USERS_D"
+
+    {
+        echo "<proton>"
+        echo "    <users>"
+        echo "        <$PROTON_USER>"
+        echo "            <password>$(printf '%s' "$PROTON_PASSWORD" | xml_escape)</password>"
+        echo "            <access_management>$(printf '%s' "$PROTON_ACCESS_MANAGEMENT" | xml_escape)</access_management>"
+        echo "            <profile>default</profile>"
+        echo "            <quota>default</quota>"
+        echo "        </$PROTON_USER>"
+        echo "    </users>"
+        echo "</proton>"
+    } > "$PROTON_USERS_D/default-user.xml"
+fi
 
 if [ -n "$STREAM_STORAGE_BROKERS" ]; then
     # Replace `brokers: localhost:9092` in config.yaml with customized one


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Not applicable; this changes a shell script.
- Did you separate headers to a different section in existing community code base ? Not applicable.
- Did you surround `proton: starts/ends` for new code in existing community code base ? Not applicable for the Docker entrypoint shell script.

Please write user-readable short description of the changes:

This updates the Docker entrypoint path that handles `PROTON_USER`, `PROTON_PASSWORD`, and `PROTON_DEFAULT_ACCESS_MANAGEMENT`.

When those environment variables are provided, the entrypoint now writes a `users.d/default-user.xml` override using Proton's `<proton>` root element. That matches the root used by the Proton server config and avoids the config merge failure reported when Docker env-based user configuration is enabled.

The generated XML also escapes env-derived values and validates the username before using it as an XML element name.

Validation performed:

```powershell
wsl -e bash -n docker/server/entrypoint.sh
```

Result: shell syntax check passed.

```powershell
git show --check --oneline --summary HEAD
```

Result:

```text
32d49afa Use Proton root for Docker user override
```

Fixes #927