### PR TITLE
ci: move native macOS arm64 builds to GitHub-hosted runners

### DIFF
--- a/.github/workflows/manual_trigger_build.yml
+++ b/.github/workflows/manual_trigger_build.yml
@@ -408,10 +408,32 @@ jobs:
 
   Build_macOS_arm:
     if: github.event.inputs.OS == 'macos' && github.event.inputs.arch == 'arm'
-    runs-on: [self-hosted, macOS, ARM64]
+    # GitHub-hosted Apple Silicon larger runner (M2 Pro, 5 vCPU, 14 GB RAM).
+    # Largest arm64 tier GitHub offers; the 12-core "large" tier is Intel-only,
+    # so it cannot native-compile arm64.
+    runs-on: macos-26-xlarge
+    # GitHub-hosted jobs hard-stop at 360 min; 350 leaves margin for the
+    # always()-guarded ccache upload below the 300-min build guard.
+    timeout-minutes: 350
+    # The cache object below is a single shared key, so concurrent runs would
+    # race on save and the loser's work would be discarded. Queue instead of
+    # cancelling: a run that reaches the save step is what warms the next one.
+    concurrency:
+      group: build-macos-arm-ccache
+      cancel-in-progress: false
     env:
       build_directory: ${{ github.workspace }}/build
       build_type: RelWithDebInfo
+      # Hosted runners are ephemeral and this job previously had no ccache at
+      # all, which only worked because a persistent machine kept its build tree
+      # between runs. The cache now round-trips through S3. Uncompressed .tar on
+      # purpose: ccache 4.x already compresses its entries, so gzip would only
+      # cost single-threaded CPU on both ends.
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_MAXSIZE: 10G
+      CCACHE_COMPILERCHECK: content
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      MACOS_CCACHE_S3: s3://timeplus-ci-internal/proton-oss/cache-macos-arm-native.tar
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.1
@@ -423,16 +445,111 @@ jobs:
       - name: Get MacOS version
         run: sw_vers
 
+      # GitHub documents this runner as having 14 GB of free SSD; in practice
+      # the image is a 320 GB volume with ~87 GB free, and this cleanup takes it
+      # to ~116 GB. Keep both the cleanup and the assertion: the documented
+      # figure is what GitHub is entitled to shrink to, and failing here costs
+      # two minutes instead of hitting ENOSPC hours into the build.
+      - name: Free disk space
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          DEFAULT_XCODE="$(dirname "$(dirname "$(xcode-select -p)")")"
+          echo "Keeping default Xcode: $DEFAULT_XCODE"
+          for x in /Applications/Xcode*.app; do
+            if [ "$(readlink -f "$x")" = "$(readlink -f "$DEFAULT_XCODE")" ]; then
+              continue
+            fi
+            echo "Removing $x"
+            sudo rm -rf "$x" &
+          done
+          wait
+          sudo xcrun simctl runtime delete all 2>/dev/null || true
+          echo "Disk after cleanup:"
+          df -h /
+
+          REQUIRED_GB=40
+          AVAIL_GB=$(df -k "$GITHUB_WORKSPACE" | awk 'NR==2 {print int($4/1024/1024)}')
+          echo "Available after cleanup: ${AVAIL_GB} GB (need ${REQUIRED_GB} GB)"
+          if [ "$AVAIL_GB" -lt "$REQUIRED_GB" ]; then
+            echo "::error::Only ${AVAIL_GB} GB free after cleanup, need ${REQUIRED_GB} GB. The runner image likely changed what it preinstalls; extend this step or move the job to a runner with more disk."
+            exit 1
+          fi
+
+      # The image already ships CMake, Ninja, gh and AWS CLI. llvm@21 is pinned
+      # as a versioned formula so `brew --prefix llvm@21` stays valid when the
+      # image's unversioned llvm moves past 21. coreutils provides gtimeout for
+      # the build guard; findutils and grep provide the gfind/ggrep that
+      # cmake/tools.cmake hard-requires on Darwin and that the macOS userland
+      # does not include.
+      - name: Install toolchain
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          brew install llvm@21 ccache coreutils findutils grep
+          "$(brew --prefix llvm@21)/bin/clang" --version
+          ccache --version | head -1
+          gtimeout --version | head -1
+          gfind --version | head -1
+          ggrep --version | head -1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # Streamed rather than downloaded-then-extracted, which keeps the archive
+      # off the disk budget entirely.
+      - name: Restore ccache from S3
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          if aws s3 cp --no-progress "$MACOS_CCACHE_S3" - | tar -xf - -C "$CCACHE_DIR"; then
+            echo "Restored ccache from S3"
+            du -sh "$CCACHE_DIR"
+          else
+            echo "No ccache archive in S3 yet - cold build"
+          fi
+
       - name: Create and Configure Build
         run: |
           mkdir -p ${{ env.build_directory }}
           export CC=$(brew --prefix llvm@21)/bin/clang
           export CXX=$(brew --prefix llvm@21)/bin/clang++
           export PATH=$(brew --prefix llvm@21)/bin:$PATH
