### PR TITLE
ci: repin ec2-github-runner to timeplus-io fork

### DIFF
--- a/.github/workflows/manual_trigger_delete_image.yml
+++ b/.github/workflows/manual_trigger_delete_image.yml
@@ -115,8 +115,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        # Temporary pin to the Node 24-compatible fork until the companion ec2-github-runner PR merges.
-        uses: yokofly/ec2-github-runner@522cb941f0d76565385ce7aeb6771bf58451ba1b
+        # Pinned to timeplus-io/ec2-github-runner main (Node 24 compatible, PR #3).
+        uses: timeplus-io/ec2-github-runner@d962b847c8b500e9bc25e4a1df62c9237c5c7e6a
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/run_command.yml
+++ b/.github/workflows/run_command.yml
@@ -142,8 +142,8 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        # Temporary pin to the Node 24-compatible fork until the companion ec2-github-runner PR merges.
-        uses: yokofly/ec2-github-runner@522cb941f0d76565385ce7aeb6771bf58451ba1b
+        # Pinned to timeplus-io/ec2-github-runner main (Node 24 compatible, PR #3).
+        uses: timeplus-io/ec2-github-runner@d962b847c8b500e9bc25e4a1df62c9237c5c7e6a
         with:
           mode: ${{ inputs.run_mode }}
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -290,8 +290,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        # Keep the stop path on the same pinned fork revision as start.
-        uses: yokofly/ec2-github-runner@522cb941f0d76565385ce7aeb6771bf58451ba1b
+        # Keep the stop path on the same pinned revision as start.
+        uses: timeplus-io/ec2-github-runner@d962b847c8b500e9bc25e4a1df62c9237c5c7e6a
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

[timeplus-io/ec2-github-runner#3](https://github.com/timeplus-io/ec2-github-runner/pull/3) merged the Node 24 compatibility fix upstream, so the temporary pin to the personal fork (`yokofly/ec2-github-runner`) is no longer needed.

All three call sites now use `timeplus-io/ec2-github-runner@d962b847c8b500e9bc25e4a1df62c9237c5c7e6a`:

- `.github/workflows/run_command.yml` — start and stop EC2 runner
- `.github/workflows/manual_trigger_delete_image.yml` — stop EC2 runner

## Verification

- The merge commit's root tree SHA (`ceb0f7056b32388ccdfd45e05ac583dd2de39c92`) is **identical** to the previously pinned fork revision `yokofly@522cb941f0d76565385ce7aeb6771bf58451ba1b`. This is a content no-op — same `dist/`, same `action.yml` (`using: node24`).
 
🤖 Generated with [Claude Code](https://claude.com/claude-code)