### PR TITLE
fix: throw bad_alloc on failed ByteVector allocation instead of NULL deref

### DIFF
--- a/src/Cluster/Base/ByteVector.h
+++ b/src/Cluster/Base/ByteVector.h
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <memory>
+#include <new>
 #include <string_view>
 #include <boost/core/noncopyable.hpp>
 
@@ -52,9 +53,13 @@ public:
     explicit ByteVector(size_t reserved) : mem(nullptr, std::free), cap(reserved), siz(reserved)
     {
         if (reserved)
+        {
             /// If `reserved` is 0, it is undefined if std::malloc will return an nullptr or a
             /// one byte memory addr. So only call malloc when `reserved` is not zero.
             mem.reset(static_cast<char *>(std::malloc(reserved)));
+            if (!mem)
+                throw std::bad_alloc();
+        }
     }
 
     explicit ByteVector(std::string_view data) : ByteVector(data.size())

--- a/src/Cluster/Base/tests/gtest_bytevector.cpp
+++ b/src/Cluster/Base/tests/gtest_bytevector.cpp
@@ -1,6 +1,10 @@
 #include <Cluster/Base/ByteVector.h>
 
+#include <base/defines.h>
+
+#include <cstdint>
 #include <cstring>
+#include <new>
 
 #include <gtest/gtest.h>
 
@@ -69,4 +73,35 @@ TEST(ByteVector, Release)
 
     EXPECT_EQ(cache.data(), nullptr);
     EXPECT_EQ(cache.size(), 0);
+}
+
+namespace
+{
+/// Force a genuine, failing allocation. A release build would otherwise elide the unused malloc/free
+/// pair, assume the allocation succeeded, and drop the null-check (and its throw). The empty asm with
+/// a memory clobber consumes the buffer so the optimizer must keep the real malloc; `reserved` stays
+/// opaque behind the non-inlinable boundary so the call is not constant-folded.
+[[gnu::noinline]] void allocateReserved(size_t reserved)
+{
+    cluster::ByteVector bytes(reserved);
+    char * data = bytes.data();
+    __asm__ __volatile__("" : : "r"(data) : "memory");
+}
+}
+
+TEST(ByteVector, ThrowsBadAllocOnFailedReserve)
+{
+    /// A reservation that the allocator cannot satisfy must surface as std::bad_alloc rather than
+    /// leaving the ByteVector with a null buffer that later NULL-derefs (e.g. on a torn-WAL read of
+    /// a garbage size).
+#if defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER)
+    /// These sanitizers replace the allocator and abort on the oversized malloc by default
+    /// (allocator_may_return_null=0) instead of returning null, so the failure path is covered by the
+    /// plain and UBSan builds rather than forcing a binary-wide allocator option. The ADDRESS_/
+    /// THREAD_/MEMORY_SANITIZER macros come from <base/defines.h>, which must be included for the
+    /// guard to fire.
+    GTEST_SKIP() << "oversized malloc aborts under the sanitizer allocator; covered in plain builds";
+#else
+    EXPECT_THROW(allocateReserved(SIZE_MAX), std::bad_alloc);
+#endif
 }


### PR DESCRIPTION
Check the `malloc` result in `ByteVector(size_t)` and throw `std::bad_alloc` on failure instead of leaving a null buffer for a later NULL-deref (e.g. on a torn-log read of a garbage size). Adds a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)