-          cmake -B ${{ env.build_directory }} -G "Ninja" -DCMAKE_BUILD_TYPE=${{ env.build_type }} -DENABLE_TESTS=OFF -DENABLE_UTILS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_PULSAR=ON
+          # CMAKE_OSX_DEPLOYMENT_TARGET pins the binary's minimum macOS at
+          # 11.0, which is what the previous builder produced: `vtool
+          # -show-build` on the released Darwin-arm64 binary reports minos 11.0.
+          # Left unset it would follow the runner image's much newer SDK and
+          # silently drop users on macOS 11-14.
+          #
+          # CMAKE_*_FLAGS_ADD is appended after DEBUG_INFO_FLAGS in the root
+          # CMakeLists.txt, so -g0 wins and turns debug info off. Debug info is
+          # ~89% of object bytes in this configuration, so this is the
+          # difference between a ~45 GB and an ~8 GB build tree, and it shrinks
+          # the cache by the same factor. Nothing is lost: this job publishes
+          # only the stripped binary, so the DWARF was already discarded.
+          cmake -B ${{ env.build_directory }} -G "Ninja" -DCMAKE_BUILD_TYPE=${{ env.build_type }} -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_CXX_FLAGS_ADD=-g0 -DCMAKE_C_FLAGS_ADD=-g0 -DCMAKE_ASM_FLAGS_ADD=-g0 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_TESTS=OFF -DENABLE_UTILS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_PULSAR=ON
 
+      # A fully cold build can outlive the 6h job limit, and a killed job
+      # uploads nothing, so it would never converge. The guard turns "would
+      # have been killed" into a controlled failure that still reaches the
+      # always()-guarded cache save, so one or two re-runs bootstrap a warm
+      # cache from nothing.
       - name: Build with Ninja
-        run: cmake --build ${{ env.build_directory }}
+        run: |
+          rc=0
+          gtimeout 300m cmake --build ${{ env.build_directory }} || rc=$?
+          if [ "$rc" = "124" ]; then
+            echo "::warning::Build exceeded the 300-minute guard. The ccache accumulated so far is uploaded by the 'Save ccache to S3' step - re-run to continue from it."
+          fi
+          exit $rc
+
+      # Surface hit rate so cold-vs-warm builds are visible at a glance.
+      - name: ccache stats
+        if: always()
+        run: ccache -sv || true
 
       - name: Process Binary
         run: |
@@ -446,7 +563,7 @@ jobs:
 
           if [ "${{ github.event.inputs.strip_binary }}" == "true" ]; then
             echo "Stripping the binary..."
-            /opt/homebrew/opt/llvm@21/bin/llvm-strip $ORIGINAL_BINARY -o $STRIPPED_BINARY
+            "$(brew --prefix llvm@21)/bin/llvm-strip" $ORIGINAL_BINARY -o $STRIPPED_BINARY
             echo "Stripped binary size:"
             ls -lh $STRIPPED_BINARY
           else
@@ -469,12 +586,17 @@ jobs:
           echo "TARBALL_NAME=$TARBALL_NAME" >> $GITHUB_ENV
           echo "TARBALL_PATH=$TARBALL_PATH" >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # The minimum supported macOS lives in a Mach-O load command and shows up
