### PR TITLE
ci: declare AWS_ACCESS_KEY_ID in compatibility_test workflow_call

### DIFF
--- a/.github/workflows/compatibility_test.yml
+++ b/.github/workflows/compatibility_test.yml
@@ -71,6 +71,8 @@ on:
         type: string
         default: "3"
     secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
       AWS_REGION:


### PR DESCRIPTION
Fixes #1191.

## Problem

`NightlyTest` fails immediately with `startup_failure` — GitHub rejects the workflow file before any job runs. `proton_ci` is unaffected.

`nightly_test.yml` is the only workflow that calls the reusable `compatibility_test.yml`, and its call passes `AWS_ACCESS_KEY_ID` in the `secrets:` block. But `compatibility_test.yml`'s `on.workflow_call.secrets` no longer **declared** that secret. Passing a secret the callee doesn't declare is a startup-time validation error in GitHub Actions, and it fires even though the compatibility job is guarded by `if: false` (interface validation happens at workflow-compile time, before `if` is evaluated). That aborts the whole run.

`proton_ci` only calls `run_command.yml`, which already declares `AWS_ACCESS_KEY_ID`, so it never hits the mismatch.

## Fix

Restore the `AWS_ACCESS_KEY_ID` declaration in `compatibility_test.yml`'s `workflow_call.secrets`, realigning the callee interface with what `nightly_test.yml` already passes (matches the last known-good state).

```diff
     secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
```

## Verification

- YAML parses; `workflow_call.secrets` now includes `AWS_ACCESS_KEY_ID`.
- After merge, re-run `NightlyTest` via `workflow_dispatch` and confirm jobs start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)