### PR TITLE
fix(iceberg): no trailing separator in getLocation for a bare bucket root

### DIFF
--- a/src/Storages/Iceberg/ICatalog.cpp
+++ b/src/Storages/Iceberg/ICatalog.cpp
@@ -77,8 +77,17 @@ std::string TableMetadata::getLocation(bool path_only) const
 
     if (path_only)
         return path;
-    else
-        return std::filesystem::path(location_without_path) / path;
+
+    /// A table whose location is a bare bucket root (every Amazon S3 Tables table is one,
+    /// `s3://<bucket>` with no path) has an empty path. Appending it through
+    /// std::filesystem::path would leave a trailing separator, and every path derived from
+    /// this one (`{}/metadata/...`, `{}/data/...`) would then carry `//`. The objects are
+    /// written at the single-slash key, so the committed metadata would point at paths
+    /// PyArrow and DuckDB refuse to read.
+    if (path.empty())
+        return location_without_path;
+
+    return std::filesystem::path(location_without_path) / path;
 }
 
 void TableMetadata::setSchema(const DB::NamesAndTypesList & schema_)

--- a/src/Storages/Iceberg/tests/gtest_table_metadata_location.cpp
+++ b/src/Storages/Iceberg/tests/gtest_table_metadata_location.cpp
@@ -1,0 +1,34 @@
+#include <Storages/Iceberg/ICatalog.h>
+
+#include <gtest/gtest.h>
+
+using Apache::Iceberg::TableMetadata;
+
+TEST(IcebergTableMetadata, LocationWithPathRoundTrips)
+{
+    TableMetadata metadata;
+    metadata.withLocation().setLocation("s3://bucket/path/to/table");
+
+    EXPECT_EQ(metadata.getLocation(/*path_only=*/false), "s3://bucket/path/to/table");
+    EXPECT_EQ(metadata.getLocation(/*path_only=*/true), "path/to/table");
+}
+
+TEST(IcebergTableMetadata, BareBucketLocationHasNoTrailingSeparator)
+{
+    /// Every Amazon S3 Tables table location is a bare bucket root. A trailing separator
+    /// here becomes `s3://bucket//metadata/...` in the committed manifest list.
+    TableMetadata metadata;
+    metadata.withLocation().setLocation("s3://0e1f2a3b-4c5d-6e7f--table-s3");
+
+    EXPECT_EQ(metadata.getLocation(/*path_only=*/false), "s3://0e1f2a3b-4c5d-6e7f--table-s3");
+    EXPECT_EQ(metadata.getLocation(/*path_only=*/true), "");
+}
+
+TEST(IcebergTableMetadata, LocationWithTrailingSlashHasNoTrailingSeparator)
+{
+    TableMetadata metadata;
+    metadata.withLocation().setLocation("s3://bucket/");
+
+    EXPECT_EQ(metadata.getLocation(/*path_only=*/false), "s3://bucket");
+    EXPECT_EQ(metadata.getLocation(/*path_only=*/true), "");
+}


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes.
- Did you separate headers to a different section in existing community code base ? No new includes.
- Did you surround `proton: starts/ends` for new code in existing community code base ? Not applicable, `src/Storages/Iceberg` is Proton code.

Part 3 of 4 for #1221 (defect 3).

**What a user sees.** With defects 1 and 2 fixed, the commit lands with the right `added-records`, but the committed manifest list points at

```
s3://<uuid>--table-s3//metadata/snap-....avro
```

while the objects were written at single-slash keys. PyArrow refuses the table (`ArrowInvalid: Empty path component`), DuckDB gets `SignatureDoesNotMatch` because the `//` breaks SigV4 canonical-path agreement.

**Root cause.** Every Amazon S3 Tables table location is a bare bucket root, `s3://<bucket>` with no path component, so `TableMetadata::path` is empty and `std::filesystem::path(location_without_path) / ""` in `getLocation` yields a trailing separator. `IcebergSink` then formats `{}/metadata/snap-...avro`, `{}/metadata/...-m0.avro` and the data-file keys on top of it. The PUT keys are derived from the same string through `Poco::URI(...).getPath()`, which normalises, hence the mismatch between object and reference. Glue and warehouse-style locations always carry a path, so they never hit this.

**The change.** Return `location_without_path` unchanged when `path` is empty. Adds `src/Storages/Iceberg/tests/gtest_table_metadata_location.cpp`: a normal location round-trips, a bare bucket root and a trailing-slash location come back without a trailing separator.

**Verification.** Not compiled here. On 3.0.29, rewriting the catalog's `LoadTableResult.location` in flight from `s3://<bucket>` to `s3://<bucket>/t` (making `path` non-empty) produced single-slash references and the committed table was readable by PyIceberg and DuckDB, which is the same condition this guard produces.