+      # in no build output anyone reads, so raising it is silent. Assert it.
+      - name: Verify deployment target
+        run: |
+          EXPECTED=11.0
+          ACTUAL=$(vtool -show-build "$BINARY_PATH" | awk '/^ *minos/ {print $2; exit}')
+          echo "minos=$ACTUAL (expected $EXPECTED)"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Binary's minimum macOS is $ACTUAL, expected $EXPECTED. Changing the floor is a product decision -- update CMAKE_OSX_DEPLOYMENT_TARGET and this check together."
+            exit 1
+          fi
 
       - name: Upload Artifact To S3 (tar.gz)
         run: |
@@ -516,3 +638,17 @@ jobs:
         run: |
           TARBALL=${{ env.TARBALL_PATH }}
           shasum -a 256 "$TARBALL"
+
+      # Runs on success, build failure and the build guard alike, so even a
+      # partial compile warms the next run. Placed last so a failed upload
+      # cannot block the artifact steps above.
+      - name: Save ccache to S3
+        if: always()
+        run: |
+          if [ -d "$CCACHE_DIR" ] && [ -n "$(ls -A "$CCACHE_DIR" 2>/dev/null)" ]; then
+            ccache -sv || true
+            du -sh "$CCACHE_DIR"
+            tar -cf - -C "$CCACHE_DIR" . | aws s3 cp --no-progress - "$MACOS_CCACHE_S3"
+          else
+            echo "ccache dir empty - nothing to save"
+          fi

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -548,10 +548,32 @@ jobs:
 
   Build_Native_Darwin_arm64:
     needs: Build_Linux_X86_64 # Gate the job behind the Linux x86_64 job so the release exists before uploads.
-    runs-on: [self-hosted, macOS, ARM64]
+    # GitHub-hosted Apple Silicon larger runner (M2 Pro, 5 vCPU, 14 GB RAM).
+    # Largest arm64 tier GitHub offers; the 12-core "large" tier is Intel-only,
+    # so it cannot native-compile arm64.
+    runs-on: macos-26-xlarge
+    # GitHub-hosted jobs hard-stop at 360 min; 350 leaves margin for the
+    # always()-guarded ccache upload below the 300-min build guard.
+    timeout-minutes: 350
+    # The cache object below is a single shared key, so concurrent runs would
+    # race on save and the loser's work would be discarded. Queue instead of
+    # cancelling: a run that reaches the save step is what warms the next one.
+    concurrency:
+      group: release-macos-arm-ccache
+      cancel-in-progress: false
     env:
       build_directory: ${{ github.workspace }}/build
       build_type: RelWithDebInfo
+      # Hosted runners are ephemeral and this job previously had no ccache at
+      # all, which only worked because a persistent machine kept its build tree
+      # between runs. The cache now round-trips through S3. Uncompressed .tar on
+      # purpose: ccache 4.x already compresses its entries, so gzip would only
+      # cost single-threaded CPU on both ends.
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_MAXSIZE: 10G
+      CCACHE_COMPILERCHECK: content
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      MACOS_CCACHE_S3: s3://timeplus-ci-internal/proton-oss/cache-macos-arm-native.tar
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.1
@@ -569,6 +591,73 @@ jobs:
           echo "Checking out tag $LATEST_TAG"
           git checkout $LATEST_TAG
           echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+      # GitHub documents this runner as having 14 GB of free SSD; in practice
