### PR TITLE
fix(iceberg): send the Host header once on REST catalog POSTs

### DIFF
--- a/src/Common/sendRequest.cpp
+++ b/src/Common/sendRequest.cpp
@@ -52,11 +52,15 @@ std::pair<String, Int32> sendRequest(
         if (!user.empty())
             request.add("x-timeplus-user", user);
 
-        /// add other headers
+        /// Set, not add: a caller that signed the request (the Iceberg REST catalog with
+        /// SigV4) forwards `host` among its signed headers, and add() would send a second
+        /// Host line next to the one setHost() wrote above. Amazon S3 Tables answers that
+        /// with HTTP 400 and an empty body. ReadWriteBufferFromHTTP applies headers with
+        /// set() for the same reason.
         if (!headers.empty())
-            for(const auto & [k, v]: headers)
+            for (const auto & [k, v] : headers)
                 if (!k.empty())
-                    request.add(k, v);
+                    request.set(k, v);
 
         if (!password.empty())
         {


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes.
- Did you separate headers to a different section in existing community code base ? No new includes.
- Did you surround `proton: starts/ends` for new code in existing community code base ? Not applicable, `src/Common/sendRequest.cpp` is Proton code.

Part 2 of 4 for #1221 (defect 2).

**What a user sees.** With defect 1 fixed, every data file of an Iceberg `INSERT` into Amazon S3 Tables is written, then the commit fails:

```
Code: 736. DB::Exception: Failed to commit table, HTTP response code=400, body=. (ICEBERG_CATALOG_ERROR)
```

Reads against the same catalog work.

**Root cause.** `RestCatalog::commitTable` (and `createTable`, `dropTable`) sign the request with the AWS SDK and forward every signed header to `DB::sendRequest`. The SDK's `StandardHttpRequest` constructor sets `host`, so it is among the signed headers. `sendRequest` calls `request.setHost(uri.getHost())` and then `request.add(k, v)` for each forwarded header. Poco's `add` appends, so the request goes out with two `Host` lines, and S3 Tables answers 400 with an empty body. The GET path applies the same headers through `ReadWriteBufferFromHTTP`, which uses `request.set`, which is why reads work and writes do not.

Confirmed directly against the S3 Tables catalog with a SigV4-signed `commitTable` POST for a table that does not exist, so nothing is written and an accepted request answers 404:

| request | answer |
|---|---|
| one `Host` header | 404 `no_such_table` |
| `Host` header twice | 400, empty body |
| one `Host`, plus `Keep-Alive` and `x-timeplus-query-id` | 404 `no_such_table` |

**The change.** Apply forwarded headers with `set`, as `ReadWriteBufferFromHTTP` already does. `RestCatalog` is the only caller of this helper.

**Verification.** Not compiled here; the table above is the direct evidence. On 3.0.29, routing the catalog through a proxy that rebuilt the headers made the same commit succeed.
