### PR TITLE
fix(ci): unblock darwin cross-compile release builds

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -397,7 +397,9 @@ jobs:
     uses: timeplus-io/proton/.github/workflows/run_command.yml@develop
     with:
       ec2-instance-type: c6i.8xlarge
-      ec2-image-id: ami-042a37e33a285c22b
+      # Use the same x86_64 runner AMI as the native Linux build to avoid older Docker/seccomp profiles
+      # that can break container builds (e.g. `ninja: fatal: posix_spawn: Operation not permitted`).
+      ec2-image-id: ${{ vars.X64_AMI }}
       submodules: 'true'
       run_mode: 'start' # start ec2 on demand instance
       upload_files: |
@@ -428,6 +430,10 @@ jobs:
         echo "max_size = 100.0G" > $GITHUB_WORKSPACE/ccache/ccache.conf
 
         # compiling
+        # NOTE: some older Docker/seccomp profiles block `clone3`, which breaks glibc `posix_spawn`
+        # inside Ubuntu 22.04-based builder images (observed as: `ninja: fatal: posix_spawn: Operation not permitted`).
+        # Keep this scoped to the darwin cross-compile builder container.
+        export PACKAGER_DOCKER_RUN_ARGS="--security-opt seccomp=unconfined"
         ./docker/packager/packager --package-type binary --docker-image-version clang-21 --build-type release --proton-build --disable-python-udf --cache ccache --ccache_dir $GITHUB_WORKSPACE/ccache --output-dir $GITHUB_WORKSPACE/output --compiler clang-21-darwin
 
         if [ ! -f "$GITHUB_WORKSPACE/output/proton" ]; then
@@ -504,6 +510,8 @@ jobs:
         echo "max_size = 100.0G" > $GITHUB_WORKSPACE/ccache/ccache.conf
 
         # compiling
+        # See Build_Darwin_X86_64 for why this is needed on some runners.
+        export PACKAGER_DOCKER_RUN_ARGS="--security-opt seccomp=unconfined"
         ./docker/packager/packager --package-type binary --docker-image-version clang-21 --build-type release --proton-build --disable-python-udf --cache ccache --ccache_dir $GITHUB_WORKSPACE/ccache --output-dir $GITHUB_WORKSPACE/output --compiler clang-21-darwin-aarch64
         if [ ! -f "$GITHUB_WORKSPACE/output/proton" ]; then
           echo "Compiling proton Failed"

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -49,13 +49,18 @@ def run_docker_image_with_env(image_name, output, env_variables, ch_root, ccache
     else:
         interactive = ""
 
-    cmd = "docker run --network=host --rm --volume={output_path}:/output --volume={ch_root}:/build --volume={ccache_dir}:/ccache {env} {interactive} {img_name}".format(
+    docker_run_args = os.environ.get("PACKAGER_DOCKER_RUN_ARGS", "").strip()
+    if docker_run_args:
+        docker_run_args = " " + docker_run_args
+
+    cmd = "docker run{docker_run_args} --network=host --rm --volume={output_path}:/output --volume={ch_root}:/build --volume={ccache_dir}:/ccache {env} {interactive} {img_name}".format(
         output_path=output,
         ch_root=ch_root,
         ccache_dir=ccache_dir,
         env=env_part,
         img_name=image_name + ":" + docker_image_version,
-        interactive=interactive
+        interactive=interactive,
+        docker_run_args=docker_run_args,
     )
 
     logging.info("Will build ClickHouse pkg with cmd: '{}'".format(cmd))


### PR DESCRIPTION
## Problem

`release_build` fails in `Build_Darwin_X86_64` before a single source file is compiled ([run 30727288045](https://github.com/timeplus-io/proton/actions/runs/30727288045/job/91441671621)):

```
-- Check for working C compiler: /usr/bin/clang-21 - broken
    Run Build Command(s): /usr/bin/ninja -v cmTC_84cf3
    ninja: fatal: posix_spawn: Operation not permitted
-- Configuring incomplete, errors occurred!
```

The other three build jobs in that run were only cancelled by fail-fast, not broken.

## Cause

The darwin cross-compile jobs pin an older runner AMI (`ami-042a37e33a285c22b`). The builder image moved to an Ubuntu 22.04 base (glibc 2.35) as part of the clang-21 toolchain migration, and glibc 2.34+ has `posix_spawn` issue `clone3` first. The older Docker/seccomp profile on that AMI answers unknown syscalls with `EPERM` rather than `ENOSYS`, so glibc's fallback to `clone` never triggers and ninja cannot spawn any child process.

Confirming evidence from the same failing run: the identical image digest (`sha256:6075e6c6…`) ran ninja fine on the Linux arm64 runner, which uses a different AMI. `Build_Linux_X86_64` is unaffected because it already resolves its runner through `vars.X64_AMI`.

## Changes

- `docker/packager/packager` — add a `PACKAGER_DOCKER_RUN_ARGS` passthrough for extra `docker run` flags. When unset, the constructed command is byte-identical to before.
- `.github/workflows/release_build.yml`
  - `Build_Darwin_X86_64` now uses `${{ vars.X64_AMI }}`, the same runner the native Linux x86_64 build already uses.
  - Both darwin cross-compile jobs export `PACKAGER_DOCKER_RUN_ARGS="--security-opt seccomp=unconfined"`, so the fix holds regardless of runner age. Scoped to the cross-compile builder container only.

## Verification

- `yaml.safe_load` on the workflow: OK
- `py_compile` on the packager: OK
- Command construction checked both ways:
  - unset → `docker run --network=host --rm …` (unchanged)
  - set → `docker run --security-opt seccomp=unconfined --network=host --rm …`

Real validation is the next `release_build` run.