+      # the image is a 320 GB volume with ~87 GB free, and this cleanup takes it
+      # to ~116 GB. Keep both the cleanup and the assertion: the documented
+      # figure is what GitHub is entitled to shrink to, and failing here costs
+      # two minutes instead of hitting ENOSPC hours into the build.
+      - name: Free disk space
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          DEFAULT_XCODE="$(dirname "$(dirname "$(xcode-select -p)")")"
+          echo "Keeping default Xcode: $DEFAULT_XCODE"
+          for x in /Applications/Xcode*.app; do
+            if [ "$(readlink -f "$x")" = "$(readlink -f "$DEFAULT_XCODE")" ]; then
+              continue
+            fi
+            echo "Removing $x"
+            sudo rm -rf "$x" &
+          done
+          wait
+          sudo xcrun simctl runtime delete all 2>/dev/null || true
+          echo "Disk after cleanup:"
+          df -h /
+
+          REQUIRED_GB=40
+          AVAIL_GB=$(df -k "$GITHUB_WORKSPACE" | awk 'NR==2 {print int($4/1024/1024)}')
+          echo "Available after cleanup: ${AVAIL_GB} GB (need ${REQUIRED_GB} GB)"
+          if [ "$AVAIL_GB" -lt "$REQUIRED_GB" ]; then
+            echo "::error::Only ${AVAIL_GB} GB free after cleanup, need ${REQUIRED_GB} GB. The runner image likely changed what it preinstalls; extend this step or move the job to a runner with more disk."
+            exit 1
+          fi
+
+      # The image already ships CMake, Ninja, gh and AWS CLI. llvm@21 is pinned
+      # as a versioned formula so `brew --prefix llvm@21` stays valid when the
+      # image's unversioned llvm moves past 21. coreutils provides gtimeout for
+      # the build guard; findutils and grep provide the gfind/ggrep that
+      # cmake/tools.cmake hard-requires on Darwin and that the macOS userland
+      # does not include.
+      - name: Install toolchain
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          brew install llvm@21 ccache coreutils findutils grep
+          "$(brew --prefix llvm@21)/bin/clang" --version
+          ccache --version | head -1
+          gtimeout --version | head -1
+          gfind --version | head -1
+          ggrep --version | head -1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # Streamed rather than downloaded-then-extracted, which keeps the archive
+      # off the disk budget entirely.
+      - name: Restore ccache from S3
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          if aws s3 cp --no-progress "$MACOS_CCACHE_S3" - | tar -xf - -C "$CCACHE_DIR"; then
+            echo "Restored ccache from S3"
+            du -sh "$CCACHE_DIR"
+          else
+            echo "No ccache archive in S3 yet - cold build"
+          fi
+
 
       # Setup build environment and configure CMake
       - name: Create and Configure Build
@@ -577,11 +666,40 @@ jobs:
           export CC=$(brew --prefix llvm@21)/bin/clang
           export CXX=$(brew --prefix llvm@21)/bin/clang++
           export PATH=$(brew --prefix llvm@21)/bin:$PATH
-          cmake -B ${{ env.build_directory }} -G "Ninja" -DCMAKE_BUILD_TYPE=${{ env.build_type }} -DENABLE_TESTS=OFF -DENABLE_UTILS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_PROTON_LOCAL=OFF -DENABLE_PULSAR=ON -DENABLE_PYTHON_UDF=ON -DENABLE_PROTON_PYTHON=ON -DENABLE_PYTHON_FREE_THREADED=ON
+          # CMAKE_OSX_DEPLOYMENT_TARGET pins the binary's minimum macOS at
+          # 11.0, which is what the previous builder produced: `vtool
+          # -show-build` on the released Darwin-arm64 binary reports minos 11.0.
+          # Left unset it would follow the runner image's much newer SDK and
+          # silently drop users on macOS 11-14.
+          #
+          # CMAKE_*_FLAGS_ADD is appended after DEBUG_INFO_FLAGS in the root
+          # CMakeLists.txt, so -g0 wins and turns debug info off. Debug info is
+          # ~89% of object bytes in this configuration, so this is the
+          # difference between a ~45 GB and an ~8 GB build tree, and it shrinks
+          # the cache by the same factor. Nothing is lost: this job publishes
+          # only the stripped binary, so the DWARF was already discarded.
+          cmake -B ${{ env.build_directory }} -G "Ninja" -DCMAKE_BUILD_TYPE=${{ env.build_type }} -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_CXX_FLAGS_ADD=-g0 -DCMAKE_C_FLAGS_ADD=-g0 -DCMAKE_ASM_FLAGS_ADD=-g0 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_TESTS=OFF -DENABLE_UTILS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_PROTON_LOCAL=OFF -DENABLE_PULSAR=ON -DENABLE_PYTHON_UDF=ON -DENABLE_PROTON_PYTHON=ON -DENABLE_PYTHON_FREE_THREADED=ON
 
       # Compile the project using Ninja
+      # A fully cold build can outlive the 6h job limit, and a killed job
+      # uploads nothing, so it would never converge. The guard turns "would
+      # have been killed" into a controlled failure that still reaches the
+      # always()-guarded cache save, so one or two re-runs bootstrap a warm
+      # cache from nothing.
       - name: Build with Ninja
