### PR TITLE
fix(streaming): suppress phantom changelog rows in multishard memory aggregation

### DIFF
--- a/src/Interpreters/Streaming/Aggregator/MemoryAggregator/MemoryAggregator_Convert.cpp
+++ b/src/Interpreters/Streaming/Aggregator/MemoryAggregator/MemoryAggregator_Convert.cpp
@@ -241,17 +241,33 @@ BlocksList MemoryAggregator::mergeAndConvertToBlocks(
             auto merged_retracted_data = mergeGroups(many_data_variants, retract_cparams);
             if (merged_retracted_data)
             {
-                AggregatingConvertParams merged_cparams{AggregatingConvertType::Normal};
-                auto retract_blocks = doConvertToBlocks(*merged_retracted_data, /*final_=*/true, max_threads, merged_cparams);
-                for (auto & retract_block : retract_blocks)
-                {
-                    auto rows = retract_block.rows();
-                    retract_block.insert(
-                        ColumnWithTypeAndName{ColumnInt8::create(rows, static_cast<Int8>(-1)), delta_col_type, "_tp_delta"});
-                    retract_block.setRetract();
-                }
+                chassert(merged_retracted_data->aggregatorType() == AggregatorType::Memory);
+                auto & merged_memory = static_cast<MemoryAggregatedDataVariants &>(*merged_retracted_data);
 
-                blocks.splice(blocks.end(), std::move(retract_blocks));
+                /// without_key special case: mergeRetractGroups bails when no shard has a retract yet
+                /// (e.g. first changelog emit) and leaves first.without_key at the init-empty state.
+                /// Converting that as Normal would emit a phantom (…, 0, -1) row — skip it.
+                const bool empty_without_key
+                    = merged_memory.type == MemoryAggregatedDataVariants::Type::without_key && merged_memory.without_key
+                    && TrackingUpdatesWithRetract::empty(merged_memory.without_key);
+
+                if (!empty_without_key)
+                {
+                    /// Use UpdatesAfterRetract so the keyed conversion filters out merged entries whose
+                    /// prior-state contribution sums to empty — a fresh key inserted in this cycle on
+                    /// one shard with no carry-over from any other shard.
+                    AggregatingConvertParams merged_cparams{AggregatingConvertType::UpdatesAfterRetract};
+                    auto retract_blocks = doConvertToBlocks(merged_memory, /*final_=*/true, max_threads, merged_cparams);
+                    for (auto & retract_block : retract_blocks)
+                    {
+                        auto rows = retract_block.rows();
+                        retract_block.insert(
+                            ColumnWithTypeAndName{ColumnInt8::create(rows, static_cast<Int8>(-1)), delta_col_type, "_tp_delta"});
+                        retract_block.setRetract();
+                    }
+
+                    blocks.splice(blocks.end(), std::move(retract_blocks));
+                }
             }
         }
 

--- a/tests/cluster/smoke/0012_multishards8_emit/3_multishards_global_aggr_emit_changelog.yaml
+++ b/tests/cluster/smoke/0012_multishards8_emit/3_multishards_global_aggr_emit_changelog.yaml
@@ -73,7 +73,6 @@ steps:
   - type: check
     target_name: multishards-3-1
     expected_result:
-    - [0, 0, 0, -1]
     - [1, 1, 1, 1]
     - [1, 1, 1, -1]
     - [1, 1, 2, 1]

--- a/tests/queries_ported/0_stateless/99103_aggr_with_emit_changelog.reference
+++ b/tests/queries_ported/0_stateless/99103_aggr_with_emit_changelog.reference
@@ -25,8 +25,19 @@
 3	1	1
 
 === Multi-shard aggr with emit changelog results ===
->>> Pure memory aggr without key: ❌ (FIXME)
->>> Pure memory aggr: ❌ (FIXME)
+>>> Pure memory aggr without key:
+1	1	1	1
+1	1	1	-1
+1	1	2	1
+1	1	2	-1
+1	2	5	1
+>>> Pure memory aggr:
+1	k1	k1	1	1
+1	k1	k1	1	-1
+1	k1	k2	2	1
+1	k1	k2	2	-1
+1	k1	k3	3	1
+2	t1	t2	2	1
 >>> Hybrid aggr without key:
 1	1	1	1
 1	1	1	-1

--- a/tests/queries_ported/0_stateless/99103_aggr_with_emit_changelog.sql
+++ b/tests/queries_ported/0_stateless/99103_aggr_with_emit_changelog.sql
@@ -49,8 +49,8 @@ drop view if exists 99103_mv3;
 drop view if exists 99103_mv4;
 drop stream if exists 99103_stream;
 create stream 99103_stream(i int, k string) settings shards=3, flush_threshold_count=1;
