### PR TITLE
fix(test): silence -Wunused-function for allocateReserved in sanitizer builds

### DIFF
--- a/src/Cluster/Base/tests/gtest_bytevector.cpp
+++ b/src/Cluster/Base/tests/gtest_bytevector.cpp
@@ -81,7 +81,8 @@ namespace
 /// pair, assume the allocation succeeded, and drop the null-check (and its throw). The empty asm with
 /// a memory clobber consumes the buffer so the optimizer must keep the real malloc; `reserved` stays
 /// opaque behind the non-inlinable boundary so the call is not constant-folded.
-[[gnu::noinline]] void allocateReserved(size_t reserved)
+/// Unused under the sanitizer builds below, where the only caller is compiled out.
+[[maybe_unused]] [[gnu::noinline]] void allocateReserved(size_t reserved)
 {
     cluster::ByteVector bytes(reserved);
     char * data = bytes.data();


### PR DESCRIPTION
## Problem

The sanitizer build (`-fsanitize=address`) fails to compile `unit_tests_dbms`:

```
src/Cluster/Base/tests/gtest_bytevector.cpp:84:24: error: unused function 'allocateReserved' [-Werror,-Wunused-function]
   84 | [[gnu::noinline]] void allocateReserved(size_t reserved)
      |                        ^~~~~~~~~~~~~~~~
```

`allocateReserved` (added in #1192) is referenced only from the `#else` branch of the `ByteVector.ThrowsBadAllocOnFailedReserve` test's sanitizer guard. Under ASan/TSan/MSan that branch is `GTEST_SKIP`'d and preprocessed away, leaving the function defined but never called. clang's `-Werror,-Wunused-function` then rejects the translation unit. The plain and UBSan builds compile the `#else`, so only the sanitizer builds break.

## Fix

Mark the helper `[[maybe_unused]]` — the standard-C++ way to express "dead in some build configs." It suppresses the warning when the sole caller is compiled out and is a no-op when it's present. The `[[gnu::noinline]]` attribute is left intact: it serves a different purpose (keeping the `malloc(SIZE_MAX)` opaque/un-constant-folded at `-O2`/`-O3` so the failure path is genuinely exercised).

## Verification

Reproduced with `clang++-21` and the CI warning flags on a minimal TU:
- **With** `[[maybe_unused]]` under `-DADDRESS_SANITIZER` (caller compiled out): compiles clean.
- **Without** it: the exact `-Wunused-function` error reproduces.

Follow-up to #1192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)