-        run: cmake --build ${{ env.build_directory }}
+        run: |
+          rc=0
+          gtimeout 300m cmake --build ${{ env.build_directory }} || rc=$?
+          if [ "$rc" = "124" ]; then
+            echo "::warning::Build exceeded the 300-minute guard. The ccache accumulated so far is uploaded by the 'Save ccache to S3' step - re-run to continue from it."
+          fi
+          exit $rc
+
+      # Surface hit rate so cold-vs-warm builds are visible at a glance.
+      - name: ccache stats
+        if: always()
+        run: ccache -sv || true
+
 
       # Strip the binary to reduce its size and rename it
       - name: Strip and Rename binary
@@ -589,18 +707,25 @@ jobs:
           ORIGINAL_BINARY=${{ env.build_directory }}/programs/proton
           STRIPPED_BINARY=${{ env.build_directory }}/programs/proton-${{ env.LATEST_TAG }}-Darwin-arm64
           ls -lh $ORIGINAL_BINARY
-          /opt/homebrew/opt/llvm@21/bin/llvm-strip $ORIGINAL_BINARY -o $STRIPPED_BINARY
+          "$(brew --prefix llvm@21)/bin/llvm-strip" $ORIGINAL_BINARY -o $STRIPPED_BINARY
           ls -lh $STRIPPED_BINARY
 
       # Set up AWS credentials for S3 upload
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
 
       # Upload the stripped binary to an AWS S3 bucket with retries
+      # The minimum supported macOS lives in a Mach-O load command and shows up
+      # in no build output anyone reads, so raising it is silent. Assert it.
+      - name: Verify deployment target
+        run: |
+          EXPECTED=11.0
+          ACTUAL=$(vtool -show-build "${{ env.build_directory }}/programs/proton-${{ env.LATEST_TAG }}-Darwin-arm64" | awk '/^ *minos/ {print $2; exit}')
+          echo "minos=$ACTUAL (expected $EXPECTED)"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Binary's minimum macOS is $ACTUAL, expected $EXPECTED. Changing the floor is a product decision -- update CMAKE_OSX_DEPLOYMENT_TARGET and this check together."
+            exit 1
+          fi
+
+
       - name: Upload Artifact To S3
         run: |
           STRIPPED_BINARY=${{ env.build_directory }}/programs/proton-${{ env.LATEST_TAG }}-Darwin-arm64
@@ -721,6 +846,20 @@ jobs:
             echo "Python package upload failed after all attempts"
             exit 1
           fi