--- create materialized view 99103_mv as select min(i), max(i), count(), _tp_delta from 99103_stream emit changelog periodic 3s STORAGE_SETTINGS flush_threshold_count=1;
--- create materialized view 99103_mv2 as select i, min(k), max(k), count(), _tp_delta from 99103_stream group by i emit changelog periodic 3s STORAGE_SETTINGS flush_threshold_count=1;
+create materialized view 99103_mv as select min(i), max(i), count(), _tp_delta from 99103_stream emit changelog periodic 3s STORAGE_SETTINGS flush_threshold_count=1;
+create materialized view 99103_mv2 as select i, min(k), max(k), count(), _tp_delta from 99103_stream group by i emit changelog periodic 3s STORAGE_SETTINGS flush_threshold_count=1;
 create materialized view 99103_mv3 as select min(i), max(i), count(), _tp_delta from 99103_stream emit changelog periodic 3s settings default_hash_table='hybrid',max_hot_keys=2 STORAGE_SETTINGS flush_threshold_count=1;
 create materialized view 99103_mv4 as select i, min(k), max(k), count(), _tp_delta from 99103_stream group by i emit changelog periodic 3s settings default_hash_table='hybrid',max_hot_keys=2 STORAGE_SETTINGS flush_threshold_count=1;
 
@@ -59,12 +59,12 @@ insert into 99103_stream(i, k) values (1, 'k1');
 select sleep(3) format Null;
 insert into 99103_stream(i, k) values (1, 'k2');
 -- Validate checkpoint
--- system pause materialized view 99103_mv;
--- system pause materialized view 99103_mv2;
+system pause materialized view 99103_mv;
+system pause materialized view 99103_mv2;
 system pause materialized view 99103_mv3;
 system pause materialized view 99103_mv4;
--- system resume materialized view 99103_mv;
--- system resume materialized view 99103_mv2;
+system resume materialized view 99103_mv;
+system resume materialized view 99103_mv2;
 system resume materialized view 99103_mv3;
 system resume materialized view 99103_mv4;
 select sleep(1) format Null;
@@ -73,17 +73,17 @@ insert into 99103_stream(i, k) values (1, 'k3')(2, 't1')(2, 't2');
 select sleep(3) format Null;
 select sleep(1) format Null;
 
-select '>>> Pure memory aggr without key: ❌ (FIXME)';
--- select * except _tp_time from table(99103_mv) order by _tp_sn; --- bug issue: https://github.com/timeplus-io/proton-enterprise/issues/10137
-select '>>> Pure memory aggr: ❌ (FIXME)';
--- select * except _tp_time from table(99103_mv2) order by _tp_sn, i;
+select '>>> Pure memory aggr without key:';
+select * except _tp_time from table(99103_mv) order by _tp_sn;
+select '>>> Pure memory aggr:';
+select * except _tp_time from table(99103_mv2) order by _tp_sn, i;
 select '>>> Hybrid aggr without key:';
 select * except _tp_time from table(99103_mv3) order by _tp_sn;
 select '>>> Hybrid aggr:';
 select * except _tp_time from table(99103_mv4) order by _tp_sn, i;
 
--- drop view if exists 99103_mv;
--- drop view if exists 99103_mv2;
+drop view if exists 99103_mv;
+drop view if exists 99103_mv2;
 drop view if exists 99103_mv3;
 drop view if exists 99103_mv4;
 drop stream if exists 99103_stream;


### PR DESCRIPTION
## Problem

Global / multi-shard streaming aggregation with `EMIT CHANGELOG` could emit a phantom retract row (e.g. `(…, 0, -1)`) on the first changelog cycle. When no shard has produced a retract yet, `mergeRetractGroups` bails and leaves the merged `without_key` state at its init-empty value; converting that as `Normal` produced a spurious negative-delta row.

## Fix

- Skip the `without_key` conversion when the merged retract state is empty.
- Use `UpdatesAfterRetract` for the keyed path, so freshly-inserted keys with no carry-over from other shards are filtered out instead of being retracted.

## Tests

- Re-enables the previously-disabled pure-memory aggregation cases (with and without key) in `99103_aggr_with_emit_changelog` and drops the phantom row from the multishard smoke expectation.
- `./run-sql-tests.sh 99103_aggr_with_emit_changelog` → **OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)