### PR TITLE
fix(metrics): freeze the disk_utils key set after the first collection

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4432,19 +4432,25 @@ void Context::setCPUUsage(double cpu_usage) noexcept
     Globals::getServerDescriptor().cpu_usage.store(cpu_usage, std::memory_order_relaxed);
 }
 
-void Context::updateDiskUsage(const String & name, UInt64 total_bytes, UInt64 available_bytes, bool) noexcept
+void NO_SANITIZE_THREAD
+Context::updateDiskUsage(const String & name, UInt64 total_bytes, UInt64 available_bytes, bool first_run) noexcept
 {
-    if (total_bytes > 0)
-    {
-        /// No lock needed - intentional design to avoid slowing the system
-        /// The disk volumes are populated at startup and keys don't change
-        ServerDescriptor::DiskStats stats;
-        stats.total_mb = total_bytes / (1024 * 1024);
-        stats.free_mb = available_bytes / (1024 * 1024);
-        stats.util = 1.0 - (static_cast<double>(available_bytes) / total_bytes);
+    if (total_bytes == 0)
+        return;
 
-        Globals::getServerDescriptor().disk_utils[name] = stats;
-    }
+    /// Only update on the first run, or for a disk name already seen on the first run.
+    /// A disk added later (CREATE DISK) would insert a key and could rehash disk_utils while
+    /// checkDiskUtil() walks it on an ingest thread, so we don't report it until a restart.
+    auto & server = Globals::getServerDescriptor();
+    if (!first_run && !server.disk_utils.contains(name))
+        return;
+
+    ServerDescriptor::DiskStats stats;
+    stats.total_mb = total_bytes / (1024 * 1024);
+    stats.free_mb = available_bytes / (1024 * 1024);
+    stats.util = 1.0 - (static_cast<double>(available_bytes) / total_bytes);
+
+    server.disk_utils[name] = stats;
 }
 
 void NO_SANITIZE_THREAD


### PR DESCRIPTION
`updateDiskUsage()` took a `first_run` flag and ignored it, then did an unconditional `disk_utils[name] = stats`. `disk_utils` is read without a lock, which is only sound if the key set never changes, and it does change: local disks can be created at runtime via CREATE DISK, so the next AsynchronousMetrics cycle inserts a new key and can rehash the map.

The reader is not a cold path. `Context::checkDiskUtil()` walks `disk_utils` from `checkIngest()`, which `StorageStream::write()` calls on every INSERT. Rehashing during that iteration is undefined behavior, unlike the races on the values, which are intentional and kept.

Use the flag, and mark the function NO_SANITIZE_THREAD. This restores the guard the same collection path already applies to `disk_io_stats`; a disk added after startup is not reported until a restart.

PR checklist:
- Did you run ClangFormat ?
- Did you separate headers to a different section in existing community code base ?
- Did you surround `proton: starts/ends` for new code in existing community code base ?

Please write user-readable short description of the changes:
