### PR TITLE
ci: move runner subnet to us-west-2c (capacity)

### DIFF
--- a/.github/workflows/run_command.yml
+++ b/.github/workflows/run_command.yml
@@ -16,7 +16,7 @@ on:
       ec2-subnet-id:
         type: string
         required: false
-        default: subnet-0154cd4c9c48527f2
+        default: subnet-027f098f48bf5a452
       ec2-security-group-id:
         type: string
         required: false


### PR DESCRIPTION
us-west-2d has had no c5.9xlarge capacity since yesterday (persistent InsufficientInstanceCapacity on both repos' x64 runners). Moves the default runner subnet to us-west-2c (subnet-027f098f48bf5a452, same VPC/SG/key), which offers all required instance types. Uncoupled from any settings — safe to merge immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Dzn5Pq5zm3xKTGEKzKU5t