### PR TITLE
fix(ci): unblock the manual darwin x86_64 cross-compile build

### DIFF
--- a/.github/workflows/manual_trigger_build.yml
+++ b/.github/workflows/manual_trigger_build.yml
@@ -346,7 +346,9 @@ jobs:
     uses: timeplus-io/proton/.github/workflows/run_command.yml@develop
     with:
       ec2-instance-type: c6i.8xlarge
-      ec2-image-id: ami-042a37e33a285c22b
+      # Use the same x86_64 runner AMI as the native Linux build to avoid older Docker/seccomp profiles
+      # that can break container builds (e.g. `ninja: fatal: posix_spawn: Operation not permitted`).
+      ec2-image-id: ${{ vars.X64_AMI }}
       submodules: 'true'
       run_mode: 'start'
       s3_upload: true
@@ -371,6 +373,10 @@ jobs:
         chmod a+x $GITHUB_WORKSPACE/contrib/v8-cmake/torque
 
         # compiling
+        # NOTE: some older Docker/seccomp profiles block `clone3`, which breaks glibc `posix_spawn`
+        # inside Ubuntu 22.04-based builder images (observed as: `ninja: fatal: posix_spawn: Operation not permitted`).
+        # Keep this scoped to the darwin cross-compile builder container.
+        export PACKAGER_DOCKER_RUN_ARGS="--security-opt seccomp=unconfined"
         ./docker/packager/packager --package-type binary --docker-image-version clang-21 --build-type release --proton-build --disable-python-udf --cache ccache --ccache_dir $GITHUB_WORKSPACE/ccache --output-dir $GITHUB_WORKSPACE/output --compiler clang-21-darwin
 
         if [ ! -f "$GITHUB_WORKSPACE/output/proton" ]; then


### PR DESCRIPTION
Follow-up to #1207, which fixed `release_build.yml` but missed the same job in `manual_trigger_build.yml`.

## Problem

`Build_macOS_X86_64` in `manual_trigger_build.yml` still pinned the older runner AMI (`ami-042a37e33a285c22b`) and did not pass the seccomp option, so a manual **macos / x64** build dies in cmake configure before compiling anything:

```
-- Check for working C compiler: /usr/bin/clang-21 - broken
    ninja: fatal: posix_spawn: Operation not permitted
```

Older Docker/seccomp profiles answer `clone3` with `EPERM` rather than `ENOSYS`, so glibc 2.34+'s `posix_spawn` never falls back and ninja cannot spawn a child process inside the Ubuntu 22.04-based builder image.

`Build_macOS_arm` is unaffected — it runs natively on a `[self-hosted, macOS, ARM64]` runner, no container involved.

## Changes

- `Build_macOS_X86_64` uses `${{ vars.X64_AMI }}`, the same runner the native Linux x86_64 build already uses.
- Exports `PACKAGER_DOCKER_RUN_ARGS="--security-opt seccomp=unconfined"` before the packager call, scoped to that container.

Identical to what #1207 did for the two darwin jobs in `release_build.yml`. The `PACKAGER_DOCKER_RUN_ARGS` passthrough in `docker/packager/packager` already landed with that PR, so no change is needed there.

## Verification

- `yaml.safe_load` on the workflow: OK
- Swept every darwin cross-compile packager invocation across `.github/workflows/`; all three now carry the export:

```
manual_trigger_build.yml:380  seccomp=YES
release_build.yml:437         seccomp=YES
release_build.yml:515         seccomp=YES
```

Real validation is a manual macos/x64 run.