+      # Runs on success, build failure and the build guard alike, so even a
+      # partial compile warms the next run. Placed last so a failed upload
+      # cannot block the artifact steps above.
+      - name: Save ccache to S3
+        if: always()
+        run: |
+          if [ -d "$CCACHE_DIR" ] && [ -n "$(ls -A "$CCACHE_DIR" 2>/dev/null)" ]; then
+            ccache -sv || true
+            du -sh "$CCACHE_DIR"
+            tar -cf - -C "$CCACHE_DIR" . | aws s3 cp --no-progress - "$MACOS_CCACHE_S3"
+          else
+            echo "ccache dir empty - nothing to save"
+          fi
+
 
   Update_Homebrew_Tap:
     if: ${{ !inputs.prerelease }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,46 @@ else ()
 endif ()
 # proton: ends
 
+# proton: starts
+if (OS_DARWIN)
+    # Imported targets for macOS system libraries (LibEdit, FFI, LibXml2, ZLIB)
+    # carry <SDK>/usr/include as an interface include directory and propagate
+    # it to anything that links them. CMake normally drops include directories
+    # that are already implicit for the compiler, which is why this stays
+    # invisible in most builds -- but the compiler-detected implicit list does
+    # not always spell the SDK the same way find_package() resolved it, and
+    # then the SDK's /usr/include lands in the -isystem list ahead of clang's
+    # own resource directory. libcxx's stddef.h include_next's into Apple's
+    # stddef.h instead of clang's, size_t and ptrdiff_t are never defined, and
+    # the build fails in whatever target happened to link one of those
+    # libraries -- nowhere near the actual cause.
+    #
+    # Declaring the directory implicit makes CMake filter it out everywhere.
+    # Nothing is lost: clang already searches the SDK's /usr/include by
+    # default, in the correct order.
+    #
+    # CMAKE_OSX_SYSROOT is not a reliable source for the path -- CMake leaves
+    # it empty when building against the host's default SDK, which is the case
+    # on GitHub's macOS runner images -- so fall back to asking the toolchain.
+    set (_proton_macos_sdk "${CMAKE_OSX_SYSROOT}")
+    if (NOT _proton_macos_sdk)
+        execute_process (
+            COMMAND xcrun --show-sdk-path
+            OUTPUT_VARIABLE _proton_macos_sdk
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+    endif ()
+    if (IS_DIRECTORY "${_proton_macos_sdk}/usr/include")
+        message (STATUS "Filtering ${_proton_macos_sdk}/usr/include out of generated include flags")
+        foreach (_lang C CXX ASM)
+            list (APPEND CMAKE_${_lang}_IMPLICIT_INCLUDE_DIRECTORIES "${_proton_macos_sdk}/usr/include")
+        endforeach ()
+    else ()
+        message (WARNING "Could not locate the macOS SDK; its /usr/include may leak into include flags")
+    endif ()
+endif ()
+# proton: ends
+
 if (OS_DARWIN)
     # The `-all_load` flag forces loading of all symbols from all libraries,
     # and leads to multiply-defined symbols. This flag allows force loading


### PR DESCRIPTION
## What

Moves both native macOS arm64 build jobs off the self-hosted Mac mini onto GitHub-hosted `macos-26-xlarge` runners, so the mini can be decommissioned.

| Job | Workflow | Was | Now |
|---|---|---|---|
| `Build_macOS_arm` | `manual_trigger_build.yml` | `[self-hosted, macOS, ARM64]` | `macos-26-xlarge` |
| `Build_Native_Darwin_arm64` | `release_build.yml` | `[self-hosted, macOS, ARM64]` | `macos-26-xlarge` |

## Why these jobs needed more than a `runs-on` swap

The mini had state accumulated by hand that an ephemeral runner does not have:

- **Undeclared host tools.** `cmake/tools.cmake` requires GNU `find`/`grep`; the mini had them installed manually. Now `brew install llvm@21 ccache coreutils findutils grep`, with version assertions on `gfind`/`ggrep`.
- **No ccache at all.** These jobs never had a compiler cache — the mini's persistent disk made them incremental for free. Added an S3 round-trip (`s3://timeplus-ci-internal/proton-oss/cache-macos-arm-native.tar`), streamed uncompressed since ccache 4.x already zstd-compresses entries.
- **The macOS SDK leaked into include flags.** `LibEdit`, `FFI`, `LibXml2` and `ZLIB` each contribute `<SDK>/usr/include` via `find_package`, which shadows libc++ headers. The mini's older CMake filtered it implicitly; the hosted image's does not. Fixed in `CMakeLists.txt` by appending the SDK include dir to `CMAKE_<LANG>_IMPLICIT_INCLUDE_DIRECTORIES`, resolving `CMAKE_OSX_SYSROOT` and falling back to `xcrun --show-sdk-path` (that variable is empty when building against the host default SDK, as on hosted runners).

## Deployment target — silent-regression guard

The branch originally pinned `CMAKE_OSX_DEPLOYMENT_TARGET=15.0`. Every currently shipped arm64 artifact reports `minos 11.0`, so that would have quietly dropped macOS 11–14 support. Pinned to `11.0` and added a post-build assertion:

```
ACTUAL=$(vtool -show-build "$BINARY_PATH" | awk '/^ *minos/ {print $2; exit}')
[ "$ACTUAL" = "11.0" ] || exit 1
```

## Other hardening

- Disk-space assertion before the build (runners measured at 320 GB volume / 87 GB free).
- `gtimeout 300m` around the build so a hang surfaces as a warning instead of burning the 350-minute job budget.
- `-g0` on the manual job (artifact is stripped anyway). The release job keeps debug info — it runs `dsymutil` and ships a dSYM.
- Serialized on `concurrency: build-macos-arm-ccache` so parallel runs don't clobber the shared cache object.

## Notes

- Rebased onto `develop` after #1212/#1213; the AWS-account migration this branch originally carried is now redundant and was dropped. The cache path above already uses the new bucket.
- The `proton-oss/` cache prefix starts cold, so the first run on each job is a full build.
- Keep the mini powered until a real release has run on hosted hardware.
