### PR TITLE
ci: validation run on migrated AWS infrastructure

### DIFF
--- a/.github/workflows/proton_ci.yml
+++ b/.github/workflows/proton_ci.yml
@@ -402,3 +402,5 @@ jobs:
           SANITIZER: "address"
           ARCH: ${{ vars.X64_ARCH }}
           GITHUB_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.sha }}
+
+# CI validation marker: first full pipeline run on the new AWS account with synced proton-oss ccache (2026-08-05).


### PR DESCRIPTION
Final proton migration validation rung: full ProtonCI (build with synced proton-oss ccache + test suites) on the new AWS account. Trivial comment-only change. Close after green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Dzn5Pq5zm3xKTGEKzKU5t