### PR TITLE
fix(s3): do not send the Keep-Alive header to S3 (S3 Tables rejects it)

### DIFF
--- a/base/poco/Net/include/Poco/Net/HTTPRequest.h
+++ b/base/poco/Net/include/Poco/Net/HTTPRequest.h
@@ -159,6 +159,18 @@ public:
 	static const std::string UPGRADE;
 	static const std::string EXPECT;
 
+	/// proton: starts
+	void setSuppressKeepAliveHeader(bool suppress);
+		/// Suppresses the hop-by-hop `Keep-Alive: timeout=..., max=...` request header that
+		/// HTTPClientSession::sendRequest would otherwise add. The header is deprecated by RFC 7230
+		/// and some peers reject it outright: Amazon S3 Tables answers `S3TablesUnsupportedHeader`
+		/// to any PUT carrying it. Keep-alive itself and connection reuse are unaffected -- they are
+		/// driven by the `Connection` header and by the connection pool.
+
+	bool getSuppressKeepAliveHeader() const;
+		/// Returns true if the `Keep-Alive` request header is suppressed for this request.
+	/// proton: ends
+
 protected:
 	void getCredentials(const std::string& header, std::string& scheme, std::string& authInfo) const;
 		/// Returns the authentication scheme and additional authentication
@@ -181,6 +193,9 @@ private:
 	
 	std::string _method;
 	std::string _uri;
+	/// proton: starts
+	bool _suppress_keep_alive_header = false;
+	/// proton: ends
 	
 	HTTPRequest(const HTTPRequest&);
 	HTTPRequest& operator = (const HTTPRequest&);
@@ -200,6 +215,20 @@ inline const std::string& HTTPRequest::getURI() const
 {
 	return _uri;
 }
+
+
+/// proton: starts
+inline void HTTPRequest::setSuppressKeepAliveHeader(bool suppress)
+{
+	_suppress_keep_alive_header = suppress;
+}
+
+
+inline bool HTTPRequest::getSuppressKeepAliveHeader() const
+{
+	return _suppress_keep_alive_header;
+}
+/// proton: ends
 
 
 } } // namespace Poco::Net

--- a/base/poco/Net/src/HTTPClientSession.cpp
+++ b/base/poco/Net/src/HTTPClientSession.cpp
@@ -281,8 +281,11 @@ std::ostream& HTTPClientSession::sendRequest(HTTPRequest& request)
 		    reconnect();
 		if (!request.has(HTTPMessage::CONNECTION))
                     request.setKeepAlive(keepAlive);
-                if (keepAlive && !request.has(HTTPMessage::CONNECTION_KEEP_ALIVE) && _keepAliveTimeout.totalSeconds() > 0)
+                /// proton: starts. Skip the header for requests that asked for it.
+                if (keepAlive && !request.getSuppressKeepAliveHeader() && !request.has(HTTPMessage::CONNECTION_KEEP_ALIVE)
+                    && _keepAliveTimeout.totalSeconds() > 0)
                     request.setKeepAliveTimeout(_keepAliveTimeout.totalSeconds(), _keepAliveMaxRequests);
+                /// proton: ends
 		if (!request.has(HTTPRequest::HOST) && !_host.empty())
 			request.setHost(_host, _port);
 		if (!_proxyConfig.host.empty() && !bypassProxy())

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -450,6 +450,11 @@ void PocoHTTPClient::makeRequestInternalImpl(
 
             Poco::Net::HTTPRequest poco_request(Poco::Net::HTTPRequest::HTTP_1_1);
 
+            /// proton: starts. Amazon S3 Tables rejects any request carrying the hop-by-hop
+            /// `Keep-Alive` header (S3TablesUnsupportedHeader); plain S3 ignores it.
+            poco_request.setSuppressKeepAliveHeader(true);
+            /// proton: ends
+
             /** According to RFC-2616, Request-URI is allowed to be encoded.
               * However, there is no clear agreement on which exact symbols must be encoded.
               * Effectively, `Poco::URI` chooses smaller subset of characters to encode,


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes, on the changed lines of `src/IO/S3/PocoHTTPClient.cpp`. The two Poco files keep Poco's own tab style, as the upstream ClickHouse commit did.
- Did you separate headers to a different section in existing community code base ? No new includes.
- Did you surround `proton: starts/ends` for new code in existing community code base ? Yes, all three hunks.

Part 1 of 4 for #1221 (defect 1).

**What a user sees.** Any `INSERT` into an Iceberg database backed by Amazon S3 Tables fails on its first Parquet upload:

```
Code: 499. DB::Exception: Message: Unable to parse ExceptionName: S3TablesUnsupportedHeader
Message: S3 Tables does not support the following header: keep-alive value: timeout=30, max=1000,
bucket <uuid>--table-s3, key /data/00000-....parquet, object size 1409. (S3_ERROR)
```

**Root cause.** `HTTPClientSession::sendRequest` (`base/poco/Net/src/HTTPClientSession.cpp:284`) stamps the hop-by-hop `Keep-Alive: timeout=..., max=...` header whenever session keep-alive is on and the keep-alive timeout is positive, and nothing on the S3 client path can turn it off: `IcebergS3Configuration::createClient` never sets `http_keep_alive_timeout`, and the user-level setting does not reach it. S3 Tables validates request headers against an allowlist and rejects the request; plain S3 ignores the header, which is why the Glue + S3 tests passed. Renaming the header does not help, it has to be absent.

**The change** ports ClickHouse/ClickHouse@70f9551c73: a per-request flag on `Poco::Net::HTTPRequest` (`setSuppressKeepAliveHeader`), honoured in `HTTPClientSession::sendRequest`, and set for every request `PocoHTTPClient` sends to S3. Keep-alive itself and connection reuse are unaffected; they are driven by the `Connection` header and by the connection pool.

**Verification.** Not compiled here. The behaviour was validated on `timeplus/proton:3.0.29` against an S3 Tables bucket with the header stripped externally by a proxy: `HEAD → 404`, `PUT parquet → 200`, `PUT manifest → 200`, `PUT manifest-list → 200`. The commit then fails on defect 2 of #1221, fixed separately.
