### PR TITLE
fix build(missing header include in PostgreSQLHandlerFactory.cpp)

### DIFF
--- a/src/Server/PostgreSQLHandlerFactory.cpp
+++ b/src/Server/PostgreSQLHandlerFactory.cpp
@@ -1,7 +1,6 @@
 #include "PostgreSQLHandlerFactory.h"
-#include <memory>
-#include <filesystem>
 #include <Server/PostgreSQLHandler.h>
+#include <Poco/Util/LayeredConfiguration.h>
 
 namespace DB
 {


### PR DESCRIPTION
follow up #1197

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
